### PR TITLE
fetch: preserve response metadata across Lean -> Rust handoff

### DIFF
--- a/FormalWeb/EventLoop.lean
+++ b/FormalWeb/EventLoop.lean
@@ -63,7 +63,7 @@ instance : Inhabited EventLoop where
 
 inductive EventLoopTaskMessage where
   | createEmptyDocument (traversableId : Nat) (documentId : DocumentId)
-  | createLoadedDocument (traversableId : Nat) (documentId : DocumentId) (url : String) (body : String)
+  | createLoadedDocument (traversableId : Nat) (documentId : DocumentId) (response : NavigationResponse)
   | destroyDocument (documentId : DocumentId)
   | queueUpdateTheRendering (traversableId : Nat) (documentId : DocumentId)
   | queueDispatchEvent (documentId : DocumentId) (event : String)
@@ -81,8 +81,7 @@ inductive EventLoopTaskMessage where
   | runNextTask
   | queueDocumentFetchCompletion
       (handler : RustNetHandlerPointer)
-      (resolvedUrl : String)
-      (body : ByteArray)
+      (response : FetchResponse)
     | queueWindowTimerTask
       (documentId : DocumentId)
       (timerId : Nat)
@@ -137,8 +136,7 @@ deriving DecidableEq
 structure PendingCreateLoadedDocumentTask where
   traversableId : Nat
   documentId : DocumentId
-  url : String
-  body : String
+  response : NavigationResponse
 deriving DecidableEq
 
 structure PendingDestroyDocumentTask where
@@ -172,8 +170,7 @@ deriving DecidableEq
 
 structure PendingDocumentFetchCompletionTask where
   handler : RustNetHandlerPointer
-  resolvedUrl : String
-  body : ByteArray
+  response : FetchResponse
 deriving DecidableEq
 
 structure PendingRunWindowTimerTask where
@@ -552,7 +549,7 @@ instance : Inhabited EventLoopTaskState where
 
 inductive EventLoopRuntimeEffect where
   | createEmptyDocument (traversableId : Nat) (documentId : DocumentId)
-  | createLoadedDocument (traversableId : Nat) (documentId : DocumentId) (url : String) (body : String)
+  | createLoadedDocument (traversableId : Nat) (documentId : DocumentId) (response : NavigationResponse)
   | destroyDocument (documentId : DocumentId)
   | updateTheRendering (traversableId : Nat) (documentId : DocumentId)
   | dispatchEvent (events : List PendingDispatchEvent)
@@ -564,8 +561,7 @@ inductive EventLoopRuntimeEffect where
     | clearTimeout (timerKey : Nat)
   | documentFetchCompletion
       (handler : RustNetHandlerPointer)
-      (resolvedUrl : String)
-      (body : ByteArray)
+      (response : FetchResponse)
     | runWindowTimer
       (documentId : DocumentId)
       (timerId : Nat)
@@ -595,13 +591,15 @@ def handleRuntimeEffect
         state.contentProcess.raw
         (USize.ofNat traversableId)
         (USize.ofNat documentId.id)
-  | .createLoadedDocument traversableId documentId url body =>
+  | .createLoadedDocument traversableId documentId response =>
       contentProcessCreateLoadedDocument
         state.contentProcess.raw
         (USize.ofNat traversableId)
         (USize.ofNat documentId.id)
-        url
-        body
+        response.url
+        (USize.ofNat response.status)
+        response.contentType
+        response.body
   | .destroyDocument documentId =>
       contentProcessDestroyDocument state.contentProcess.raw (USize.ofNat documentId.id)
   | .updateTheRendering traversableId documentId =>
@@ -624,12 +622,14 @@ def handleRuntimeEffect
       hooks.scheduleTimeout request
   | .clearTimeout timerKey =>
       hooks.clearTimeout timerKey
-  | .documentFetchCompletion handler resolvedUrl body =>
+  | .documentFetchCompletion handler response =>
       contentProcessCompleteDocumentFetch
         state.contentProcess.raw
         handler.raw
-        resolvedUrl
-        body
+        response.url
+        (USize.ofNat response.status)
+        response.contentType
+        response.body
   | .runWindowTimer documentId timerId timerKey nestingLevel =>
       contentProcessRunWindowTimer
         state.contentProcess.raw
@@ -732,7 +732,7 @@ def runNextQueuedTaskM : EventLoopM Unit := fun state =>
             | [] =>
                 (none, readyState)
             | pendingTask :: pendingTasks =>
-                (some (.createLoadedDocument pendingTask.traversableId pendingTask.documentId pendingTask.url pendingTask.body),
+                (some (.createLoadedDocument pendingTask.traversableId pendingTask.documentId pendingTask.response),
                   {
                     blockedState with
                       liveDocumentIds := blockedState.liveDocumentIds.insert pendingTask.documentId.id ()
@@ -780,7 +780,7 @@ def runNextQueuedTaskM : EventLoopM Unit := fun state =>
                 (none, readyState)
             | pendingTask :: pendingTasks =>
                 if hasPendingDocumentFetchRequest blockedState.pendingDocumentFetchRequests pendingTask.handler then
-                  (some (.documentFetchCompletion pendingTask.handler pendingTask.resolvedUrl pendingTask.body),
+                  (some (.documentFetchCompletion pendingTask.handler pendingTask.response),
                     {
                       blockedState with
                         pendingDocumentFetchRequests :=
@@ -847,7 +847,7 @@ def handleEventLoopTaskMessage
             state.pendingCreateEmptyDocumentTasks.concat { traversableId, documentId }
       }
       (((), #[]), state)
-  | .createLoadedDocument traversableId documentId url body =>
+  | .createLoadedDocument traversableId documentId response =>
       let task : Task := {
         step := .createLoadedDocument
         documentId := some documentId.id
@@ -856,7 +856,7 @@ def handleEventLoopTaskMessage
         state with
           eventLoop := state.eventLoop.enqueueTask task
           pendingCreateLoadedDocumentTasks :=
-            state.pendingCreateLoadedDocumentTasks.concat { traversableId, documentId, url, body }
+            state.pendingCreateLoadedDocumentTasks.concat { traversableId, documentId, response }
       }
       (((), #[]), state)
   | .destroyDocument documentId =>
@@ -942,13 +942,13 @@ def handleEventLoopTaskMessage
           eventLoop := state.eventLoop.wakeForNextTask
       }
       (((), #[]), state)
-  | .queueDocumentFetchCompletion handler resolvedUrl body =>
+  | .queueDocumentFetchCompletion handler response =>
       let task : Task := { step := .completeDocumentFetch }
       let state := {
         state with
           eventLoop := state.eventLoop.enqueueTask task
           pendingDocumentFetchCompletionTasks :=
-            state.pendingDocumentFetchCompletionTasks.concat { handler, resolvedUrl, body }
+            state.pendingDocumentFetchCompletionTasks.concat { handler, response }
       }
       (((), #[EventLoopEffect.performRuntimeEffect (.clearTimeout handler.raw.toNat)]), state)
   | .queueWindowTimerTask documentId timerId timerKey nestingLevel =>
@@ -1094,7 +1094,7 @@ def startEventLoopWorker
       let onComplete := fun response => do
         trySendAndForget
           channel
-          (.queueDocumentFetchCompletion handler response.url response.body)
+          (.queueDocumentFetchCompletion handler response)
       trySendAndForget fetchChannel (.startDocumentFetch handler request onComplete)
     scheduleTimeout := fun request => do
       let nowMs ← IO.monoMsNow

--- a/FormalWeb/FFI.lean
+++ b/FormalWeb/FFI.lean
@@ -38,7 +38,7 @@ opaque contentProcessCreateEmptyDocument : USize → USize → USize → IO Unit
 
 /-- Sends a create-loaded-document command to the event loop's content process. -/
 @[extern "contentProcessCreateLoadedDocument"]
-opaque contentProcessCreateLoadedDocument : USize → USize → USize → @& String → @& String → IO Unit
+opaque contentProcessCreateLoadedDocument : USize → USize → USize → @& String → USize → @& String → @& String → IO Unit
 
 /-- Sends a destroy-document command to the event loop's content process. -/
 @[extern "contentProcessDestroyDocument"]
@@ -66,6 +66,6 @@ opaque contentProcessFailDocumentFetch : USize → USize → IO Unit
 
 /-- Completes a queued document fetch inside the event loop's content process. -/
 @[extern "contentProcessCompleteDocumentFetch"]
-opaque contentProcessCompleteDocumentFetch : USize → USize → @& String → ByteArray → IO Unit
+opaque contentProcessCompleteDocumentFetch : USize → USize → @& String → USize → @& String → ByteArray → IO Unit
 
 end FormalWeb

--- a/FormalWeb/Proofs/EventLoopProof.lean
+++ b/FormalWeb/Proofs/EventLoopProof.lean
@@ -207,4 +207,67 @@ theorem runEventLoopMonadic_trace
       (runEventLoopMonadic state message).2 := by
   simpa [runEventLoopMonadic] using runEventLoopMessagesMonadic_trace state [message]
 
+theorem createLoadedDocument_preserves_navigation_response_metadata :
+    (runEventLoopMonadic
+      { eventLoop := { id := 3 } }
+      (.createLoadedDocument
+        { id := 7 }
+        {
+          url := "https://example.test/final"
+          status := 201
+          contentType := "text/html; charset=utf-8"
+          body := "<p>ok</p>"
+        })).1 =
+      #[EventLoopEffect.runNextTask
+        {
+          step := .createLoadedDocument
+          documentId := some 7
+        }
+        (some (.createLoadedDocument
+          { id := 7 }
+          {
+            url := "https://example.test/final"
+            status := 201
+            contentType := "text/html; charset=utf-8"
+            body := "<p>ok</p>"
+          }))] := by
+  native_decide
+
+theorem queueDocumentFetchCompletion_preserves_fetch_response_metadata :
+    (runEventLoopMonadic
+      {
+        eventLoop := { id := 3 }
+        pendingDocumentFetchRequests :=
+          [{
+            handler := { raw := 9 }
+            request := {
+              url := "https://example.test/script.js"
+            }
+          }]
+      }
+      (.queueDocumentFetchCompletion
+        { raw := 9 }
+        {
+          url := "https://example.test/script.js"
+          status := 404
+          contentType := "text/html"
+          body := "<html>missing</html>".toUTF8
+        })).1 =
+      #[
+        EventLoopEffect.performRuntimeEffect (.clearTimeout 9),
+        EventLoopEffect.runNextTask
+          {
+            step := .completeDocumentFetch
+          }
+          (some (.documentFetchCompletion
+            { raw := 9 }
+            {
+              url := "https://example.test/script.js"
+              status := 404
+              contentType := "text/html"
+              body := "<html>missing</html>".toUTF8
+            }))
+      ] := by
+  native_decide
+
 end FormalWeb

--- a/FormalWeb/UserAgent.lean
+++ b/FormalWeb/UserAgent.lean
@@ -2067,8 +2067,7 @@ def handleFetchCompletedM
             EventLoopTaskMessage.createLoadedDocument
               pendingNavigationFinalization.traversableId
               document.documentId
-              navigationResponse.url
-              navigationResponse.body
+              navigationResponse
         tell #[.eventLoopMessage document.eventLoopId eventLoopMessage]
   match renderingDispatch? with
   | some (eventLoopId, eventLoopMessage) =>

--- a/content/src/main.rs
+++ b/content/src/main.rs
@@ -28,9 +28,10 @@ use ipc_messages::content::Command::{
 };
 use ipc_messages::content::{
     Bootstrap, ColorScheme as MessageColorScheme, Command, DispatchEventEntry,
-    Event as ContentEvent, FetchRequest as ContentFetchRequest, FontTransportSender, FrameId,
-    PaintFrame, RecordedScene, ScriptEvaluationResult, ScrollOffset, ViewportSnapshot,
-    WebviewId,
+    Event as ContentEvent, FetchRequest as ContentFetchRequest,
+    FetchResponse as ContentFetchResponse, FontTransportSender, FrameId,
+    LoadedDocumentResponse, PaintFrame, RecordedScene, ScriptEvaluationResult, ScrollOffset,
+    ViewportSnapshot, WebviewId,
 };
 use std::{
     cell::RefCell,
@@ -43,6 +44,36 @@ use std::{
 use url::Url;
 
 const EMPTY_HTML_DOCUMENT: &str = "<html><head></head><body></body></html>";
+
+fn normalized_content_type_essence(content_type: &str) -> String {
+    content_type
+        .split(';')
+        .next()
+        .map(str::trim)
+        .unwrap_or("")
+        .to_ascii_lowercase()
+}
+
+fn is_javascript_mime_essence(essence: &str) -> bool {
+    matches!(
+        essence,
+        "text/javascript"
+            | "application/javascript"
+            | "application/ecmascript"
+            | "text/ecmascript"
+            | "application/x-javascript"
+            | "text/x-javascript"
+    )
+}
+
+fn deferred_script_response_is_executable(response: &ContentFetchResponse) -> bool {
+    if !(200..=299).contains(&response.status) {
+        return false;
+    }
+
+    let essence = normalized_content_type_essence(&response.content_type);
+    essence.is_empty() || is_javascript_mime_essence(&essence)
+}
 
 fn new_font_namespace() -> u64 {
     let pid = u64::from(std::process::id());
@@ -496,18 +527,23 @@ impl ContentRuntime {
         &mut self,
         traversable_id: u64,
         document_id: u64,
-        url: String,
-        body: String,
+        response: LoadedDocumentResponse,
     ) -> Result<(), String> {
+        let LoadedDocumentResponse {
+            final_url,
+            status: _,
+            content_type: _,
+            body,
+        } = response;
         // Note: This block continues <https://html.spec.whatwg.org/#navigate-html>.
         // Step 1: "Let document be the result of creating and initializing a `Document` object given `html`, `text/html`, and navigationParams."
         // Note: `BaseDocument::new` and `EnvironmentSettingsObject::new` split document creation between the DOM carrier and the JavaScript environment settings object.
         let document = Rc::new(RefCell::new(BaseDocument::new(
-            self.document_config(document_id, Some(url.clone())),
+            self.document_config(document_id, Some(final_url.clone())),
         )));
         let settings = EnvironmentSettingsObject::new(
             Rc::clone(&document),
-            Url::parse(&url).map_err(|error| error.to_string())?,
+            Url::parse(&final_url).map_err(|error| error.to_string())?,
         )?;
         settings.install_timer_host(document_id, self.event_sender.clone())?;
 
@@ -532,7 +568,7 @@ impl ContentRuntime {
                 settings,
                 pending_update_the_rendering: false,
                 pending_document_load: Some(PendingDocumentLoad {
-                    finalize_url: url.clone(),
+                    finalize_url: final_url.clone(),
                     scripts: deferred_scripts,
                 }),
             },
@@ -735,8 +771,7 @@ impl ContentRuntime {
     fn complete_document_fetch(
         &mut self,
         handler_id: u64,
-        resolved_url: String,
-        body: Vec<u8>,
+        response: ContentFetchResponse,
     ) -> Result<(), String> {
         let pending_handler = {
             let mut local_state = self
@@ -756,7 +791,7 @@ impl ContentRuntime {
                 request_url: _,
                 handler,
             } => {
-                handler.bytes(resolved_url, Bytes::copy_from_slice(&body));
+                handler.bytes(response.final_url.clone(), Bytes::copy_from_slice(&response.body));
                 let Some(content_document) = self.documents.get(&document_id) else {
                     eprintln!("[content] complete_document_fetch: document {document_id} not found");
                     return Ok(());
@@ -770,8 +805,15 @@ impl ContentRuntime {
                 document_id,
                 script_index,
             } => {
-                let _ = resolved_url;
-                self.complete_deferred_script_fetch(document_id, script_index, body);
+                if deferred_script_response_is_executable(&response) {
+                    self.complete_deferred_script_fetch(document_id, script_index, response.body);
+                } else {
+                    eprintln!(
+                        "content deferred script rejected: url={} status={} content-type={}",
+                        response.final_url, response.status, response.content_type,
+                    );
+                    self.mark_deferred_script_failed(document_id, script_index);
+                }
                 let Some(content_document) = self.documents.get(&document_id) else {
                     eprintln!("[content] complete_document_fetch (deferred script): document {document_id} not found");
                     return Ok(());
@@ -876,10 +918,9 @@ impl ContentRuntime {
             CreateLoadedDocument {
                 traversable_id,
                 document_id,
-                url,
-                body,
+                response,
             } => {
-                self.create_loaded_document(traversable_id, document_id, url, body)?;
+                self.create_loaded_document(traversable_id, document_id, response)?;
                 Ok(true)
             }
             DestroyDocument { document_id } => {
@@ -933,10 +974,9 @@ impl ContentRuntime {
             }
             CompleteDocumentFetch {
                 handler_id,
-                resolved_url,
-                body,
+                response,
             } => {
-                self.complete_document_fetch(handler_id, resolved_url, body)?;
+                self.complete_document_fetch(handler_id, response)?;
                 Ok(true)
             }
             FailDocumentFetch { handler_id } => {
@@ -1016,4 +1056,57 @@ fn main() -> Result<(), String> {
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        ContentFetchResponse, deferred_script_response_is_executable,
+        is_javascript_mime_essence, normalized_content_type_essence,
+    };
+
+    fn response(status: u16, content_type: &str) -> ContentFetchResponse {
+        ContentFetchResponse {
+            final_url: String::from("https://example.test/script.js"),
+            status,
+            content_type: content_type.to_string(),
+            body: b"console.log('ok');".to_vec(),
+        }
+    }
+
+    #[test]
+    fn deferred_scripts_accept_successful_javascript_mime() {
+        assert!(deferred_script_response_is_executable(&response(
+            200,
+            "text/javascript; charset=utf-8"
+        )));
+    }
+
+    #[test]
+    fn deferred_scripts_reject_non_success_status() {
+        assert!(!deferred_script_response_is_executable(&response(
+            404,
+            "text/javascript"
+        )));
+    }
+
+    #[test]
+    fn deferred_scripts_reject_clearly_wrong_mime() {
+        assert!(!deferred_script_response_is_executable(&response(
+            200,
+            "text/html"
+        )));
+    }
+
+    #[test]
+    fn deferred_scripts_allow_missing_content_type() {
+        assert!(deferred_script_response_is_executable(&response(200, "")));
+    }
+
+    #[test]
+    fn content_type_essence_is_case_and_parameter_insensitive() {
+        let essence = normalized_content_type_essence("Application/JavaScript; Charset=UTF-8");
+        assert_eq!(essence, "application/javascript");
+        assert!(is_javascript_mime_essence(&essence));
+    }
 }

--- a/ffi/Cargo.lock
+++ b/ffi/Cargo.lock
@@ -802,6 +802,7 @@ dependencies = [
  "kurbo",
  "serde",
  "serde_json",
+ "webview",
  "winit",
 ]
 
@@ -865,6 +866,7 @@ dependencies = [
  "ipc-channel",
  "ipc_messages",
  "serde_json",
+ "webview",
 ]
 
 [[package]]
@@ -3978,6 +3980,18 @@ dependencies = [
  "phf_codegen",
  "string_cache",
  "string_cache_codegen",
+]
+
+[[package]]
+name = "webview"
+version = "0.1.0"
+dependencies = [
+ "anyrender",
+ "blitz-traits",
+ "ipc_messages",
+ "keyboard-types",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/ffi/build.rs
+++ b/ffi/build.rs
@@ -89,10 +89,37 @@ struct DependencyArtifacts {
     external_objects: BTreeSet<PathBuf>,
 }
 
+fn object_file_matches_target(object_path: &Path, target: &str) -> bool {
+    let Ok(header) = fs::read(object_path) else {
+        return false;
+    };
+
+    let header = &header[..header.len().min(4)];
+
+    if target.contains("apple") {
+        matches!(
+            header,
+            [0xfe, 0xed, 0xfa, 0xce]
+                | [0xce, 0xfa, 0xed, 0xfe]
+                | [0xfe, 0xed, 0xfa, 0xcf]
+                | [0xcf, 0xfa, 0xed, 0xfe]
+                | [0xca, 0xfe, 0xba, 0xbe]
+                | [0xbe, 0xba, 0xfe, 0xca]
+                | [0xca, 0xfe, 0xba, 0xbf]
+                | [0xbf, 0xba, 0xfe, 0xca]
+        )
+    } else if target.contains("windows") {
+        header.starts_with(b"MZ")
+    } else {
+        header == b"\x7fELF"
+    }
+}
+
 fn collect_dependency_artifacts(
     entry_c_files: &[PathBuf],
     root_ir_dir: &Path,
     package_ir_dirs: &BTreeMap<String, PathBuf>,
+    target: &str,
 ) -> DependencyArtifacts {
     let mut pending = VecDeque::from(entry_c_files.to_vec());
     let mut visited = BTreeSet::new();
@@ -125,7 +152,7 @@ fn collect_dependency_artifacts(
 
             if dep_c_file.starts_with(root_ir_dir) {
                 compiled_c_files.insert(dep_c_file.clone());
-            } else if dep_object.is_file() {
+            } else if dep_object.is_file() && object_file_matches_target(&dep_object, target) {
                 external_objects.insert(dep_object);
             } else {
                 compiled_c_files.insert(dep_c_file.clone());
@@ -192,6 +219,7 @@ fn main() {
         std::slice::from_ref(&runtime_entry),
         &lake_ir_dir,
         &package_ir_dirs,
+        &target,
     );
 
     println!("cargo:rustc-link-search=native={}", lean_lib_dir.display());

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -400,12 +400,22 @@ pub extern "C" fn contentProcessCreateLoadedDocument(
     handle: usize,
     traversable_id: usize,
     document_id: usize,
-    url: *mut lean_object,
+    final_url: *mut lean_object,
+    status: usize,
+    content_type: *mut lean_object,
     body: *mut lean_object,
 ) -> *mut lean_object {
     match panic::catch_unwind(AssertUnwindSafe(|| {
-        let c_url = unsafe { leanStringCstr(url) };
-        let url = unsafe { CStr::from_ptr(c_url) }.to_string_lossy().into_owned();
+        let status = u16::try_from(status)
+            .map_err(|_| format!("loaded document status out of range: {status}"))?;
+        let c_final_url = unsafe { leanStringCstr(final_url) };
+        let final_url = unsafe { CStr::from_ptr(c_final_url) }
+            .to_string_lossy()
+            .into_owned();
+        let c_content_type = unsafe { leanStringCstr(content_type) };
+        let content_type = unsafe { CStr::from_ptr(c_content_type) }
+            .to_string_lossy()
+            .into_owned();
         let c_body = unsafe { leanStringCstr(body) };
         let body = unsafe { CStr::from_ptr(c_body) }.to_string_lossy().into_owned();
         content_bridge::send_command(
@@ -413,8 +423,12 @@ pub extern "C" fn contentProcessCreateLoadedDocument(
             ContentCommand::CreateLoadedDocument {
                 traversable_id: traversable_id as u64,
                 document_id: document_id as u64,
-                url,
-                body,
+                response: ipc_messages::content::LoadedDocumentResponse {
+                    final_url,
+                    status,
+                    content_type,
+                    body,
+                },
             },
         )
     })) {
@@ -557,12 +571,22 @@ pub extern "C" fn contentProcessFailDocumentFetch(
 pub extern "C" fn contentProcessCompleteDocumentFetch(
     handle: usize,
     handler_id: usize,
-    resolved_url: *mut lean_object,
+    final_url: *mut lean_object,
+    status: usize,
+    content_type: *mut lean_object,
     bytes: *mut lean_object,
 ) -> *mut lean_object {
     match panic::catch_unwind(AssertUnwindSafe(|| {
-        let c_resolved_url = unsafe { leanStringCstr(resolved_url) };
-        let resolved_url = unsafe { CStr::from_ptr(c_resolved_url) }.to_string_lossy().into_owned();
+        let status = u16::try_from(status)
+            .map_err(|_| format!("document fetch status out of range: {status}"))?;
+        let c_final_url = unsafe { leanStringCstr(final_url) };
+        let final_url = unsafe { CStr::from_ptr(c_final_url) }
+            .to_string_lossy()
+            .into_owned();
+        let c_content_type = unsafe { leanStringCstr(content_type) };
+        let content_type = unsafe { CStr::from_ptr(c_content_type) }
+            .to_string_lossy()
+            .into_owned();
         let size = unsafe { leanByteArraySize(bytes) };
         let bytes_ptr = unsafe { leanByteArrayCptr(bytes) };
         let payload = unsafe { std::slice::from_raw_parts(bytes_ptr, size) };
@@ -570,8 +594,12 @@ pub extern "C" fn contentProcessCompleteDocumentFetch(
             handle,
             ContentCommand::CompleteDocumentFetch {
                 handler_id: handler_id as u64,
-                resolved_url,
-                body: payload.to_vec(),
+                response: ipc_messages::content::FetchResponse {
+                    final_url,
+                    status,
+                    content_type,
+                    body: payload.to_vec(),
+                },
             },
         )
     })) {

--- a/ipc_messages/src/content.rs
+++ b/ipc_messages/src/content.rs
@@ -35,6 +35,22 @@ pub struct FetchRequest {
     pub body: String,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LoadedDocumentResponse {
+    pub final_url: String,
+    pub status: u16,
+    pub content_type: String,
+    pub body: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FetchResponse {
+    pub final_url: String,
+    pub status: u16,
+    pub content_type: String,
+    pub body: Vec<u8>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum UserNavigationInvolvement {
     None,
@@ -473,8 +489,7 @@ pub enum Command {
     CreateLoadedDocument {
         traversable_id: u64,
         document_id: u64,
-        url: String,
-        body: String,
+        response: LoadedDocumentResponse,
     },
     DestroyDocument { document_id: u64 },
     EvaluateScript {
@@ -501,8 +516,7 @@ pub enum Command {
     },
     CompleteDocumentFetch {
         handler_id: u64,
-        resolved_url: String,
-        body: Vec<u8>,
+        response: FetchResponse,
     },
     FailDocumentFetch {
         handler_id: u64,
@@ -527,8 +541,9 @@ pub enum Event {
 #[cfg(test)]
 mod tests {
     use super::{
-        FontTransportReceiver, FontTransportSender, FrameId, PaintFrame,
-        PaintTransportSummary, SceneSummary, ScrollOffset, WebviewId,
+        Command, FetchResponse, FontTransportReceiver, FontTransportSender, FrameId,
+        LoadedDocumentResponse, PaintFrame, PaintTransportSummary, SceneSummary, ScrollOffset,
+        WebviewId,
     };
     use anyrender::{
         Glyph, PaintScene, Scene,
@@ -708,5 +723,78 @@ mod tests {
             .expect("second frame should decode")
             .into_scene(&receiver);
         assert_single_glyph_run_font(&second_scene, &[1, 2, 3, 4], 8);
+    }
+
+    #[test]
+    fn create_loaded_document_command_round_trips_response_metadata() {
+        let encoded = postcard::to_allocvec(&Command::CreateLoadedDocument {
+            traversable_id: 3,
+            document_id: 7,
+            response: LoadedDocumentResponse {
+                final_url: String::from("https://example.test/final"),
+                status: 201,
+                content_type: String::from("text/html; charset=utf-8"),
+                body: String::from("<p>ok</p>"),
+            },
+        })
+        .expect("create-loaded-document should serialize");
+        let decoded: Command =
+            postcard::from_bytes(&encoded).expect("create-loaded-document should deserialize");
+
+        match decoded {
+            Command::CreateLoadedDocument {
+                traversable_id,
+                document_id,
+                response,
+            } => {
+                assert_eq!(traversable_id, 3);
+                assert_eq!(document_id, 7);
+                assert_eq!(
+                    response,
+                    LoadedDocumentResponse {
+                        final_url: String::from("https://example.test/final"),
+                        status: 201,
+                        content_type: String::from("text/html; charset=utf-8"),
+                        body: String::from("<p>ok</p>"),
+                    }
+                );
+            }
+            other => panic!("expected CreateLoadedDocument, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn complete_document_fetch_command_round_trips_response_metadata() {
+        let encoded = postcard::to_allocvec(&Command::CompleteDocumentFetch {
+            handler_id: 19,
+            response: FetchResponse {
+                final_url: String::from("https://example.test/script.js"),
+                status: 404,
+                content_type: String::from("text/html"),
+                body: vec![1, 2, 3, 4],
+            },
+        })
+        .expect("complete-document-fetch should serialize");
+        let decoded: Command =
+            postcard::from_bytes(&encoded).expect("complete-document-fetch should deserialize");
+
+        match decoded {
+            Command::CompleteDocumentFetch {
+                handler_id,
+                response,
+            } => {
+                assert_eq!(handler_id, 19);
+                assert_eq!(
+                    response,
+                    FetchResponse {
+                        final_url: String::from("https://example.test/script.js"),
+                        status: 404,
+                        content_type: String::from("text/html"),
+                        body: vec![1, 2, 3, 4],
+                    }
+                );
+            }
+            other => panic!("expected CompleteDocumentFetch, got {other:?}"),
+        }
     }
 }


### PR DESCRIPTION
This is my first PR to formal-web. I’m working on the fetch, and this PR is focused on understanding the codebase and preserving response metadata across fetch calls.