### PR TITLE
 Fix spec tool docs and add iterative-spec reminders to results

### DIFF
--- a/.pi/extensions/web_standards/README.md
+++ b/.pi/extensions/web_standards/README.md
@@ -25,6 +25,17 @@ Because every spec anchor (heading, dfn, span, `a`) matches an `id` attribute in
 
 Algorithm steps are rendered with recursive step numbers (1, 1.1, 1.1.1, 1.2, 2, …). The HTML spec provides no step numbers in the markup — they are computed from the nested `<ol>` structure.
 
+**Cross-reference table.** When the content contains spec cross-references (terms linked to other sections or specs), a table is appended at the bottom:
+
+```
+┌─ Term           ── Link                                                        ─┐
+│ boolean         https://webidl.spec.whatwg.org/#idl-boolean                     │
+│ CSSOMString     https://drafts.csswg.org/cssom-1/#cssomstring                   │
+└──────────────────────────────────────────────────────────────────────────────────┘
+```
+
+Each row pairs a term name with the anchor URL where it's defined. You can look up any of these with another `spec_lookup` call — split the URL before `#` as `url=` and after `#` as `id=`, e.g. `spec_lookup(url="https://webidl.spec.whatwg.org/", id="idl-boolean")`. This lets you follow the spec's dependency chain across specs step by step.
+
 ### `spec_search_id` (find ids by keyword)
 
 Search across all elements with an `id` attribute for a substring match. Returns a list of matching ids with their tag and first line of text. Use this to discover anchor IDs when you know a keyword but not the exact id.

--- a/.pi/extensions/web_standards/index.ts
+++ b/.pi/extensions/web_standards/index.ts
@@ -49,6 +49,18 @@ function formatLinkTable(links: { text: string; href: string }[]): string {
   return ["", header, ...rows, sep].join("\n");
 }
 
+// ── Doc style reminder appended to every successful result ──────────────────────
+
+const DOC_REMINDER = `
+
+── Spec Doc Reminder ──
+When implementing from this spec:
+• Prefix each algorithm step with // Step N: <first words of spec step>
+• Top doc comment on implementing functions/structs: spec anchor URL
+• // Note: only for discrepancies between code and spec text
+• Re-read the spec and compare against your code iteratively
+`;
+
 // ── Algorithm step rendering ──────────────────────────────────────────────────
 // The HTML spec uses nested <ol> elements for algorithm steps. The <li> elements
 // are NOT numbered in the HTML — the browser renders them. We assign numbers
@@ -280,7 +292,7 @@ export default function (pi: ExtensionAPI) {
           content: [
             {
               type: "text" as const,
-              text: truncate(parts.join("\n\n") + linkTable),
+              text: truncate(parts.join("\n\n") + linkTable + DOC_REMINDER),
             },
           ],
           details: { url, id, tag: tagName },
@@ -302,7 +314,7 @@ export default function (pi: ExtensionAPI) {
         }
         const linkTable = formatLinkTable(links);
         return {
-          content: [{ type: "text" as const, text: truncate(output + linkTable) }],
+          content: [{ type: "text" as const, text: truncate(output + linkTable + DOC_REMINDER) }],
           details: { url, id, tag: tagName, algorithm: algoName },
         };
       }
@@ -319,7 +331,7 @@ export default function (pi: ExtensionAPI) {
       ];
       const linkTable = formatLinkTable(links);
       return {
-        content: [{ type: "text" as const, text: truncate(parts.join("\n\n") + linkTable) }],
+        content: [{ type: "text" as const, text: truncate(parts.join("\n\n") + linkTable + DOC_REMINDER) }],
         details: { url, id, tag: tagName },
       };
     },
@@ -392,7 +404,7 @@ export default function (pi: ExtensionAPI) {
         .join("\n\n");
 
       return {
-        content: [{ type: "text" as const, text: truncate(output + note) }],
+        content: [{ type: "text" as const, text: truncate(output + note + DOC_REMINDER) }],
         details: {
           url,
           query,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,13 +93,10 @@ for detailed documentation.
 
 ## web_standards — Spec Reading
 
-The `.pi/extensions/web_standards/` extension lazily loads and caches web standards documents (WHATWG, W3C, etc.) on first use. Provides four tools for the agent to read specs interactively:
+The `.pi/extensions/web_standards/` extension lazily loads and caches web standards documents (WHATWG, W3C, etc.) on first use. Provides two tools for the agent to read specs interactively:
 
-- **`spec_select`** — Run CSS selectors against a spec document to discover headings (`h2[id]`), definitions (`dfn[id]`), algorithm boxes (`div[data-algorithm]`), etc.
 - **`spec_lookup`** — Look up a named anchor in a spec by its `id` attribute. Returns the element's tag, rendered content, and walks forward siblings to show algorithm boxes (with full recursive step numbering) until the next heading or named definition. This is the primary tool for reading spec content.
-- **`spec_select`** — Run CSS selectors against a spec document to discover headings (`h2[id]`), definitions (`dfn[id]`), algorithm boxes (`div[data-algorithm]`), etc.
-- **`spec_html`** — Return inner HTML of the first matching element. Best for self-contained blocks: tables, definition lists (`dl`), example blocks.
-- **`/spec-loaded` command** — Lists all spec URLs currently cached in memory.
+- **`spec_search_id`** — Search for element `id` attributes containing a given substring. Use to discover anchor IDs when you know a keyword but not the exact id.
 
 # Naming Conventions
 
@@ -117,7 +114,7 @@ The `.pi/extensions/web_standards/` extension lazily loads and caches web standa
 - Describe current architecture and behavior; keep task history out of repository docs.
 - Keep README guidance general and durable; one-off implementation details belong in source or tests, not in repository docs.
 - Use neutral, factual language.
-- Use the `web_standards` extension tools (`spec_lookup`, `spec_select`, `spec_html`) to read spec content instead of reading local copies or fetching directly.
+- Use the `web_standards` extension tools (`spec_lookup`, `spec_search_id`) to read spec content instead of reading local copies or fetching directly. This is not a one-shot lookup — consult the spec **iteratively** as you write code: start by reading the algorithm to understand the structure, implement the corresponding code, then re-read the spec and compare each step against what you wrote. The spec is the source of truth for both the algorithm logic and the documentation annotations (`// Step N:`, anchor URLs, `// Note:` for discrepancies) that code must carry. The end-of-task spec-mapping review (step 4 below) is the final checkpoint that every algorithm in the changeset is consistently implemented and properly annotated.
 - Treat `vendor/` and vendored WPT resources as read-only unless the task explicitly requires vendor changes.
 - The words "runtime" and "sidecar" are forbidden in this repo.
 - **Method doc comments:** A method that implements a spec algorithm should have only the spec link as its doc comment. All explanation, step references, and context belong in `//` comments inside the method body. A `// Note:` below the link is acceptable only for brief continuations of the algorithm that cannot be expressed as body comments. Why? Because the entire thing is a runtime, one that implements the Web, and so neither concept should ever be used to model or document some component of what is basically one big integrated system. No component is more or less of a "sidecar" than any other — each plays a specific role. Instead of reaching for these forbidden words, think about what the thing you want to name does, what its role in the system is, and come up with something descriptive.


### PR DESCRIPTION
   AGENTS.md:
   - Remove references to non-existent tools (spec_select, spec_html, /spec-loaded) and replace with spec_search_id; correct "four tools" to "two tools"
   - Expand web_standards usage guidance to emphasize iterative spec consultation — read, implement, re-read, compare — and link to the doc style annotations and end-of-task spec-mapping review

   web_standards/README.md:
   - Document the cross-reference table appended to spec_lookup output, showing how to chain lookups across specs

   web_standards/index.ts:
   - Append a DOC_REMINDER to every successful tool result, listing the four key documentation conventions (// Step N:, anchor URLs, // Note: only for discrepancies, iterative re-read)