### PR TITLE
   pi browser extension: make tools work with formal-web CDP

### DIFF
--- a/.pi/extensions/browser/README.md
+++ b/.pi/extensions/browser/README.md
@@ -1,8 +1,10 @@
 # pi browser extension
 
 Provides `browser_navigate`, `browser_click`, `browser_evaluate`,
-`browser_get_text`, `browser_screenshot`, and the other browser tools
+`browser_get_text`, `browser_screenshot`, and other browser tools
 available to the agent. Connects to a CDP-compatible browser.
+
+Works with standard Chrome/Chromium instances **and** formal-web's CDP server.
 
 ## Usage
 
@@ -12,28 +14,111 @@ embedder/target/debug/formal-web-embedder cdp --port 9222 \
   --startup-url "file:///path/to/page.html"
 
 # Inside pi, connect the extension to the running server
-# (this currently doesn't work reliably with formal-web's CDP)
 /pi command: /browser-connect 9222
 ```
 
-## Current state
+## Tools
 
-The extension connects to a CDP endpoint and wraps its commands into
-agent-callable tools. It works with standard Chrome/Chromium instances.
-Connecting to formal-web's CDP server is the goal but not yet functional —
-the WebSocket connection opens but the tools fail with closed-socket errors.
+All tools auto-reconnect on socket failures and fall back to JS-based
+implementations for CDP domains formal-web does not support.
 
-## Plan to fix
+| Tool | Primary mechanism | Works in formal-web? |
+|---|---|---|
+| `browser_navigate` | `Page.navigate` | ✅ Full support |
+| `browser_reload` | `Page.reload` | ✅ Full support |
+| `browser_evaluate` | `Runtime.evaluate` | ✅ Full support |
+| `browser_click` | `el.click()` via JS eval, then CDP `Input.dispatchMouseEvent` | ⚠️ `el.click()` throws (not in DOM); CDP physical click sends PointerUp/PointerDown events but DOM `click` synthesis is not yet wired. Agent can fall back to `browser_evaluate` with `location.assign()` etc. |
+| `browser_type` | JS input value setter (`jsSetInputValue`) + `input`/`change` events | ✅ `jsSetInputValue` fallback works. CDP `Input.dispatchKeyEvent` is a no-op — the tool skips it. |
+| `browser_hover` | CDP `mouseMoved` then verify with `:hover` check | ✅ Falls back to `jsHoverElement` (dispatches `mouseover`/`mouseenter` via DOM) |
+| `browser_get_text` | `Runtime.evaluate` reading `innerText` | ⚠️ `body.innerText` may be `null`; use `browser_evaluate` with `textContent` as needed |
+| `browser_get_attribute` | `Runtime.evaluate` | ✅ Full support |
+| `browser_get_computed_style` | `Runtime.evaluate` | ✅ Full support |
+| `browser_screenshot` | `Page.captureScreenshot` | ✅ Full support |
+| `browser_capture_console` | Listens for `Runtime.consoleAPICalled` events | ❌ Not emitted by CDP server yet — always returns empty. |
+| `browser_history_back` | `history.back()` via JS eval | ❌ `history` is not defined in the JS environment yet. Use `browser_evaluate` with `location.assign()` as fallback. |
 
-1. Determine why the WebSocket connection closes after `/browser-connect`.
-   The `resolvePageWsUrl` function fetches `/json/list` and connects to the
-   first page target's `webSocketDebuggerUrl`. If formal-web's CDP closes
-   the socket after `Page.enable` / `Runtime.enable` / `DOM.enable` / `Log.enable`,
-   one of those domain-enable commands may be unsupported.
+## Commands
 
-2. Gracefully handle unsupported CDP domains: send a reduced set of enable
-   commands (just `Page.enable` and `Runtime.enable`) and skip `DOM.enable`
-   and `Log.enable` if they fail.
+| Command | Description |
+|---|---|
+| `/browser-connect [port]` | Connect to a CDP endpoint (default port 9222) |
+| `/browser-disconnect` | Disconnect from the CDP endpoint |
+| `/browser-status` | Show connection state and available targets |
+| `/test-page` | Queue the FormalWeb startup page test suite |
 
-3. Add a `/browser-status` command that reports the connection state and
-   the list of available targets.
+## Architecture
+
+- **`cdp.ts`** — WebSocket CDP client, connection management, reconnection logic,
+  JS-based fallbacks for unsupported CDP domains (`jsSetInputValue`,
+  `jsHoverElement`, `jsUnhoverElement`).
+- **`tools.ts`** — Tool registration with auto-reconnect wrapper.
+- **`index.ts`** — Extension entry point and slash commands.
+- **`tests/formalweb.ts`** — FormalWeb startup page test plan (run via `/test-page`).
+
+### Formal-web CDP specifics
+
+Formal-web's CDP server implements a subset of the CDP protocol:
+
+- **Supported:** `Page.enable`, `Page.navigate`, `Page.reload`, `Page.captureScreenshot`,
+  `Page.getFrameTree`, `Page.createIsolatedWorld`, `Runtime.enable`, `Runtime.evaluate`,
+  `Input.dispatchMouseEvent` (only `mouseReleased` triggers click),
+  `DOM.getDocument`, `DOM.querySelector`, `DOM.querySelectorAll`,
+  `DOM.performSearch`, `DOM.getSearchResults`, `DOM.describeNode`,
+  `Target.*`, `Browser.getVersion`, `Accessibility.*`
+- **No-op stubs (return {}):** `Input.dispatchKeyEvent`,
+  `DOM.enable`, `Log.enable` (unknown methods return `{}`)
+- **Not supported (return error):** `Runtime.callFunctionOn`,
+  `DOM.getBoxModel`, `DOM.getContentQuads`
+
+The JS fallback in `browser_type` sets input values directly via `Runtime.evaluate`
+and dispatches `input`/`change` events to trigger reactive frameworks.
+
+## Future direction
+
+The CDP pi tools are meant for **live interactive debugging** of formal-web
+during feature development. WebDriver is reserved for automated regression
+suites (WPT, verification smoke tests).
+
+### Near-term improvements (CDP server side)
+
+1. **Synthesize DOM `click` from pointer events** —
+   `automation_click` sends `PointerMove` → `PointerDown` → `PointerUp` to the
+   content process, but no DOM `click` event is generated from those yet. Wiring
+   this into the content event pipeline would make `browser_click` work for
+   interactive elements without needing a JS fallback.
+
+2. **Emit `Runtime.consoleAPICalled` events** — The CDP server emits navigation
+   events (`Page.frameNavigated`, `Page.loadEventFired`) but not console events.
+   Adding a bridge from the content process's console to the CDP event sink would
+   let `browser_capture_console` capture `console.log`/`warn`/`error` output.
+
+3. **Expose `history` global** — Session history (`history.back()`/`forward()`) is
+   not yet wired into the JS environment. Once the traversable's session history
+   is exposed, `browser_history_back` will work.
+
+4. **Reduce render latency after navigation** — `Page.loadEventFired` fires before
+   the first paint completes. Adding a small render-wait or exposing the paint
+   state separately would make `browser_navigate` return after the page is visibly
+   ready rather than just loaded.
+
+### Future tool additions
+
+- **`browser_scroll`** — The CDP server already handles `Input.dispatchMouseEvent`
+  for clicks; adding scroll delta handling would let the agent check
+  scroll-triggered rendering.
+- **`browser_set_viewport`** — Resize the viewport programmatically for
+  responsive-design debugging.
+- **`browser_trace`** — Start/stop a performance trace (`Tracing.start`).
+
+### Relationship to WebDriver
+
+| | CDP (pi tools) | WebDriver (WPT) |
+|---|---|---|
+| **Purpose** | Interactive debugging | Automated regression testing |
+| **User** | The pi agent (you) | WPT runner, verification scripts |
+| **Connection** | Persistent WebSocket | Request-response HTTP |
+| **State** | Live page state | Session-per-test |
+| **JS eval** | Direct `Runtime.evaluate` | Wrapped in execute-script commands |
+
+Both are valuable — WebDriver for running the full WPT suite, CDP for the
+iterative "navigate → inspect → mutate → screenshot" loop during feature work.

--- a/.pi/extensions/browser/cdp.ts
+++ b/.pi/extensions/browser/cdp.ts
@@ -1,33 +1,62 @@
 import WebSocket from "ws";
 
 export class CDPClient {
-  private ws: WebSocket;
+  private ws: WebSocket | null = null;
+  private wsUrl: string;
   private pending = new Map<number, { resolve: (value: any) => void; reject: (error: Error) => void }>();
   private eventHandlers = new Map<string, Array<(params: any) => void>>();
   private msgId = 0;
-  readonly ready: Promise<void>;
+  private _ready: Promise<void>;
+  private _resolveReady: (() => void) | null = null;
+  private _rejectReady: ((error: Error) => void) | null = null;
+  private _closed = false;
 
   constructor(wsUrl: string) {
-    this.ws = new WebSocket(wsUrl);
-    this.ready = new Promise((resolve, reject) => {
-      this.ws.on("open", () => resolve());
-      this.ws.on("error", (error) => reject(error));
+    this.wsUrl = wsUrl;
+    this._ready = new Promise((resolve, reject) => {
+      this._resolveReady = resolve;
+      this._rejectReady = reject;
+    });
+    this.connect();
+  }
+
+  private connect() {
+    this._closed = false;
+    this.ws = new WebSocket(this.wsUrl);
+    this.ws.on("open", () => {
+      if (this._resolveReady) {
+        this._resolveReady();
+        this._resolveReady = null;
+        this._rejectReady = null;
+      }
+    });
+    this.ws.on("error", (error) => {
+      if (this._rejectReady) {
+        this._rejectReady(error);
+        this._resolveReady = null;
+        this._rejectReady = null;
+      }
     });
     this.ws.on("message", (raw) => {
-      const msg = JSON.parse(raw.toString());
-      if (msg.id != null && this.pending.has(msg.id)) {
-        const { resolve, reject } = this.pending.get(msg.id)!;
-        this.pending.delete(msg.id);
-        msg.error ? reject(new Error(msg.error.message)) : resolve(msg.result ?? {});
-        return;
-      }
-      if (msg.method) {
-        for (const handler of this.eventHandlers.get(msg.method) ?? []) {
-          handler(msg.params);
+      try {
+        const msg = JSON.parse(raw.toString());
+        if (msg.id != null && this.pending.has(msg.id)) {
+          const { resolve, reject } = this.pending.get(msg.id)!;
+          this.pending.delete(msg.id);
+          msg.error ? reject(new Error(msg.error.message)) : resolve(msg.result ?? {});
+          return;
         }
+        if (msg.method) {
+          for (const handler of this.eventHandlers.get(msg.method) ?? []) {
+            handler(msg.params);
+          }
+        }
+      } catch {
+        // Ignore malformed messages
       }
     });
     this.ws.on("close", () => {
+      this._closed = true;
       const error = new Error("CDP socket closed");
       for (const { reject } of this.pending.values()) {
         reject(error);
@@ -36,17 +65,33 @@ export class CDPClient {
     });
   }
 
-  send<T = any>(method: string, params: object = {}): Promise<T> {
+  get ready(): Promise<void> {
+    return this._ready;
+  }
+
+  get closed(): boolean {
+    return this._closed;
+  }
+
+  async send<T = any>(method: string, params: object = {}): Promise<T> {
+    if (this._closed || !this.ws) {
+      throw new Error("CDP socket closed");
+    }
     return new Promise((resolve, reject) => {
       const id = ++this.msgId;
       this.pending.set(id, { resolve, reject });
-      this.ws.send(JSON.stringify({ id, method, params }), (error) => {
-        if (!error) {
-          return;
-        }
+      try {
+        this.ws!.send(JSON.stringify({ id, method, params }), (error) => {
+          if (!error) {
+            return;
+          }
+          this.pending.delete(id);
+          reject(error);
+        });
+      } catch (error: any) {
         this.pending.delete(id);
         reject(error);
-      });
+      }
     });
   }
 
@@ -68,12 +113,20 @@ export class CDPClient {
   }
 
   close() {
-    this.ws.close();
+    this._closed = true;
+    if (this.ws) {
+      this.ws.close();
+      this.ws = null;
+    }
   }
 }
 
 let _client: CDPClient | null = null;
 let _port = 9222;
+
+/** Track the number of consecutive failures to detect truly dead connections. */
+let _consecutiveFailures = 0;
+const MAX_CONSECUTIVE_FAILURES = 3;
 
 export function setPort(port: number) {
   _port = port;
@@ -82,22 +135,84 @@ export function setPort(port: number) {
 export function disconnect() {
   _client?.close();
   _client = null;
+  _consecutiveFailures = 0;
 }
 
-export async function getClient(): Promise<CDPClient> {
-  if (_client) {
+export async function getClient(reconnect = false): Promise<CDPClient> {
+  // If reconnection is forced or too many failures, clear the cached client.
+  if (reconnect || _consecutiveFailures >= MAX_CONSECUTIVE_FAILURES) {
+    _client?.close();
+    _client = null;
+    _consecutiveFailures = 0;
+  }
+
+  if (_client && !_client.closed) {
     return _client;
   }
+
+  // If cached client was closed, create a new one.
+  if (_client?.closed) {
+    _client = null;
+    _consecutiveFailures = 0;
+  }
+
   const wsUrl = await resolvePageWsUrl(_port);
-  _client = new CDPClient(wsUrl);
-  await _client.ready;
+  const client = new CDPClient(wsUrl);
+  await client.ready;
+
+  // Enable required domains. DOM.enable and Log.enable are optional;
+  // formal-web's CDP server may not support them but it handles unknown
+  // methods gracefully (returns {} without error). Still, we catch
+  // any unexpected errors so the connection can proceed.
   await Promise.all([
-    _client.send("Page.enable"),
-    _client.send("Runtime.enable"),
-    _client.send("DOM.enable"),
-    _client.send("Log.enable"),
+    client.send("Page.enable"),
+    client.send("Runtime.enable"),
   ]);
-  return _client;
+  await Promise.all([
+    client.send("DOM.enable").catch(() => {}),
+    client.send("Log.enable").catch(() => {}),
+  ]);
+
+  _client = client;
+  _consecutiveFailures = 0;
+  return client;
+}
+
+/**
+ * Mark a failure on the current connection.
+ * Returns true if the caller should reconnect before retrying.
+ */
+export function noteSendFailure(): boolean {
+  _consecutiveFailures++;
+  return _consecutiveFailures >= MAX_CONSECUTIVE_FAILURES;
+}
+
+/**
+ * Check connection status and available targets.
+ */
+export async function browserStatus(): Promise<{
+  connected: boolean;
+  port: number;
+  targets: Array<{ type: string; url: string; webSocketDebuggerUrl?: string }>;
+}> {
+  const targets: Array<{ type: string; url: string; webSocketDebuggerUrl?: string }> = [];
+  let connected = false;
+
+  try {
+    const response = await fetch(`http://localhost:${_port}/json/list`);
+    if (response.ok) {
+      const list = await response.json() as Array<{ type: string; url: string; webSocketDebuggerUrl?: string }>;
+      targets.push(...list);
+    }
+  } catch {
+    // Can't fetch target list
+  }
+
+  if (_client && !_client.closed) {
+    connected = true;
+  }
+
+  return { connected, port: _port, targets };
 }
 
 async function resolvePageWsUrl(port: number): Promise<string> {
@@ -170,4 +285,95 @@ export async function getBoundingRect(
     throw new Error(`Element not found: ${selector}`);
   }
   return rect;
+}
+
+/**
+ * Fallback for tools that need CDP Input domain commands that formal-web
+ * may not support (dispatchKeyEvent, dispatchMouseEvent for hover).
+ * Attempts the CDP command; if it throws due to an unsupported domain,
+ * returns false so the caller can use a JS-based fallback.
+ */
+export async function tryCdpInput(
+  client: CDPClient,
+  method: string,
+  params: object
+): Promise<boolean> {
+  try {
+    await client.send(method, params);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Set an input field value via JS evaluation.
+ */
+export async function jsSetInputValue(
+  client: CDPClient,
+  selector: string,
+  text: string
+): Promise<void> {
+  const nativeInputValueSetter = await jsEval<boolean>(
+    client,
+    `(() => {
+      const el = document.querySelector(${JSON.stringify(selector)});
+      if (!el) return false;
+      // Set the value and dispatch input/change events to trigger reactivity.
+      const nativeSetter = Object.getOwnPropertyDescriptor(
+        window.HTMLInputElement.prototype, 'value'
+      )?.set;
+      if (nativeSetter) {
+        nativeSetter.call(el, ${JSON.stringify(text)});
+      } else {
+        el.value = ${JSON.stringify(text)};
+      }
+      el.dispatchEvent(new Event('input', { bubbles: true }));
+      el.dispatchEvent(new Event('change', { bubbles: true }));
+      return true;
+    })()`
+  );
+  if (!nativeInputValueSetter) {
+    throw new Error(`Element not found: ${selector}`);
+  }
+}
+
+/**
+ * Simulate a mouse hover via JS by dispatching mouseenter/mouseover events.
+ */
+export async function jsHoverElement(
+  client: CDPClient,
+  selector: string
+): Promise<void> {
+  const hovered = await jsEval<boolean>(
+    client,
+    `(() => {
+      const el = document.querySelector(${JSON.stringify(selector)});
+      if (!el) return false;
+      el.dispatchEvent(new MouseEvent('mouseover', { bubbles: true, relatedTarget: null }));
+      el.dispatchEvent(new MouseEvent('mouseenter', { bubbles: false, relatedTarget: null }));
+      return true;
+    })()`
+  );
+  if (!hovered) {
+    throw new Error(`Element not found: ${selector}`);
+  }
+}
+
+/**
+ * Unhover (move mouse away) via JS.
+ */
+export async function jsUnhoverElement(
+  client: CDPClient,
+  selector: string
+): Promise<void> {
+  await jsEval(
+    client,
+    `(() => {
+      const el = document.querySelector(${JSON.stringify(selector)});
+      if (!el) return;
+      el.dispatchEvent(new MouseEvent('mouseout', { bubbles: true, relatedTarget: null }));
+      el.dispatchEvent(new MouseEvent('mouseleave', { bubbles: false, relatedTarget: null }));
+    })()`
+  );
 }

--- a/.pi/extensions/browser/index.ts
+++ b/.pi/extensions/browser/index.ts
@@ -1,4 +1,4 @@
-import { disconnect, setPort } from "./cdp.js";
+import { browserStatus, disconnect, setPort } from "./cdp.js";
 import { registerTools } from "./tools.js";
 import { FORMALWEB_TEST_PLAN } from "./tests/formalweb.js";
 
@@ -34,6 +34,29 @@ export default function (pi: any) {
     handler: async (_args, ctx) => {
       disconnect();
       ctx.ui.notify("Disconnected from browser", "info");
+    },
+  });
+
+  pi.registerCommand("browser-status", {
+    description: "Report connection status and available CDP targets. Usage: /browser-status",
+    handler: async (_args, ctx) => {
+      try {
+        const status = await browserStatus();
+        const lines: string[] = [];
+        lines.push(`Port: ${status.port}`);
+        lines.push(`Connected: ${status.connected}`);
+        if (status.targets.length > 0) {
+          lines.push(`Targets (${status.targets.length}):`);
+          for (const target of status.targets) {
+            lines.push(`  - ${target.type}: ${target.url}`);
+          }
+        } else {
+          lines.push("No targets found.");
+        }
+        ctx.ui.notify(lines.join("\n"), status.connected ? "info" : "warning");
+      } catch (error: any) {
+        ctx.ui.notify(`Status check failed: ${error.message}`, "error");
+      }
     },
   });
 

--- a/.pi/extensions/browser/tools.ts
+++ b/.pi/extensions/browser/tools.ts
@@ -1,5 +1,16 @@
 import { writeFile } from "node:fs/promises";
-import { getBoundingRect, getClient, jsEval, waitForLoad, waitForNavigation } from "./cdp.js";
+import {
+  getBoundingRect,
+  getClient,
+  jsEval,
+  jsHoverElement,
+  jsSetInputValue,
+  jsUnhoverElement,
+  noteSendFailure,
+  tryCdpInput,
+  waitForLoad,
+  waitForNavigation,
+} from "./cdp.js";
 
 const MAX_TEXT = 4000;
 
@@ -30,6 +41,34 @@ function toolSchema(properties: Record<string, unknown>, required: string[] = []
   };
 }
 
+/**
+ * Wrap a tool execute handler with automatic reconnection logic.
+ * If the underlying CDP socket fails, this clears the cached client
+ * and retries once before giving up.
+ */
+function withReconnect<T>(
+  fn: () => Promise<T>
+): () => Promise<T> {
+  return async () => {
+    try {
+      return await fn();
+    } catch (error: any) {
+      if (
+        error?.message?.includes("CDP socket closed") ||
+        error?.message?.includes("WebSocket") ||
+        error?.code === "ECONNRESET"
+      ) {
+        // Force reconnection and retry once
+        noteSendFailure();
+        await getClient(true);
+        // Re-run the function; it will getClient() internally and pick up the fresh connection
+        return await fn();
+      }
+      throw error;
+    }
+  };
+}
+
 export function registerTools(pi: any) {
   pi.registerTool({
     name: "browser_navigate",
@@ -41,15 +80,17 @@ export function registerTools(pi: any) {
       url: { type: "string", description: "Fully-qualified URL to navigate to" },
     }, ["url"]),
     async execute(_id: string, params: { url: string }) {
-      const client = await getClient();
-      const nav = waitForLoad(client);
-      await client.send("Page.navigate", { url: params.url });
-      await nav;
-      const title = await jsEval<string>(client, "document.title");
-      return {
-        content: [{ type: "text", text: truncate(`Navigated to ${params.url}\nTitle: ${title}`) }],
-        details: { url: params.url, title },
-      };
+      return await withReconnect(async () => {
+        const client = await getClient();
+        const nav = waitForLoad(client);
+        await client.send("Page.navigate", { url: params.url });
+        await nav;
+        const title = await jsEval<string>(client, "document.title");
+        return {
+          content: [{ type: "text", text: truncate(`Navigated to ${params.url}\nTitle: ${title}`) }],
+          details: { url: params.url, title },
+        };
+      })();
     },
   });
 
@@ -63,15 +104,17 @@ export function registerTools(pi: any) {
       ignoreCache: { type: "boolean", description: "Hard reload ignoring cache (default false)" },
     }),
     async execute(_id: string, params: { ignoreCache?: boolean }) {
-      const client = await getClient();
-      const nav = waitForLoad(client);
-      await client.send("Page.reload", { ignoreCache: params.ignoreCache ?? false });
-      await nav;
-      const url = await jsEval<string>(client, "location.href");
-      return {
-        content: [{ type: "text", text: truncate(`Reloaded: ${url}`) }],
-        details: { url },
-      };
+      return await withReconnect(async () => {
+        const client = await getClient();
+        const nav = waitForLoad(client);
+        await client.send("Page.reload", { ignoreCache: params.ignoreCache ?? false });
+        await nav;
+        const url = await jsEval<string>(client, "location.href");
+        return {
+          content: [{ type: "text", text: truncate(`Reloaded: ${url}`) }],
+          details: { url },
+        };
+      })();
     },
   });
 
@@ -85,10 +128,12 @@ export function registerTools(pi: any) {
       expression: { type: "string", description: "JS expression to evaluate" },
     }, ["expression"]),
     async execute(_id: string, params: { expression: string }) {
-      const client = await getClient();
-      const value = await jsEval(client, params.expression);
-      const text = truncate(JSON.stringify(jsonSerializable(value), null, 2) ?? "undefined");
-      return { content: [{ type: "text", text }], details: { value: jsonSerializable(value) } };
+      return await withReconnect(async () => {
+        const client = await getClient();
+        const value = await jsEval(client, params.expression);
+        const text = truncate(JSON.stringify(jsonSerializable(value), null, 2) ?? "undefined");
+        return { content: [{ type: "text", text }], details: { value: jsonSerializable(value) } };
+      })();
     },
   });
 
@@ -102,25 +147,42 @@ export function registerTools(pi: any) {
       selector: { type: "string", description: "CSS selector of the element to click" },
     }, ["selector"]),
     async execute(_id: string, params: { selector: string }) {
-      const client = await getClient();
-      const found = await jsEval<boolean>(
-        client,
-        `(() => { const el = document.querySelector(${JSON.stringify(params.selector)}); if (!el) return false; el.click(); return true; })()`
-      );
-      if (!found) {
-        throw new Error(`Element not found: ${params.selector}`);
-      }
-      return {
-        content: [{ type: "text", text: truncate(`Clicked: ${params.selector}`) }],
-        details: { selector: params.selector },
-      };
+      return await withReconnect(async () => {
+        const client = await getClient();
+
+        // First try DOM click via JS (works in Chrome; may throw in formal-web
+        // if el.click is not implemented). Catch errors gracefully.
+        const domClicked = await jsEval<boolean>(
+          client,
+          `(() => { try { const el = document.querySelector(${JSON.stringify(params.selector)}); if (!el) return false; el.click(); return true; } catch { return false; } })()`
+        );
+        if (domClicked) {
+          await new Promise((resolve) => setTimeout(resolve, 60));
+          return {
+            content: [{ type: "text", text: truncate(`Clicked: ${params.selector}`) }],
+            details: { selector: params.selector },
+          };
+        }
+
+        // Fall back to CDP physical click.
+        const rect = await getBoundingRect(client, params.selector);
+        const x = rect.left + rect.width / 2;
+        const y = rect.top + rect.height / 2;
+        await client.send("Input.dispatchMouseEvent", { type: "mousePressed", x, y, button: "left", clickCount: 1 });
+        await client.send("Input.dispatchMouseEvent", { type: "mouseReleased", x, y, button: "left", clickCount: 1 });
+        await new Promise((resolve) => setTimeout(resolve, 60));
+        return {
+          content: [{ type: "text", text: truncate(`Clicked: ${params.selector}`) }],
+          details: { selector: params.selector },
+        };
+      })();
     },
   });
 
   pi.registerTool({
     name: "browser_type",
     label: "Browser: type text",
-    description: "Focus a selector and type text character by character via CDP key events.",
+    description: "Focus a selector and type text into an input. Uses JS-based input setting with input/change events for framework compatibility.",
     promptSnippet: "Type text into a browser input or textarea.",
     promptGuidelines: ["Use browser_type to fill text inputs by selector before submitting a form."],
     parameters: toolSchema({
@@ -129,28 +191,32 @@ export function registerTools(pi: any) {
       clearFirst: { type: "boolean", description: "Select all and delete before typing (default false)" },
     }, ["selector", "text"]),
     async execute(_id: string, params: { selector: string; text: string; clearFirst?: boolean }) {
-      const client = await getClient();
-      const focused = await jsEval<boolean>(
-        client,
-        `(() => { const el = document.querySelector(${JSON.stringify(params.selector)}); if (!el) return false; el.focus(); return true; })()`
-      );
-      if (!focused) {
-        throw new Error(`Element not found: ${params.selector}`);
-      }
-      if (params.clearFirst) {
-        await client.send("Input.dispatchKeyEvent", { type: "keyDown", key: "a", modifiers: 2 });
-        await client.send("Input.dispatchKeyEvent", { type: "keyUp", key: "a", modifiers: 2 });
-        await client.send("Input.dispatchKeyEvent", { type: "keyDown", key: "Delete" });
-        await client.send("Input.dispatchKeyEvent", { type: "keyUp", key: "Delete" });
-      }
-      for (const char of params.text) {
-        await client.send("Input.dispatchKeyEvent", { type: "keyDown", text: char });
-        await client.send("Input.dispatchKeyEvent", { type: "keyUp", text: char });
-      }
-      return {
-        content: [{ type: "text", text: truncate(`Typed ${params.text.length} chars into ${params.selector}`) }],
-        details: { selector: params.selector, length: params.text.length },
-      };
+      return await withReconnect(async () => {
+        const client = await getClient();
+
+        // Focus the element
+        const focused = await jsEval<boolean>(
+          client,
+          `(() => { const el = document.querySelector(${JSON.stringify(params.selector)}); if (!el) return false; el.focus(); return true; })()`
+        );
+        if (!focused) {
+          throw new Error(`Element not found: ${params.selector}`);
+        }
+
+        // Use JS-based input value setting. This works reliably with both
+        // Chrome/Chromium (full CDP) and formal-web (whose Input.dispatchKeyEvent
+        // is a no-op stub). Sets the value directly and dispatches input/change
+        // events for reactive framework compatibility.
+        if (params.clearFirst) {
+          await jsSetInputValue(client, params.selector, "");
+        }
+        await jsSetInputValue(client, params.selector, params.text);
+
+        return {
+          content: [{ type: "text", text: truncate(`Typed ${params.text.length} chars into ${params.selector}`) }],
+          details: { selector: params.selector, length: params.text.length },
+        };
+      })();
     },
   });
 
@@ -164,22 +230,48 @@ export function registerTools(pi: any) {
       selector: { type: ["string", "null"], description: "CSS selector to hover over, or null to move mouse away" },
     }),
     async execute(_id: string, params: { selector?: string | null }) {
-      const client = await getClient();
-      let x = 0;
-      let y = 0;
-      let note = "Moved mouse to (0, 0)";
-      if (params.selector) {
+      return await withReconnect(async () => {
+        const client = await getClient();
+
+        if (!params.selector) {
+          // Move mouse away — unhover via JS (works everywhere).
+          await jsUnhoverElement(client, "body");
+          await new Promise((resolve) => setTimeout(resolve, 200));
+          return {
+            content: [{ type: "text", text: "Moved mouse to (0, 0)" }],
+            details: { x: 0, y: 0, selector: null },
+          };
+        }
+
         const rect = await getBoundingRect(client, params.selector);
-        x = rect.left + rect.width / 2;
-        y = rect.top + rect.height / 2;
-        note = `Hovered ${params.selector} at (${x.toFixed(0)}, ${y.toFixed(0)})`;
-      }
-      await client.send("Input.dispatchMouseEvent", { type: "mouseMoved", x, y });
-      await new Promise((resolve) => setTimeout(resolve, 200));
-      return {
-        content: [{ type: "text", text: truncate(note) }],
-        details: { x, y, selector: params.selector ?? null },
-      };
+        const x = rect.left + rect.width / 2;
+        const y = rect.top + rect.height / 2;
+
+        // Try CDP mouseMoved first; it works in Chrome/Chromium but may be
+        // a no-op in formal-web. Verify by checking :hover state after.
+        await tryCdpInput(client, "Input.dispatchMouseEvent", {
+          type: "mouseMoved",
+          x,
+          y,
+        });
+
+        // Check if the CDP command actually triggered :hover on the element.
+        const hoverActive = await jsEval<boolean>(
+          client,
+          `(() => { const el = document.querySelector(${JSON.stringify(params.selector)}); if (!el) return false; return el.matches(':hover'); })()`
+        );
+
+        if (!hoverActive) {
+          // CDP mouseMoved didn't trigger hover (formal-web) — use JS fallback.
+          await jsHoverElement(client, params.selector);
+        }
+
+        await new Promise((resolve) => setTimeout(resolve, 200));
+        return {
+          content: [{ type: "text", text: `Hovered ${params.selector} at (${x.toFixed(0)}, ${y.toFixed(0)})` }],
+          details: { x, y, selector: params.selector },
+        };
+      })();
     },
   });
 
@@ -193,16 +285,18 @@ export function registerTools(pi: any) {
       selector: { type: "string", description: "CSS selector; omit for full page text" },
     }),
     async execute(_id: string, params: { selector?: string }) {
-      const client = await getClient();
-      const expr = params.selector
-        ? `document.querySelector(${JSON.stringify(params.selector)})?.innerText ?? ""`
-        : "document.body.innerText";
-      const raw = await jsEval<string>(client, expr);
-      const text = truncate(raw ?? "");
-      return {
-        content: [{ type: "text", text }],
-        details: { selector: params.selector ?? null, length: raw?.length ?? 0 },
-      };
+      return await withReconnect(async () => {
+        const client = await getClient();
+        const expr = params.selector
+          ? `document.querySelector(${JSON.stringify(params.selector)})?.innerText ?? ""`
+          : "document.body.innerText";
+        const raw = await jsEval<string>(client, expr);
+        const text = truncate(raw ?? "");
+        return {
+          content: [{ type: "text", text }],
+          details: { selector: params.selector ?? null, length: raw?.length ?? 0 },
+        };
+      })();
     },
   });
 
@@ -217,15 +311,17 @@ export function registerTools(pi: any) {
       attribute: { type: "string", description: "Attribute name, e.g. data-active or aria-pressed" },
     }, ["selector", "attribute"]),
     async execute(_id: string, params: { selector: string; attribute: string }) {
-      const client = await getClient();
-      const value = await jsEval<string | null>(
-        client,
-        `document.querySelector(${JSON.stringify(params.selector)})?.getAttribute(${JSON.stringify(params.attribute)}) ?? null`
-      );
-      return {
-        content: [{ type: "text", text: truncate(value === null ? "(attribute not found)" : value) }],
-        details: { selector: params.selector, attribute: params.attribute, value },
-      };
+      return await withReconnect(async () => {
+        const client = await getClient();
+        const value = await jsEval<string | null>(
+          client,
+          `document.querySelector(${JSON.stringify(params.selector)})?.getAttribute(${JSON.stringify(params.attribute)}) ?? null`
+        );
+        return {
+          content: [{ type: "text", text: truncate(value === null ? "(attribute not found)" : value) }],
+          details: { selector: params.selector, attribute: params.attribute, value },
+        };
+      })();
     },
   });
 
@@ -240,15 +336,17 @@ export function registerTools(pi: any) {
       property: { type: "string", description: "CSS property name, e.g. background-color or opacity" },
     }, ["selector", "property"]),
     async execute(_id: string, params: { selector: string; property: string }) {
-      const client = await getClient();
-      const value = await jsEval<string>(
-        client,
-        `(() => { const el = document.querySelector(${JSON.stringify(params.selector)}); if (!el) throw new Error('Element not found: ' + ${JSON.stringify(params.selector)}); return getComputedStyle(el).getPropertyValue(${JSON.stringify(params.property)}); })()`
-      );
-      return {
-        content: [{ type: "text", text: truncate(value) }],
-        details: { selector: params.selector, property: params.property, value },
-      };
+      return await withReconnect(async () => {
+        const client = await getClient();
+        const value = await jsEval<string>(
+          client,
+          `(() => { const el = document.querySelector(${JSON.stringify(params.selector)}); if (!el) throw new Error('Element not found: ' + ${JSON.stringify(params.selector)}); return getComputedStyle(el).getPropertyValue(${JSON.stringify(params.property)}); })()`
+        );
+        return {
+          content: [{ type: "text", text: truncate(value) }],
+          details: { selector: params.selector, property: params.property, value },
+        };
+      })();
     },
   });
 
@@ -262,14 +360,16 @@ export function registerTools(pi: any) {
       path: { type: "string", description: "Output path (default: ./screenshot.png)" },
     }),
     async execute(_id: string, params: { path?: string }) {
-      const client = await getClient();
-      const { data } = await client.send<{ data: string }>("Page.captureScreenshot", { format: "png" });
-      const outPath = params.path ?? "./screenshot.png";
-      await writeFile(outPath, Buffer.from(data, "base64"));
-      return {
-        content: [{ type: "text", text: truncate(`Screenshot saved to ${outPath}`) }],
-        details: { path: outPath },
-      };
+      return await withReconnect(async () => {
+        const client = await getClient();
+        const { data } = await client.send<{ data: string }>("Page.captureScreenshot", { format: "png" });
+        const outPath = params.path ?? "./screenshot.png";
+        await writeFile(outPath, Buffer.from(data, "base64"));
+        return {
+          content: [{ type: "text", text: truncate(`Screenshot saved to ${outPath}`) }],
+          details: { path: outPath },
+        };
+      })();
     },
   });
 
@@ -283,19 +383,21 @@ export function registerTools(pi: any) {
       durationMs: { type: "number", description: "How long to listen in ms (default 1000)", default: 1000 },
     }),
     async execute(_id: string, params: { durationMs?: number }) {
-      const client = await getClient();
-      const logs: Array<{ level: string; text: string }> = [];
-      const off = client.onEvent("Runtime.consoleAPICalled", (event: any) => {
-        const text = (event.args ?? []).map((arg: any) => arg.value ?? arg.description ?? "").join(" ");
-        logs.push({ level: event.type, text });
-      });
-      await new Promise((resolve) => setTimeout(resolve, params.durationMs ?? 1000));
-      off();
-      const summary = logs.length === 0 ? "(no console output)" : logs.map((entry) => `[${entry.level}] ${entry.text}`).join("\n");
-      return {
-        content: [{ type: "text", text: truncate(summary) }],
-        details: { logs },
-      };
+      return await withReconnect(async () => {
+        const client = await getClient();
+        const logs: Array<{ level: string; text: string }> = [];
+        const off = client.onEvent("Runtime.consoleAPICalled", (event: any) => {
+          const text = (event.args ?? []).map((arg: any) => arg.value ?? arg.description ?? "").join(" ");
+          logs.push({ level: event.type, text });
+        });
+        await new Promise((resolve) => setTimeout(resolve, params.durationMs ?? 1000));
+        off();
+        const summary = logs.length === 0 ? "(no console output)" : logs.map((entry) => `[${entry.level}] ${entry.text}`).join("\n");
+        return {
+          content: [{ type: "text", text: truncate(summary) }],
+          details: { logs },
+        };
+      })();
     },
   });
 
@@ -307,15 +409,17 @@ export function registerTools(pi: any) {
     promptGuidelines: ["Use browser_history_back to restore the previous page after testing navigation."],
     parameters: toolSchema({}, []),
     async execute() {
-      const client = await getClient();
-      const nav = waitForNavigation(client);
-      await jsEval(client, "history.back()");
-      await nav;
-      const url = await jsEval<string>(client, "location.href");
-      return {
-        content: [{ type: "text", text: truncate(`Back to: ${url}`) }],
-        details: { url },
-      };
+      return await withReconnect(async () => {
+        const client = await getClient();
+        const nav = waitForNavigation(client);
+        await jsEval(client, "history.back()");
+        await nav;
+        const url = await jsEval<string>(client, "location.href");
+        return {
+          content: [{ type: "text", text: truncate(`Back to: ${url}`) }],
+          details: { url },
+        };
+      })();
     },
   });
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,11 +48,33 @@ The `.pi/extensions/pi-share-hf/` extension archives pi sessions to `.pi/collect
 - **`/collect-session` command** — Interactive equivalent of the above.
 - **`upload_session` tool** — Stub only; not yet implemented. Will eventually upload collected sessions to a remote destination (e.g. Hugging Face dataset).
 
+## pi-browser — CDP Browser Tools
+
+The `.pi/extensions/browser/` extension wraps formal-web's CDP server into
+agent-callable tools for live interactive debugging during feature development.
+
+- **`browser_navigate`** — Navigate to a URL and wait for load.
+- **`browser_evaluate`** — Run a JavaScript expression in the page context.
+- **`browser_click`** — Click an element by CSS selector.
+- **`browser_type`** — Type text into an input.
+- **`browser_hover`** — Hover over an element for CSS `:hover` testing.
+- **`browser_get_text`** — Read visible text from the page or a selector.
+- **`browser_get_attribute`** — Read a DOM attribute value.
+- **`browser_get_computed_style`** — Read a computed CSS property.
+- **`browser_screenshot`** — Capture a PNG screenshot.
+- **`browser_capture_console`** — Collect console output for N milliseconds.
+- **`browser_history_back`** — Go back in browser history.
+- **`browser_reload`** — Reload the current page.
+- **`/browser-connect [port]`** — Connect to a CDP endpoint.
+- **`/browser-status`** — Show connection state and targets.
+
+See `.pi/extensions/browser/README.md` for tool details, command reference,
+formal-web CDP specifics, and the future roadmap.
+
 ## Testing with formal-web
 
 Formal-web supports three testing interfaces. See `automation/README.md`
-for detailed documentation, and `.pi/extensions/browser/README.md` for the
-pi browser extension that wraps CDP into agent-callable tools.
+for detailed documentation.
 
 ## web_standards — Spec Reading
 
@@ -86,9 +108,14 @@ Errors must always be logged before being discarded. A `Result` value must never
 
 At the end of each task, run the following steps **in order**:
 
-1. **Suggest a commit message** — Propose a commit message for changes tracked by git.
+1. **Tear down browser/CDP infra** — Kill any formal-web embedder processes
+   (`pkill -f "formal-web-embedder")`, CDP servers, or other sidecars that
+   were started during the session. Leftover processes can block ports and
+   interfere with subsequent tasks.
 
-2. **Run task-appropriate verification** — Run only the verification steps that are relevant to the changes made. If the task involves changes to browser implementation code, run the following; otherwise skip them:
+2. **Suggest a commit message** — Propose a commit message for changes tracked by git.
+
+3. **Run task-appropriate verification** — Run only the verification steps that are relevant to the changes made. If the task involves changes to browser implementation code, run the following; otherwise skip them:
    - **Default WPT run** — Runs the Web Platform Tests suite to check for regressions in browser behavior. Appropriate for changes to content, DOM, HTML, or Web IDL implementation code.
    - **`./verification/verify-navigation.sh`** — Builds and launches the formal-web browser with embedded TLA+ verification, tests hyperlink navigation via WebDriver, and validates shutdown-time model checking. Appropriate for changes to navigation, session history, embedder, or content-process code.
-3. DO NOT collect pi sessions; those are collected automatically on shutdown.
+4. DO NOT collect pi sessions; those are collected automatically on shutdown.


### PR DESCRIPTION
   - Gracefully handle unsupported CDP domains (DOM.enable, Log.enable)
   - Add reconnection logic and /browser-status command
   - Fix browser_type: use JS input setting instead of no-op CDP key events
   - Fix browser_hover: verify :hover state, fall back to JS DOM events
   - Fix browser_click: catch el.click() errors, fall back to CDP physical click
   - Wrap all tools with auto-reconnect on socket drop
   - Update README with formal-web CDP specifics and future roadmap
   - Document browser extension tools in AGENTS.md
   - Add teardown step for browser/CDP infra at end of task