### PR TITLE
Replace eprintln with structured logging (log + env_logger)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -179,12 +179,28 @@ The `.pi/extensions/web_standards/` extension lazily loads and caches web standa
 
 # Error Logging
 
-Errors must always be logged before being discarded. A `Result` value must never be silently dropped anywhere in the codebase — every `Result<_, E>` carries diagnostic information that can help debug failures in this multi-process system.
+# Logging
 
-- Use `if let Err(error) = fallible_operation() { eprintln!("...: {error}"); }` instead of `let _ = fallible_operation();`. The error message should identify the operation and include the error.
+The project uses the standard `log` crate with `env_logger` for structured logging. All crates depend on `log`; binary crates also depend on `env_logger` and call `env_logger::init()` at startup.
+
+## Log levels by category
+
+| Level | When to use |
+|---|---|
+| `error!` | Operation failures, system errors, unexpected conditions that need investigation |
+| `warn!` | Non-critical issues, unimplemented features, recoverable problems |
+| `info!` | Lifecycle events, startup/shutdown, test summaries |
+| `debug!` | Debug traces enabled by toggle (e.g. `render-state`, `timer-debug`, `stream-debug`, `cdp`) |
+| `trace!` | Very verbose debugging enabled by toggle (e.g. `input-debug`, `startup-debug`) |
+
+## Rules
+
+- Errors must always be logged before being discarded. A `Result` value must never be silently dropped anywhere in the codebase — every `Result<_, E>` carries diagnostic information that can help debug failures in this multi-process system.
+- Use `if let Err(error) = fallible_operation() { error!("...: {error}"); }` instead of `let _ = fallible_operation();`. The error message should identify the operation and include the error.
 - The only exception is IPC `send()` on reply channels (e.g. `reply.send(...)`, `waiter.send(...)`) where a closed receiver is an expected condition (client disconnected) rather than a system error.
-- Avoid bare `.expect()` and `.unwrap()` on `Result` — prefer propagating the error with `?` or logging with `eprintln!` and recovering.
-- Use `.ok()` only when the `None`/`Err` case carries no diagnostic value (e.g. parsing an optional value from a fallible source where `None` is a valid "not present" signal). 
+- Avoid bare `.expect()` and `.unwrap()` on `Result` — prefer propagating the error with `?` or logging with `error!` and recovering.
+- Use `.ok()` only when the `None`/`Err` case carries no diagnostic value (e.g. parsing an optional value from a fallible source where `None` is a valid "not present" signal).
+- The `ConsoleSink::Stderr` variant in `content/src/js/bindings/console.rs` is exempt — it implements the browser Console API output destination, not error logging.
 
 # End-of-Task Flow
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "aligned-vec"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -199,6 +208,7 @@ dependencies = [
  "clap",
  "futures-util",
  "ipc_messages",
+ "log",
  "serde",
  "serde_json",
  "tokio",
@@ -632,10 +642,12 @@ dependencies = [
  "crossbeam-channel",
  "cssparser",
  "data-url",
+ "env_logger",
  "html5ever",
  "ipc-channel",
  "ipc_messages",
  "keyboard-types",
+ "log",
  "serde",
  "serde_json",
  "stylo",
@@ -1084,6 +1096,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_filter"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0621c04f2196ac3f488dd583365b9c09be011a4ab8b9f37248ffcc8f6198b56a"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "jiff",
+ "log",
+]
+
+[[package]]
 name = "equator"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1287,9 +1322,11 @@ dependencies = [
  "automation",
  "clap",
  "content",
+ "env_logger",
  "ipc-channel",
  "ipc_messages",
  "libc",
+ "log",
  "net",
  "serde",
  "serde_json",
@@ -1973,6 +2010,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jiff"
+version = "0.2.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4603d3033e49e2b0e31229fcab20a5d40089c607d975cd9c80551dc69eed9102"
+dependencies = [
+ "jiff-static",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "782d32378dddf207193ac91cefb848ad41abb58195c95168e1291227a0832b47"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2181,8 +2242,10 @@ dependencies = [
 name = "net"
 version = "0.1.0"
 dependencies = [
+ "env_logger",
  "ipc-channel",
  "ipc_messages",
+ "log",
  "mime_guess",
  "reqwest",
  "url",
@@ -2563,6 +2626,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
+]
+
+[[package]]
 name = "postcard"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2887,6 +2959,35 @@ dependencies = [
  "serde",
  "smallvec",
 ]
+
+[[package]]
+name = "regex"
+version = "1.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "regress"
@@ -4078,6 +4179,7 @@ dependencies = [
  "crossbeam-channel",
  "ipc-channel",
  "ipc_messages",
+ "log",
  "psl",
  "serde_json",
  "url",
@@ -4160,8 +4262,10 @@ version = "0.1.0"
 dependencies = [
  "base64",
  "clap",
+ "env_logger",
  "image",
  "ipc-channel",
+ "log",
  "serde",
  "serde_json",
 ]
@@ -4572,6 +4676,7 @@ dependencies = [
  "ipc_messages",
  "keyboard-types",
  "kurbo",
+ "log",
  "peniko",
  "serde",
  "serde_json",
@@ -4986,7 +5091,9 @@ name = "wpt_runner"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "env_logger",
  "libc",
+ "log",
  "serde",
  "serde_json",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,8 @@ ipc_messages = { path = "ipc_messages" }
 libc = "0.2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+log = "0.4"
+env_logger = "0.11"
 url = "2"
 
 

--- a/automation/Cargo.toml
+++ b/automation/Cargo.toml
@@ -14,6 +14,7 @@ tungstenite = "0.24"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "net", "io-util", "time", "sync"] }
 tokio-tungstenite = "0.24"
 futures-util = "0.3"
+log = "0.4"
 uuid = { version = "1", features = ["v4"] }
 
 [lib]

--- a/automation/src/cdp.rs
+++ b/automation/src/cdp.rs
@@ -1,3 +1,4 @@
+use log::error;
 use crate::AutomationRuntime;
 use crate::{AUTOMATION_TIMEOUT, CdpEvent, HttpRequest, SCRIPT_TIMEOUT, find_header_terminator};
 use base64::Engine as _;
@@ -133,7 +134,7 @@ impl CdpServerHandle {
                     Ok(runtime) => {
                         runtime.block_on(run_cdp_server(listener, state, shutdown_receiver))
                     }
-                    Err(error) => eprintln!("formal-web cdp server init error: {error}"),
+                    Err(error) => error!("formal-web cdp server init error: {error}"),
                 }
             })
             .map_err(|error| format!("failed to spawn CDP server thread: {error}"))?;
@@ -152,7 +153,7 @@ impl Drop for CdpServerHandle {
         }
         if let Some(listener_thread) = self.listener_thread.take() {
             if let Err(error) = listener_thread.join() {
-                eprintln!("[cdp] failed to join listener thread: {error:?}");
+                error!("[cdp] failed to join listener thread: {error:?}");
             }
         }
     }
@@ -856,7 +857,7 @@ async fn run_cdp_server(
     let listener = match tokio::net::TcpListener::from_std(listener) {
         Ok(listener) => listener,
         Err(error) => {
-            eprintln!("formal-web cdp listener init error: {error}");
+            error!("formal-web cdp listener init error: {error}");
             return;
         }
     };
@@ -868,7 +869,7 @@ async fn run_cdp_server(
         tokio::select! {
             _ = &mut shutdown => {
                 if let Err(error) = session_shutdown_tx.send(true) {
-                    eprintln!("[cdp] failed to signal session shutdown: {error}");
+                    error!("[cdp] failed to signal session shutdown: {error}");
                 }
                 break;
             }
@@ -879,12 +880,12 @@ async fn run_cdp_server(
                         let task_shutdown = session_shutdown_rx.clone();
                         sessions.spawn(async move {
                             if let Err(error) = handle_cdp_stream(stream, task_state, task_shutdown).await {
-                                eprintln!("formal-web cdp connection error: {error}");
+                                error!("formal-web cdp connection error: {error}");
                             }
                         });
                     }
                     Err(error) => {
-                        eprintln!("formal-web cdp accept error: {error}");
+                        error!("formal-web cdp accept error: {error}");
                         break;
                     }
                 }
@@ -894,7 +895,7 @@ async fn run_cdp_server(
 
     while let Some(joined) = sessions.join_next().await {
         if let Err(error) = joined {
-            eprintln!("formal-web cdp session task error: {error}");
+            error!("formal-web cdp session task error: {error}");
         }
     }
 }
@@ -1182,7 +1183,7 @@ async fn handle_websocket_connection(
         .runtime
         .set_cdp_event_sink(None, Duration::from_millis(250))
     {
-        eprintln!("[cdp] failed to clear CDP event sink: {error}");
+        error!("[cdp] failed to clear CDP event sink: {error}");
     }
     result
 }
@@ -2003,7 +2004,7 @@ mod tests {
         assert_eq!(unknown_response["result"], json!({}));
 
         if let Err(error) = socket.close(None) {
-            eprintln!("[cdp-test] failed to close test socket: {error}");
+            error!("[cdp-test] failed to close test socket: {error}");
         }
     }
 
@@ -2252,7 +2253,7 @@ mod tests {
         assert_eq!(navigate_events[4]["params"]["frame"]["id"], page_target_id);
 
         if let Err(error) = socket.close(None) {
-            eprintln!("[cdp-test] failed to close test socket: {error}");
+            error!("[cdp-test] failed to close test socket: {error}");
         }
     }
 

--- a/automation/src/webdriver.rs
+++ b/automation/src/webdriver.rs
@@ -1,3 +1,4 @@
+use log::error;
 use crate::{
     AUTOMATION_TIMEOUT, AutomationRuntime, AutomationSnapshot, HttpRequest, NEXT_SESSION_ID,
     SCRIPT_TIMEOUT, read_http_request, write_http_response,
@@ -131,7 +132,7 @@ impl Drop for WebDriverServer {
         self.stop.store(true, Ordering::Relaxed);
         if let Some(thread) = self.thread.take() {
             if let Err(error) = thread.join() {
-                eprintln!("[webdriver] failed to join server thread: {error:?}");
+                error!("[webdriver] failed to join server thread: {error:?}");
             }
         }
     }
@@ -142,14 +143,14 @@ fn run_server(listener: TcpListener, state: Arc<WebDriverState>, stop: Arc<Atomi
         match listener.accept() {
             Ok((stream, _address)) => {
                 if let Err(error) = handle_connection(stream, &state) {
-                    eprintln!("formal-web webdriver server error: {error}");
+                    error!("formal-web webdriver server error: {error}");
                 }
             }
             Err(error) if error.kind() == ErrorKind::WouldBlock => {
                 thread::sleep(Duration::from_millis(10));
             }
             Err(error) => {
-                eprintln!("formal-web webdriver accept error: {error}");
+                error!("formal-web webdriver accept error: {error}");
                 break;
             }
         }

--- a/content/Cargo.toml
+++ b/content/Cargo.toml
@@ -33,6 +33,8 @@ style_traits = { version = "0.17.0", package = "stylo_traits" }
 url = "2"
 verification = { path = "../verification" }
 wasmtime = { path = "../vendor/wasmtime/crates/wasmtime", default-features = false, features = ["runtime", "cranelift", "wat", "std"] }
+log = "0.4"
+env_logger = "0.11"
 crossbeam-channel = "0.5"
 xml5ever = "0.39.0"
 

--- a/content/src/bin/content_process.rs
+++ b/content/src/bin/content_process.rs
@@ -1,8 +1,11 @@
+use log::error;
 use std::process;
 
 fn main() {
+    env_logger::init();
+
     if let Err(error) = content::run_content_process_from_args() {
-        eprintln!("formal-web-content: {error}");
+        error!("formal-web-content: {error}");
         process::exit(1);
     }
 }

--- a/content/src/dom/dispatch.rs
+++ b/content/src/dom/dispatch.rs
@@ -1,3 +1,4 @@
+use log::trace;
 use std::{cell::RefCell, rc::Rc};
 
 use blitz_dom::BaseDocument;
@@ -501,7 +502,7 @@ fn invoke(
             ListenerPhase::Capturing => "capturing",
             ListenerPhase::Bubbling => "bubbling",
         };
-        eprintln!(
+        trace!(
             "[input-debug][dispatch] phase={} current_target={} listeners={} matching_click_listeners={}",
             phase_name,
             debug_target_label(&entry.invocation_target),

--- a/content/src/dom/ui_event_dispatch.rs
+++ b/content/src/dom/ui_event_dispatch.rs
@@ -1,3 +1,4 @@
+use log::{error, trace};
 use std::{cell::RefCell, rc::Rc};
 
 use blitz_dom::{BaseDocument, Document as BlitzDocument, EventDriver, EventHandler};
@@ -90,7 +91,7 @@ fn localize_ui_event_for_document(
     match event {
         UiEvent::PointerMove(event) | UiEvent::PointerUp(event) | UiEvent::PointerDown(event) => {
             if input_debug_enabled() {
-                eprintln!(
+                trace!(
                     "[input-debug][content] localize pointer before client=({:.1},{:.1}) page=({:.1},{:.1}) offset=({:.1},{:.1}) scroll=({:.1},{:.1})",
                     event.coords.client_x,
                     event.coords.client_y,
@@ -107,7 +108,7 @@ fn localize_ui_event_for_document(
             event.coords.page_x = event.coords.client_x + scroll_x;
             event.coords.page_y = event.coords.client_y + scroll_y;
             if input_debug_enabled() {
-                eprintln!(
+                trace!(
                     "[input-debug][content] localize pointer after client=({:.1},{:.1}) page=({:.1},{:.1})",
                     event.coords.client_x,
                     event.coords.client_y,
@@ -118,7 +119,7 @@ fn localize_ui_event_for_document(
         }
         UiEvent::Wheel(event) => {
             if input_debug_enabled() {
-                eprintln!(
+                trace!(
                     "[input-debug][content] localize wheel before client=({:.1},{:.1}) page=({:.1},{:.1}) offset=({:.1},{:.1}) scroll=({:.1},{:.1})",
                     event.coords.client_x,
                     event.coords.client_y,
@@ -135,7 +136,7 @@ fn localize_ui_event_for_document(
             event.coords.page_x = event.coords.client_x + scroll_x;
             event.coords.page_y = event.coords.client_y + scroll_y;
             if input_debug_enabled() {
-                eprintln!(
+                trace!(
                     "[input-debug][content] localize wheel after client=({:.1},{:.1}) page=({:.1},{:.1})",
                     event.coords.client_x,
                     event.coords.client_y,
@@ -167,7 +168,7 @@ pub(crate) fn dispatch_ui_event(
 ) -> Result<(), String> {
     let is_wheel = matches!(event, UiEvent::Wheel(_));
     if input_debug_enabled() {
-        eprintln!(
+        trace!(
             "[input-debug][content] document={} traversable={} event={}",
             document_id,
             source_navigable_id,
@@ -194,7 +195,7 @@ pub(crate) fn dispatch_ui_event(
     driver.handle_ui_event(event);
     if is_wheel && input_debug_enabled() {
         let document = document.borrow();
-        eprintln!(
+        trace!(
             "[input-debug][scroll] document={} traversable={} {}",
             document_id,
             source_navigable_id,
@@ -382,7 +383,7 @@ impl EventHandler for BlitzJSEventHandler<'_> {
                         .unwrap_or_else(|| format!("node#{node_id}"))
                 })
                 .collect::<Vec<_>>();
-            eprintln!(
+            trace!(
                 "[input-debug][content-dom] document={} traversable={} type={} target_node={} target_label={:?} chain={:?} chain_labels={:?}",
                 self.document_id,
                 self.source_navigable_id,
@@ -400,7 +401,7 @@ impl EventHandler for BlitzJSEventHandler<'_> {
         let event_object = create_interface_instance::<JsUiEvent>(ui_event, &mut self.settings.context)
             .expect("UIEvent construction must succeed");
         if let Err(error) = dispatch_with_chain(self, chain, &event_object) {
-            eprintln!("failed to dispatch UI event through JavaScript listeners: {error}");
+            error!("failed to dispatch UI event through JavaScript listeners: {error}");
             return;
         }
 
@@ -409,7 +410,7 @@ impl EventHandler for BlitzJSEventHandler<'_> {
         }
 
         if let Err(error) = self.settings.perform_a_microtask_checkpoint() {
-            eprintln!("failed to run a microtask checkpoint after UI event dispatch: {error}");
+            error!("failed to run a microtask checkpoint after UI event dispatch: {error}");
         }
     }
 }

--- a/content/src/html.rs
+++ b/content/src/html.rs
@@ -1,3 +1,4 @@
+use log::error;
 mod environment_settings_object;
 mod global_scope;
 mod html_anchor_element;
@@ -255,7 +256,7 @@ pub(crate) fn the_rules_for_choosing_a_navigable(
             ) {
                 Ok(result) => result,
                 Err(error) => {
-                    eprintln!(
+                    error!(
                         "the_rules_for_choosing_a_navigable: failed to create document: {error}"
                     );
                     return ChosenNavigableResult {
@@ -270,7 +271,7 @@ pub(crate) fn the_rules_for_choosing_a_navigable(
                 settings,
                 document,
             ) {
-                eprintln!(
+                error!(
                     "the_rules_for_choosing_a_navigable: failed to register document: {error}"
                 );
             }

--- a/content/src/html/environment_settings_object.rs
+++ b/content/src/html/environment_settings_object.rs
@@ -1,3 +1,4 @@
+use log::{debug, error};
 use std::{cell::RefCell, rc::Rc, time::Instant};
 
 use blitz_dom::BaseDocument;
@@ -22,7 +23,7 @@ fn timer_debug_enabled() -> bool {
 
 fn log_timer_debug(message: impl AsRef<str>) {
     if timer_debug_enabled() {
-        eprintln!("[timer-debug][settings] {}", message.as_ref());
+        debug!("[timer-debug][settings] {}", message.as_ref());
     }
 }
 
@@ -102,7 +103,7 @@ impl EnvironmentSettingsObject {
 
         store_document_object(&context, document_object).map_err(|error| error.to_string())?;
         install_document_property(&mut context).map_err(|error| error.to_string())?;
-        install_console_namespace(&mut context).map_err(|error| error.to_string())?;
+        install_console_namespace(&mut context).map_err(|error: boa_engine::JsError| error.to_string())?;
         install_css_namespace(&mut context).map_err(|error| error.to_string())?;
 
         let global = context.global_object();
@@ -221,7 +222,7 @@ impl EnvironmentSettingsObject {
                 global_scope.set_current_timer_nesting_level(previous_nesting_level);
                 Ok(())
             }) {
-                eprintln!("[timers] failed to reset timer nesting level: {error}");
+                error!("[timers] failed to reset timer nesting level: {error}");
             }
             return Ok(());
         };
@@ -243,7 +244,7 @@ impl EnvironmentSettingsObject {
                     Some(&global),
                 );
                 if let Err(error) = callback_result {
-                    eprintln!("content error: {error}");
+                    error!("content error: {error}");
                 }
             }
             TimerHandler::String { source } => {
@@ -258,30 +259,30 @@ impl EnvironmentSettingsObject {
                     .eval(Source::from_bytes(source.as_str()))
                     .map(|_| ())
                 {
-                    eprintln!("content error: {error}");
+                    error!("content error: {error}");
                 }
             }
         }
 
         if let Err(error) = with_global_scope(&self.context, |global_scope| {
             if let Err(error) = global_scope.complete_window_timer(timer_id, timer_key) {
-                eprintln!(
+                error!(
                     "failed to complete window timer (id={timer_id} key={timer_key}): {error}"
                 );
             }
             Ok(())
         }) {
-            eprintln!("failed to access global scope for timer completion: {error}");
+            error!("failed to access global scope for timer completion: {error}");
         }
         if let Err(error) = with_global_scope(&self.context, |global_scope| {
             global_scope.set_current_timer_nesting_level(previous_nesting_level);
             Ok(())
         }) {
-            eprintln!("failed to access global scope for timer nesting level: {error}");
+            error!("failed to access global scope for timer nesting level: {error}");
         }
 
         if let Err(error) = self.perform_a_microtask_checkpoint() {
-            eprintln!("content error: {error}");
+            error!("content error: {error}");
         }
         Ok(())
     }

--- a/content/src/html/global_scope.rs
+++ b/content/src/html/global_scope.rs
@@ -8,6 +8,7 @@ use std::{
 use super::environment_settings_object::EnvironmentSettingsObject;
 
 use blitz_dom::BaseDocument;
+use log::{debug, error};
 use boa_engine::{JsValue, object::JsObject};
 use boa_gc::{Finalize, GcRefCell, Trace};
 use ipc_channel::ipc::IpcSender;
@@ -28,7 +29,7 @@ fn timer_debug_enabled() -> bool {
 
 fn log_timer_debug(message: impl AsRef<str>) {
     if timer_debug_enabled() {
-        eprintln!("[timer-debug][global] {}", message.as_ref());
+        debug!("[timer-debug][global] {}", message.as_ref());
     }
 }
 
@@ -527,7 +528,7 @@ impl GlobalScope {
                     timer_key: removed_timer.timer_key,
                 }))
         {
-            eprintln!("failed to send window timer clear to the embedder: {error}");
+            error!("failed to send window timer clear to the embedder: {error}");
         }
     }
 
@@ -624,7 +625,7 @@ impl GlobalScope {
                         timer_key: timer.timer_key,
                     }))
             {
-                eprintln!("failed to clear window timer during teardown: {error}");
+                error!("failed to clear window timer during teardown: {error}");
                 break;
             }
         }

--- a/content/src/html/html_parser.rs
+++ b/content/src/html/html_parser.rs
@@ -1,3 +1,4 @@
+use log::{error, warn};
 use std::{
     borrow::Cow,
     cell::{Cell, Ref, RefCell, RefMut},
@@ -293,11 +294,11 @@ pub fn execute_parser_scripts(
     for script in scripts {
         match script {
             PendingParserScript::External { src } => {
-                eprintln!("external script fetch is not implemented yet: {src}");
+                warn!("external script fetch is not implemented yet: {src}");
             }
             PendingParserScript::Inline { source } => {
                 if let Err(error) = settings.evaluate_script(&source) {
-                    eprintln!("content error: {error}");
+                    error!("content error: {error}");
                 }
             }
         }

--- a/content/src/html/location.rs
+++ b/content/src/html/location.rs
@@ -1,3 +1,4 @@
+use log::error;
 use boa_engine::{JsData, object::JsObject};
 use boa_gc::{Finalize, Trace};
 use ipc_messages::content::UserNavigationInvolvement;
@@ -333,7 +334,7 @@ impl Location {
         // Step 5: "If the given value is the empty string, then set copyURL's port to null."
         if value.is_empty() {
             if let Err(()) = copy_url.set_port(None) {
-                eprintln!("[location] failed to clear port on URL");
+                error!("[location] failed to clear port on URL");
             }
         } else {
             // Step 6: "Otherwise, basic URL parse the given value ... with port state as state
@@ -652,12 +653,12 @@ impl Location {
         }
 
         if let Err(error) = copy_url.set_host(Some(host_port.host)) {
-            eprintln!("[location] failed to set host on URL: {error}");
+            error!("[location] failed to set host on URL: {error}");
         }
         match host_port.port {
             Some(port) => {
                 if let Err(()) = copy_url.set_port(Some(port)) {
-                    eprintln!("[location] failed to set port on URL");
+                    error!("[location] failed to set port on URL");
                 }
             }
             None => {}
@@ -669,7 +670,7 @@ impl Location {
             return;
         }
         if let Err(error) = copy_url.set_host(Some(value)) {
-            eprintln!("[location] failed to set hostname on URL: {error}");
+            error!("[location] failed to set hostname on URL: {error}");
         }
     }
 
@@ -678,7 +679,7 @@ impl Location {
             return;
         };
         if let Err(()) = copy_url.set_port(Some(port)) {
-            eprintln!("[location] failed to set port on URL");
+            error!("[location] failed to set port on URL");
         }
     }
 

--- a/content/src/html/window.rs
+++ b/content/src/html/window.rs
@@ -1,3 +1,4 @@
+use log::error;
 use std::collections::{BTreeMap, HashMap};
 use std::mem;
 
@@ -253,7 +254,7 @@ pub(crate) fn window_open_steps(
         result.new_traversable_info,
         None,
     ) {
-        eprintln!("window.open: {error}");
+        error!("window.open: {error}");
     }
 
     // Step 17: "If noopener is true or windowType is 'new with no opener',

--- a/content/src/js/bindings/html/host_hooks.rs
+++ b/content/src/js/bindings/html/host_hooks.rs
@@ -1,3 +1,4 @@
+use log::error;
 use std::{cell::RefCell, rc::Rc};
 
 use blitz_dom::BaseDocument;
@@ -70,7 +71,7 @@ pub(crate) fn build_boa_context(document: Rc<RefCell<BaseDocument>>) -> Result<C
 
     // ── Install WebAssembly namespace ──
     if let Err(error) = crate::js::bindings::install_wasm_namespace(&mut context) {
-        eprintln!("[content] failed to install WebAssembly namespace: {error}");
+        error!("[content] failed to install WebAssembly namespace: {error}");
     }
 
     macro_rules! reg {

--- a/content/src/main.rs
+++ b/content/src/main.rs
@@ -27,6 +27,7 @@ use blitz_dom::{BaseDocument, DocumentConfig};
 use blitz_paint::paint_scene;
 use blitz_traits::net::{Body, Bytes, NetHandler, NetProvider, Request};
 use blitz_traits::shell::{ClipboardError, ColorScheme, ShellProvider, Viewport};
+use log::{debug, error, trace, warn};
 use data_url::DataUrl;
 use ipc_channel::ipc::{self, IpcSender};
 use ipc_channel::router::RouterProxy;
@@ -212,7 +213,7 @@ fn input_debug_enabled() -> bool {
 
 fn log_render_state_debug(message: impl AsRef<str>) {
     if render_state_debug_enabled() {
-        eprintln!("[render-state][content] {}", message.as_ref());
+        debug!("[render-state][content] {}", message.as_ref());
     }
 }
 
@@ -243,14 +244,14 @@ fn maybe_log_input_layout_debug(document_id: DocumentId, document: &BaseDocument
     });
 
     if interesting_nodes.is_empty() {
-        eprintln!(
+        trace!(
             "[input-debug][layout] document={} interesting_nodes=none",
             document_id,
         );
         return;
     }
 
-    eprintln!(
+    trace!(
         "[input-debug][layout] document={} interesting_nodes={interesting_nodes:?}",
         document_id,
     );
@@ -308,7 +309,7 @@ impl NetProvider for ContentNetProvider {
                         body: request_body_string(&request.body),
                     },
                 )) {
-                    eprintln!("failed to send document fetch request to the embedder: {error}");
+                    error!("failed to send document fetch request to the embedder: {error}");
                 }
             }
         }
@@ -783,7 +784,7 @@ impl ContentProcess {
                 DeferredScriptState::Inline { source }
                 | DeferredScriptState::ExternalReady { source } => {
                     if let Err(error) = content_document.settings.evaluate_script(&source) {
-                        eprintln!("content error: {error}");
+                        error!("content error: {error}");
                     }
                 }
                 DeferredScriptState::ExternalPending { .. }
@@ -1000,7 +1001,7 @@ impl ContentProcess {
 
         for (script_index, src) in deferred_fetches {
             if let Err(error) = self.start_deferred_script_fetch(document_id, script_index, &src) {
-                eprintln!("content error: {error}");
+                error!("content error: {error}");
                 self.mark_deferred_script_failed(document_id, script_index);
             }
         }
@@ -1015,7 +1016,7 @@ impl ContentProcess {
     ) -> Result<serde_json::Value, String> {
         // Set up shared registry so window.open can register new documents.
         if let Err(error) = self.set_up_new_document_registry(traversable_id) {
-            eprintln!("failed to set up new document registry: {error}");
+            warn!("failed to set up new document registry: {error}");
         }
 
         let document_id = *self
@@ -1030,10 +1031,10 @@ impl ContentProcess {
 
         // Tear down and drain any documents created during JS execution.
         if let Err(error) = self.tear_down_new_document_registry(traversable_id) {
-            eprintln!("failed to tear down new document registry: {error}");
+            warn!("failed to tear down new document registry: {error}");
         }
         if let Err(error) = self.drain_new_traversable_documents() {
-            eprintln!("failed to drain new traversable documents: {error}");
+            warn!("failed to drain new traversable documents: {error}");
         }
 
         result
@@ -1046,7 +1047,7 @@ impl ContentProcess {
     ) -> Result<(), String> {
         // Set up shared registry so window.open can register new documents.
         if let Err(error) = self.set_up_new_document_registry(traversable_id) {
-            eprintln!("failed to set up new document registry: {error}");
+            warn!("failed to set up new document registry: {error}");
         }
 
         let document_id = *self
@@ -1089,7 +1090,7 @@ impl ContentProcess {
                     .remove(&content_document.traversable_id);
             }
             if let Err(error) = content_document.settings.clear_all_window_timers() {
-                eprintln!("failed to clear window timers during document teardown: {error}");
+                error!("failed to clear window timers during document teardown: {error}");
             }
         }
         // Clean up any pending wasm requests for this document so that
@@ -1413,7 +1414,7 @@ impl ContentProcess {
                     Bytes::copy_from_slice(&response.body),
                 );
                 let Some(content_document) = self.documents.get(&document_id) else {
-                    eprintln!(
+                    error!(
                         "[content] complete_document_fetch: document {document_id} not found"
                     );
                     return Ok(());
@@ -1439,14 +1440,14 @@ impl ContentProcess {
                 if deferred_script_response_is_executable(&response) {
                     self.complete_deferred_script_fetch(document_id, script_index, response.body);
                 } else {
-                    eprintln!(
+                    warn!(
                         "content deferred script rejected: url={} status={} content-type={}",
                         response.final_url, response.status, response.content_type,
                     );
                     self.mark_deferred_script_failed(document_id, script_index);
                 }
                 let Some(content_document) = self.documents.get(&document_id) else {
-                    eprintln!(
+                    error!(
                         "[content] complete_document_fetch (deferred script): document {document_id} not found"
                     );
                     return Ok(());
@@ -1494,7 +1495,7 @@ impl ContentProcess {
             } => {
                 handler.bytes(request_url, Bytes::new());
                 let Some(content_document) = self.documents.get(&document_id) else {
-                    eprintln!("[content] fail_document_fetch: document {document_id} not found");
+                    error!("[content] fail_document_fetch: document {document_id} not found");
                     return Ok(());
                 };
                 let traversable_id = content_document.traversable_id;
@@ -1512,7 +1513,7 @@ impl ContentProcess {
             } => {
                 self.mark_deferred_script_failed(document_id, script_index);
                 let Some(content_document) = self.documents.get(&document_id) else {
-                    eprintln!(
+                    error!(
                         "[content] fail_document_fetch (deferred script): document {document_id} not found"
                     );
                     return Ok(());
@@ -1547,7 +1548,7 @@ impl ContentProcess {
             document.traversable_id
         };
         if let Err(error) = self.set_up_new_document_registry(traversable_id) {
-            eprintln!("failed to set up new document registry: {error}");
+            warn!("failed to set up new document registry: {error}");
         }
         {
             let Some(document) = self.documents.get_mut(&document_id) else {
@@ -1558,10 +1559,10 @@ impl ContentProcess {
                 .run_window_timer(timer_id, timer_key, nesting_level)?;
         }
         if let Err(error) = self.tear_down_new_document_registry(traversable_id) {
-            eprintln!("failed to tear down new document registry: {error}");
+            warn!("failed to tear down new document registry: {error}");
         }
         if let Err(error) = self.drain_new_traversable_documents() {
-            eprintln!("failed to drain new traversable documents: {error}");
+            warn!("failed to drain new traversable documents: {error}");
         }
         Ok(())
     }
@@ -1662,7 +1663,7 @@ impl ContentProcess {
             };
 
             let Some(content_document) = self.documents.get_mut(&document_id) else {
-                eprintln!("WebAssembly: document {} not found", document_id);
+                error!("WebAssembly: document {} not found", document_id);
                 self.pending_wasm_requests.remove(&request_id);
                 continue;
             };
@@ -1670,7 +1671,7 @@ impl ContentProcess {
             let Some((_promise, resolvers)) =
                 content_document.settings.consume_wasm_request(request_id)
             else {
-                eprintln!(
+                error!(
                     "WebAssembly: request {} not found on document {}",
                     request_id, document_id
                 );
@@ -1689,7 +1690,7 @@ impl ContentProcess {
                         Vec::new(),
                         &mut content_document.settings.context,
                     ) {
-                        eprintln!("WebAssembly: failed to resolve compile promise: {error}");
+                        error!("WebAssembly: failed to resolve compile promise: {error}");
                     }
                 }
                 WasmResult::CompileError {
@@ -1701,7 +1702,7 @@ impl ContentProcess {
                         message,
                         &mut content_document.settings.context,
                     ) {
-                        eprintln!("WebAssembly: failed to reject compile promise: {error}");
+                        error!("WebAssembly: failed to reject compile promise: {error}");
                     }
                 }
                 WasmResult::Instantiated {
@@ -1711,7 +1712,7 @@ impl ContentProcess {
                 } => {
                     let module = self.pending_wasm_modules.remove(&request_id);
                     let Some(module) = module else {
-                        eprintln!("WebAssembly: no module found for instantiate request {}", request_id);
+                        error!("WebAssembly: no module found for instantiate request {}", request_id);
                         self.pending_wasm_requests.remove(&request_id);
                         continue;
                     };
@@ -1722,7 +1723,7 @@ impl ContentProcess {
                         &resolvers,
                         &mut content_document.settings.context,
                     ) {
-                        eprintln!("WebAssembly: failed to resolve instantiate promise: {error}");
+                        error!("WebAssembly: failed to resolve instantiate promise: {error}");
                     }
                 }
                 WasmResult::InstantiateError {
@@ -1734,7 +1735,7 @@ impl ContentProcess {
                         message,
                         &mut content_document.settings.context,
                     ) {
-                        eprintln!("WebAssembly: failed to reject instantiate promise: {error}");
+                        error!("WebAssembly: failed to reject instantiate promise: {error}");
                     }
                 }
             }
@@ -1745,7 +1746,7 @@ impl ContentProcess {
         // Flush microtasks (promise .then() handlers) after resolving/rejecting.
         for document in self.documents.values_mut() {
             if let Err(error) = document.settings.perform_a_microtask_checkpoint() {
-                eprintln!("WebAssembly: microtask checkpoint failed: {error}");
+                error!("WebAssembly: microtask checkpoint failed: {error}");
             }
         }
     }
@@ -1972,7 +1973,7 @@ pub fn run_content_process(token: String) -> Result<(), String> {
                             }
                             Ok(false) => break,
                             Err(error) => {
-                                eprintln!("content error: {error}");
+                                error!("content error: {error}");
                                 if notify {
                                     let _ = process.note_command_completed();
                                 }

--- a/content/src/streams/readablestream.rs
+++ b/content/src/streams/readablestream.rs
@@ -1,3 +1,4 @@
+use log::error;
 use std::{
     cell::{Cell, RefCell},
     collections::VecDeque,
@@ -517,14 +518,14 @@ fn readable_stream_default_tee(
             // Step 19.1: "Perform ! ReadableStreamDefaultControllerError(branch1.[[controller]], r)."
             if let Some(branch1) = branch1.as_ref() {
                 if let Err(error) = default_tee_error_branch(branch1, error.clone(), context) {
-                    eprintln!("[readable-stream] default tee error branch1 failed: {error}");
+                    error!("[readable-stream] default tee error branch1 failed: {error}");
                 }
             }
 
             // Step 19.2: "Perform ! ReadableStreamDefaultControllerError(branch2.[[controller]], r)."
             if let Some(branch2) = branch2.as_ref() {
                 if let Err(error) = default_tee_error_branch(branch2, error, context) {
-                    eprintln!("[readable-stream] default tee error branch2 failed: {error}");
+                    error!("[readable-stream] default tee error branch2 failed: {error}");
                 }
             }
 
@@ -535,7 +536,7 @@ fn readable_stream_default_tee(
                     &[JsValue::undefined()],
                     context,
                 ) {
-                    eprintln!("[readable-stream] failed to resolve cancel promise: {error}");
+                    error!("[readable-stream] failed to resolve cancel promise: {error}");
                 }
             }
 
@@ -690,7 +691,7 @@ pub(crate) fn readable_stream_default_tee_read_request_chunk_steps(
                             if let Err(error) =
                                 default_tee_error_branch(branch1, error.clone(), context)
                             {
-                                eprintln!(
+                                error!(
                                     "[readable-stream] default tee error branch1 (chunk) failed: {error}"
                                 );
                             }
@@ -701,7 +702,7 @@ pub(crate) fn readable_stream_default_tee_read_request_chunk_steps(
                             if let Err(error) =
                                 default_tee_error_branch(branch2, error.clone(), context)
                             {
-                                eprintln!(
+                                error!(
                                     "[readable-stream] default tee error branch2 (chunk) failed: {error}"
                                 );
                             }
@@ -1816,12 +1817,12 @@ fn byte_tee_forward_reader_error(
             };
             if let Some(ref branch1) = branch1 {
                 if let Err(error) = byte_tee_error_branch(branch1, error.clone(), context) {
-                    eprintln!("[readable-stream] byte tee error branch1 failed: {error}");
+                    error!("[readable-stream] byte tee error branch1 failed: {error}");
                 }
             }
             if let Some(ref branch2) = branch2 {
                 if let Err(error) = byte_tee_error_branch(branch2, error, context) {
-                    eprintln!("[readable-stream] byte tee error branch2 failed: {error}");
+                    error!("[readable-stream] byte tee error branch2 failed: {error}");
                 }
             }
             if !canceled1 || !canceled2 {
@@ -1939,7 +1940,7 @@ pub(crate) fn readable_byte_stream_tee_default_reader_chunk_steps(
                             if let Err(error) =
                                 byte_tee_error_branch(branch1, error.clone(), context)
                             {
-                                eprintln!(
+                                error!(
                                     "[readable-stream] byte tee error branch1 (chunk) failed: {error}"
                                 );
                             }
@@ -1950,7 +1951,7 @@ pub(crate) fn readable_byte_stream_tee_default_reader_chunk_steps(
                             if let Err(error) =
                                 byte_tee_error_branch(branch2, error.clone(), context)
                             {
-                                eprintln!(
+                                error!(
                                     "[readable-stream] byte tee error branch2 (chunk) failed: {error}"
                                 );
                             }
@@ -2234,14 +2235,14 @@ fn readable_byte_stream_tee_pull_with_byob_reader(
                                     // Step 19.4 chunk steps 1.5.2.1: "Perform ! ReadableByteStreamControllerError(byobBranch.[[controller]], cloneResult.[[Value]])."
                                     if let Some(branch) = byob_branch.as_ref() {
                                         if let Err(error) = byte_tee_error_branch(branch, error.clone(), context) {
-                                            eprintln!("[readable-stream] byte tee error byob-branch (chunk) failed: {error}");
+                                            error!("[readable-stream] byte tee error byob-branch (chunk) failed: {error}");
                                         }
                                     }
 
                                     // Step 19.4 chunk steps 1.5.2.2: "Perform ! ReadableByteStreamControllerError(otherBranch.[[controller]], cloneResult.[[Value]])."
                                     if let Some(branch) = other_branch.as_ref() {
                                         if let Err(error) = byte_tee_error_branch(branch, error.clone(), context) {
-                                            eprintln!("[readable-stream] byte tee error other-branch (chunk) failed: {error}");
+                                            error!("[readable-stream] byte tee error other-branch (chunk) failed: {error}");
                                         }
                                     }
 
@@ -2698,7 +2699,7 @@ fn promise_rejected_with_reason(reason: JsValue, context: &mut Context) -> JsObj
                 .reject
                 .call(&JsValue::undefined(), &[JsValue::undefined()], context)
         {
-            eprintln!("[readable-stream] failed to reject fallback promise: {error}");
+            error!("[readable-stream] failed to reject fallback promise: {error}");
         }
         promise_object
     })
@@ -2726,7 +2727,7 @@ fn reject_promise_with_error(
         .reject
         .call(&JsValue::undefined(), &[reason], context)
     {
-        eprintln!("[readable-stream] failed to reject promise with error: {error}");
+        error!("[readable-stream] failed to reject promise with error: {error}");
     }
 }
 
@@ -2782,7 +2783,7 @@ fn readable_stream_pipe_to(
         Ok(writer_object) => writer_object,
         Err(error) => {
             if let Err(error) = readable_stream_default_reader_release(reader.clone(), context) {
-                eprintln!(
+                error!(
                     "[readable-stream] failed to release reader on pipe setup error: {error}"
                 );
             }
@@ -2796,7 +2797,7 @@ fn readable_stream_pipe_to(
         Ok(writer) => writer,
         Err(error) => {
             if let Err(error) = readable_stream_default_reader_release(reader.clone(), context) {
-                eprintln!("[readable-stream] failed to release reader on writer error: {error}");
+                error!("[readable-stream] failed to release reader on writer error: {error}");
             }
             reject_promise_with_error(&pipe_resolvers, error, context);
             return pipe_promise_obj;
@@ -2959,7 +2960,7 @@ impl PipeToState {
     fn reject_and_finalize_with_reason(&self, reason: JsValue, context: &mut Context) {
         self.set_shutdown_error(Some(reason));
         if let Err(error) = self.finalize(context) {
-            eprintln!("[readable-stream] failed to finalize on rejection: {error}");
+            error!("[readable-stream] failed to finalize on rejection: {error}");
         }
     }
 

--- a/content/src/streams/readablestreamsupport.rs
+++ b/content/src/streams/readablestreamsupport.rs
@@ -1,3 +1,4 @@
+use log::error;
 use boa_engine::{
     Context, JsNativeError, JsResult, JsValue,
     builtins::promise::ResolvingFunctions,
@@ -220,7 +221,7 @@ where
                         .unwrap_or_else(|_| JsValue::undefined());
                     if let Ok(rejected) = rejected_promise(reason, context) {
                         if let Err(error) = mark_promise_as_handled(&rejected, context) {
-                            eprintln!(
+                            error!(
                                 "[readable-stream] failed to mark promise as handled: {error}"
                             );
                         }

--- a/content/src/streams/transformstream.rs
+++ b/content/src/streams/transformstream.rs
@@ -1,3 +1,4 @@
+use log::debug;
 use std::{cell::Cell, rc::Rc};
 
 use boa_engine::{
@@ -32,7 +33,7 @@ fn stream_debug_enabled() -> bool {
 
 fn log_stream_debug(message: impl AsRef<str>) {
     if stream_debug_enabled() {
-        eprintln!("[stream-debug][transform] {}", message.as_ref());
+        debug!("[stream-debug][transform] {}", message.as_ref());
     }
 }
 

--- a/content/src/wasm/worker.rs
+++ b/content/src/wasm/worker.rs
@@ -1,3 +1,4 @@
+use log::error;
 use std::collections::VecDeque;
 use std::sync::{Arc, Mutex};
 use std::thread::{self, JoinHandle};
@@ -115,7 +116,7 @@ impl WasmWorker {
         self.ensure_worker_started();
         if let Some(sender) = &self.request_sender {
             if let Err(error) = sender.send(WasmRequest::Compile { request_id, bytes }) {
-                eprintln!("WebAssembly: failed to send compile request: {error}");
+                error!("WebAssembly: failed to send compile request: {error}");
             }
         }
     }
@@ -125,7 +126,7 @@ impl WasmWorker {
         self.ensure_worker_started();
         if let Some(sender) = &self.request_sender {
             if let Err(error) = sender.send(WasmRequest::Instantiate { request_id, module }) {
-                eprintln!("WebAssembly: failed to send instantiate request: {error}");
+                error!("WebAssembly: failed to send instantiate request: {error}");
             }
         }
     }
@@ -276,7 +277,7 @@ impl Drop for WasmWorker {
         }
         if let Some(handle) = self.handle.take() {
             if let Err(error) = handle.join() {
-                eprintln!("WebAssembly: failed to join worker: {error:?}");
+                error!("WebAssembly: failed to join worker: {error:?}");
             }
         }
     }

--- a/content/src/webidl/callback.rs
+++ b/content/src/webidl/callback.rs
@@ -1,3 +1,4 @@
+use log::error;
 use boa_engine::{
     Context, JsError, JsNativeError, JsResult, JsString, JsValue,
     object::{JsObject, builtins::JsFunction},
@@ -100,7 +101,7 @@ impl EcmascriptHost for ContextCallbackHost<'_> {
     }
 
     fn report_exception(&mut self, error: JsError, _callback: &Callback) {
-        eprintln!("uncaught {} error: {error}", self.exception_context);
+        error!("uncaught {} error: {error}", self.exception_context);
     }
 }
 

--- a/content/src/webidl/promise.rs
+++ b/content/src/webidl/promise.rs
@@ -1,3 +1,4 @@
+use log::error;
 use boa_engine::{
     Context, JsError, JsNativeError, JsResult, JsValue,
     builtins::promise::ResolvingFunctions,
@@ -81,7 +82,7 @@ pub(crate) fn rejected_promise_from_error(error: JsError, context: &mut Context)
                 .reject
                 .call(&JsValue::undefined(), &[JsValue::undefined()], context)
         {
-            eprintln!(
+            error!(
                 "[webidl] failed to reject fallback promise in rejected_promise_from_error: {error}"
             );
         }

--- a/embedder/Cargo.toml
+++ b/embedder/Cargo.toml
@@ -32,4 +32,6 @@ serde_json = "1"
 verification = { path = "../verification" }
 winit = "0.30"
 uuid = { version = "1", features = ["v4"] }
+log = "0.4"
+env_logger = "0.11"
 webview = { path = "../webview" }

--- a/embedder/src/event_loop.rs
+++ b/embedder/src/event_loop.rs
@@ -18,6 +18,7 @@ use blitz_traits::shell::ColorScheme;
 use ipc_messages::content::WebviewId;
 use kurbo::{Affine, Rect};
 use peniko::{Color, Fill};
+use log::error;
 use std::sync::{Arc, LazyLock, Mutex, mpsc};
 use std::time::Duration;
 use verification::TraceSender;
@@ -99,7 +100,7 @@ impl Embedder for EventLoopEmbedder {
             .dispatcher
             .send(FormalWebUserEvent::RequestRedraw(webview_id))
         {
-            eprintln!("failed to request redraw for webview {webview_id:?}: {error}");
+            error!("failed to request redraw for webview {webview_id:?}: {error}");
         }
     }
 

--- a/embedder/src/headless.rs
+++ b/embedder/src/headless.rs
@@ -19,6 +19,7 @@ use blitz_traits::shell::ColorScheme;
 use ipc_messages::content::WebviewId;
 use keyboard_types::Modifiers as KeyboardModifiers;
 use serde_json::Value;
+use log::error;
 use std::time::Duration;
 use webview::WebviewProvider;
 
@@ -307,7 +308,7 @@ impl ApplicationHandler<FormalWebUserEvent> for HeadlessEmbedderApp {
             FormalWebUserEvent::WebviewProviderSync => {
                 if let Some(p) = self.provider.as_mut()
                     && let Err(e) = p.sync_pending_messages() {
-                    eprintln!("provider sync error: {e}");
+                    error!("provider sync error: {e}");
                 }
             }
             FormalWebUserEvent::NewFrameRendered => {

--- a/embedder/src/main.rs
+++ b/embedder/src/main.rs
@@ -1,6 +1,7 @@
 mod event_loop;
 
 use clap::{Parser, Subcommand};
+use log::error;
 use std::ffi::OsString;
 use std::process::ExitCode;
 use verification::{TraceSender, VerificationRun, run_validation_from_iter};
@@ -126,13 +127,14 @@ fn delegated_tla_validate_command() -> Option<ExitCode> {
     Some(match run_validation_from_iter(forwarded_args) {
         Ok(exit_code) => exit_code,
         Err(error) => {
-            eprintln!("formal-web-embedder: {error}");
+            error!("formal-web-embedder: {error}");
             ExitCode::from(1)
         }
     })
 }
 
 fn main() -> ExitCode {
+    env_logger::init();
     if let Some(exit_code) = delegated_tla_validate_command() {
         return exit_code;
     }
@@ -143,7 +145,7 @@ fn main() -> ExitCode {
         match VerificationRun::start() {
             Ok(run) => Some(run),
             Err(error) => {
-                eprintln!("formal-web-embedder: {error}");
+                error!("formal-web-embedder: {error}");
                 return ExitCode::from(1);
             }
         }
@@ -169,7 +171,7 @@ fn main() -> ExitCode {
     let result = combine_results(result, verification_result);
 
     if let Err(error) = result {
-        eprintln!("formal-web-embedder: {error}");
+        error!("formal-web-embedder: {error}");
         return ExitCode::from(1);
     }
 

--- a/embedder/src/windowed.rs
+++ b/embedder/src/windowed.rs
@@ -1,3 +1,4 @@
+use log::error;
 mod chrome;
 
 use self::chrome::{ChromeAction, ChromeTabInfo, ChromeUi, ChromeViewState, WinitShellProvider};
@@ -464,7 +465,7 @@ impl WindowedApp {
         };
         self.with_provider(|provider| {
             if let Err(error) = provider.send_ui_event(webview_id, event) {
-                eprintln!("content event error: {error}");
+                error!("content event error: {error}");
             }
         });
         if let Some(window_state) = self.windows.get(&window_id) {
@@ -767,7 +768,7 @@ impl ApplicationHandler<FormalWebUserEvent> for WindowedApp {
                                     ),
                                 };
                                 if let Err(error) = result {
-                                    eprintln!("content event error: {error}");
+                                    error!("content event error: {error}");
                                 }
                             });
                         }
@@ -844,7 +845,7 @@ impl ApplicationHandler<FormalWebUserEvent> for WindowedApp {
                                     }
                                 };
                                 if let Err(error) = result {
-                                    eprintln!("touch event error: {error}");
+                                    error!("touch event error: {error}");
                                 }
                             });
                         }
@@ -905,7 +906,7 @@ impl ApplicationHandler<FormalWebUserEvent> for WindowedApp {
                                     mods: modifiers,
                                 }),
                             ) {
-                                eprintln!("wheel event error: {error}");
+                                error!("wheel event error: {error}");
                             }
                         });
                     }
@@ -930,7 +931,7 @@ impl ApplicationHandler<FormalWebUserEvent> for WindowedApp {
                 if let Some(provider) = self.provider.as_mut()
                     && let Err(error) = provider.sync_pending_messages()
                 {
-                    eprintln!("provider sync error: {error}");
+                    error!("provider sync error: {error}");
                 }
             }
             FormalWebUserEvent::NewFrameRendered => {

--- a/net/Cargo.toml
+++ b/net/Cargo.toml
@@ -17,5 +17,7 @@ ipc-channel = "0.21"
 ipc_messages = { path = "../ipc_messages" }
 mime_guess = "2"
 reqwest = { version = "0.12.28", default-features = false, features = ["blocking", "rustls-tls"] }
+log = "0.4"
+env_logger = "0.11"
 url = "2"
 verification = { path = "../verification" }

--- a/net/src/bin/net_process.rs
+++ b/net/src/bin/net_process.rs
@@ -1,8 +1,11 @@
+use log::error;
 use std::process;
 
 fn main() {
+    env_logger::init();
+
     if let Err(error) = net::run_net_process_from_args() {
-        eprintln!("formal-web-net: {error}");
+        error!("formal-web-net: {error}");
         process::exit(1);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 use clap::{Parser, Subcommand};
+use log::error;
 use std::ffi::OsString;
 use std::process::{Command as ProcessCommand, ExitCode, Stdio};
 use verification::run_validation_from_iter;
@@ -44,7 +45,7 @@ fn delegated_tla_validate_command() -> Option<ExitCode> {
     Some(match run_validation_from_iter(forwarded_args) {
         Ok(exit_code) => exit_code,
         Err(error) => {
-            eprintln!("formal-web: {error}");
+            error!("formal-web: {error}");
             ExitCode::from(1)
         }
     })
@@ -138,6 +139,7 @@ fn run_embedder_cdp(verify: bool, args: automation::CdpArgs) -> Result<(), Strin
 }
 
 fn main() -> ExitCode {
+    env_logger::init();
     if let Some(exit_code) = delegated_tla_validate_command() {
         return exit_code;
     }
@@ -152,7 +154,7 @@ fn main() -> ExitCode {
         return match wpt_runner::run(args, cli.verify) {
             Ok(()) => ExitCode::SUCCESS,
             Err(error) => {
-                eprintln!("formal-web: {error}");
+                error!("formal-web: {error}");
                 ExitCode::from(1)
             }
         };
@@ -166,7 +168,7 @@ fn main() -> ExitCode {
     };
 
     if let Err(error) = result {
-        eprintln!("formal-web: {error}");
+        error!("formal-web: {error}");
         return ExitCode::from(1);
     }
 

--- a/tests/wpt_runner/Cargo.toml
+++ b/tests/wpt_runner/Cargo.toml
@@ -8,6 +8,8 @@ publish = false
 clap = { version = "4.5", features = ["derive"] }
 libc = "0.2"
 serde = { version = "1", features = ["derive"] }
+log = "0.4"
+env_logger = "0.11"
 serde_json = "1"
 
 [lib]

--- a/tests/wpt_runner/src/lib.rs
+++ b/tests/wpt_runner/src/lib.rs
@@ -1,6 +1,7 @@
 use clap::Args;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
+use log::error;
 use std::collections::{HashMap, HashSet};
 use std::ffi::OsStr;
 use std::fs;
@@ -478,7 +479,7 @@ pub fn run(args: TestWptArgs, verify: bool) -> Result<(), String> {
         if compared.actual == WptStatus::Crash {
             if let Some(runner) = shared_runner.take() {
                 if let Err(error) = runner.shutdown() {
-                    eprintln!("[wpt-runner] failed to shutdown runner on crash: {error}");
+                    error!("[wpt-runner] failed to shutdown runner on crash: {error}");
                 }
             }
             shared_runner_error = None;
@@ -507,7 +508,7 @@ pub fn run(args: TestWptArgs, verify: bool) -> Result<(), String> {
     }
 
     if summary.unexpected > 0 {
-        eprintln!(
+        error!(
             "WPT FAILURE: unexpected={} but expected 0. Treat this run as failing until the unexpected results are fixed or covered by metadata.",
             summary.unexpected
         );
@@ -801,7 +802,7 @@ impl WptServeProcess {
             Ok(child) => child,
             Err(error) => {
                 if let Err(error) = fs::remove_dir_all(&temp_dir) {
-                    eprintln!(
+                    error!(
                         "[wpt-runner] failed to remove temp dir after wptserve start error: {error}"
                     );
                 }
@@ -811,10 +812,10 @@ impl WptServeProcess {
 
         if let Err(error) = wait_for_wptserve_ready(port, &mut child, WPTSERVE_STARTUP_TIMEOUT) {
             if let Err(error) = shutdown_wptserve_child(&mut child) {
-                eprintln!("[wpt-runner] failed to shutdown wptserve child: {error}");
+                error!("[wpt-runner] failed to shutdown wptserve child: {error}");
             }
             if let Err(error) = fs::remove_dir_all(&temp_dir) {
-                eprintln!("[wpt-runner] failed to remove temp dir after wptserve timeout: {error}");
+                error!("[wpt-runner] failed to remove temp dir after wptserve timeout: {error}");
             }
             return Err(error);
         }
@@ -834,11 +835,11 @@ impl WptServeProcess {
 impl Drop for WptServeProcess {
     fn drop(&mut self) {
         if let Err(error) = shutdown_wptserve_child(&mut self.child) {
-            eprintln!("[wpt-runner] failed to shutdown wptserve child on drop: {error}");
+            error!("[wpt-runner] failed to shutdown wptserve child on drop: {error}");
         }
         unregister_wptserve_pid(self.child.id());
         if let Err(error) = fs::remove_dir_all(&self.temp_dir) {
-            eprintln!("[wpt-runner] failed to remove temp dir on drop: {error}");
+            error!("[wpt-runner] failed to remove temp dir on drop: {error}");
         }
     }
 }
@@ -887,10 +888,10 @@ impl Drop for BrowserProcess {
     fn drop(&mut self) {
         if self.child.try_wait().ok().flatten().is_none() {
             if let Err(error) = self.child.kill() {
-                eprintln!("[wpt-runner] failed to kill browser child on drop: {error}");
+                error!("[wpt-runner] failed to kill browser child on drop: {error}");
             }
             if let Err(error) = self.child.wait() {
-                eprintln!("[wpt-runner] failed to wait for browser child on drop: {error}");
+                error!("[wpt-runner] failed to wait for browser child on drop: {error}");
             }
         }
     }
@@ -1033,7 +1034,7 @@ fn run_with_shared_runner(
 
     if let Some(runner) = shared_runner.take() {
         if let Err(error) = runner.shutdown() {
-            eprintln!("[wpt-runner] failed to shutdown runner on retry: {error}");
+            error!("[wpt-runner] failed to shutdown runner on retry: {error}");
         }
     }
     *shared_runner_error = None;
@@ -2252,7 +2253,7 @@ fn register_wptserve_pid(pid: u32) {
     }
     pids.push(pid);
     if let Err(error) = save_registered_wptserve_pids(&pids) {
-        eprintln!("[wpt-runner] failed to save registered wptserve pids: {error}");
+        error!("[wpt-runner] failed to save registered wptserve pids: {error}");
     }
 }
 
@@ -2262,7 +2263,7 @@ fn unregister_wptserve_pid(pid: u32) {
     pids.retain(|existing| *existing != pid);
     if pids.len() != original_len {
         if let Err(error) = save_registered_wptserve_pids(&pids) {
-            eprintln!("[wpt-runner] failed to update registered wptserve pids: {error}");
+            error!("[wpt-runner] failed to update registered wptserve pids: {error}");
         }
     }
 }
@@ -2275,7 +2276,7 @@ fn cleanup_registered_wptserve_processes() {
 
     for pid in &pids {
         if let Err(error) = terminate_wptserve_process_group(*pid) {
-            eprintln!(
+            error!(
                 "[wpt-runner] failed to terminate wptserve process {}: {error}",
                 pid
             );
@@ -2283,7 +2284,7 @@ fn cleanup_registered_wptserve_processes() {
     }
 
     if let Err(error) = save_registered_wptserve_pids(&[]) {
-        eprintln!("[wpt-runner] failed to clear registered wptserve pids: {error}");
+        error!("[wpt-runner] failed to clear registered wptserve pids: {error}");
     }
 }
 
@@ -2417,7 +2418,7 @@ fn terminate_wptserve_process_group(pid: u32) -> Result<(), String> {
         send_signal_to_wptserve_group(pid, libc::SIGINT)?;
         thread::sleep(Duration::from_millis(100));
         if let Err(error) = send_signal_to_wptserve_group(pid, libc::SIGKILL) {
-            eprintln!("[wpt-runner] failed to send SIGKILL to wptserve group: {error}");
+            error!("[wpt-runner] failed to send SIGKILL to wptserve group: {error}");
         }
         Ok(())
     }
@@ -2545,10 +2546,10 @@ fn wait_for_wptserve_ready(port: u16, child: &mut Child, timeout: Duration) -> R
 
         if Instant::now() >= deadline {
             if let Err(error) = child.kill() {
-                eprintln!("[wpt-runner] failed to kill wptserve child on timeout: {error}");
+                error!("[wpt-runner] failed to kill wptserve child on timeout: {error}");
             }
             if let Err(error) = child.wait() {
-                eprintln!("[wpt-runner] failed to wait for wptserve child on timeout: {error}");
+                error!("[wpt-runner] failed to wait for wptserve child on timeout: {error}");
             }
             let stderr = read_child_stderr(child);
             return Err(format!(
@@ -2585,10 +2586,10 @@ fn wait_for_webdriver_ready(port: u16, child: &mut Child, timeout: Duration) -> 
 
         if Instant::now() >= deadline {
             if let Err(error) = child.kill() {
-                eprintln!("[wpt-runner] failed to kill WebDriver child on timeout: {error}");
+                error!("[wpt-runner] failed to kill WebDriver child on timeout: {error}");
             }
             if let Err(error) = child.wait() {
-                eprintln!("[wpt-runner] failed to wait for WebDriver child on timeout: {error}");
+                error!("[wpt-runner] failed to wait for WebDriver child on timeout: {error}");
             }
             let stderr = read_child_stderr(child);
             return Err(format!(
@@ -2617,10 +2618,10 @@ fn wait_for_child(child: &mut Child, timeout: Duration) -> Result<ExitStatus, St
         }
         if Instant::now() >= deadline {
             if let Err(error) = child.kill() {
-                eprintln!("[wpt-runner] failed to kill child on wait timeout: {error}");
+                error!("[wpt-runner] failed to kill child on wait timeout: {error}");
             }
             if let Err(error) = child.wait() {
-                eprintln!("[wpt-runner] failed to wait for child after kill: {error}");
+                error!("[wpt-runner] failed to wait for child after kill: {error}");
             }
             return Err(format!(
                 "child process did not exit within {} ms",
@@ -2635,7 +2636,7 @@ fn read_child_stderr(child: &mut Child) -> String {
     let mut stderr = String::new();
     if let Some(mut handle) = child.stderr.take() {
         if let Err(error) = handle.read_to_string(&mut stderr) {
-            eprintln!("[wpt-runner] failed to read child stderr: {error}");
+            error!("[wpt-runner] failed to read child stderr: {error}");
         }
     }
     if stderr.len() > CHILD_STDERR_LIMIT {

--- a/tests/wpt_runner/src/main.rs
+++ b/tests/wpt_runner/src/main.rs
@@ -1,4 +1,5 @@
 use clap::Parser;
+use log::error;
 use std::process::ExitCode;
 
 #[derive(Parser, Debug)]
@@ -13,11 +14,12 @@ struct Cli {
 }
 
 fn main() -> ExitCode {
+    env_logger::init();
     let cli = Cli::parse();
     match wpt_runner::run(cli.args, cli.verify) {
         Ok(()) => ExitCode::SUCCESS,
         Err(error) => {
-            eprintln!("formal-web-wpt: {error}");
+            error!("formal-web-wpt: {error}");
             ExitCode::from(1)
         }
     }

--- a/user_agent/Cargo.toml
+++ b/user_agent/Cargo.toml
@@ -13,6 +13,7 @@ serde_json = "1"
 psl = "2"
 url = "2"
 uuid = { version = "1", features = ["serde", "v4"] }
+log = "0.4"
 verification = { path = "../verification" }
 [lib]
 path = "src/user_agent.rs"

--- a/user_agent/src/event_loop.rs
+++ b/user_agent/src/event_loop.rs
@@ -12,6 +12,7 @@ use std::collections::{HashMap, HashSet, VecDeque};
 #[cfg(unix)]
 use std::os::unix::process::CommandExt;
 use std::process::{Child, Command as ProcessCommand};
+use log::error;
 use std::sync::Arc;
 use std::thread::{self, JoinHandle};
 use std::time::{Duration, Instant};
@@ -283,7 +284,7 @@ impl EventLoopWorker {
             // content process immediately after bootstrap.
             let command = viewport_command(snapshot);
             if let Err(error) = worker.send_command_inner(&command) {
-                eprintln!("failed to send initial viewport command: {error}");
+                error!("failed to send initial viewport command: {error}");
             }
         }
 
@@ -583,7 +584,7 @@ impl EventLoopWorker {
                     .webview_provider_sender
                     .send(WebviewProviderMessage::PaintFrame(snapshot))
                 {
-                    eprintln!("failed to enqueue webview-provider paint frame: {error}");
+                    error!("failed to enqueue webview-provider paint frame: {error}");
                 } else {
                     // Silently ignore send failures during shutdown — the event
                     // loop may have already closed.
@@ -613,14 +614,14 @@ impl EventLoopWorker {
                 Ok(true) => {}
                 Ok(false) => {
                     if let Err(error) = child.kill() {
-                        eprintln!("failed to kill content process: {error}");
+                        error!("failed to kill content process: {error}");
                     }
                     if let Err(error) = child.wait() {
-                        eprintln!("failed to wait for content process exit: {error}");
+                        error!("failed to wait for content process exit: {error}");
                     }
                 }
                 Err(error) => {
-                    eprintln!("content bridge shutdown poll error: {error}");
+                    error!("content bridge shutdown poll error: {error}");
                 }
             }
         }
@@ -637,12 +638,12 @@ impl EventLoopWorker {
             select! {
                 recv(command_receiver) -> command => {
                     let Ok(command) = command else {
-                        eprintln!(
+                        error!(
                             "event loop command channel closed for event loop {}; sending shutdown to content",
                             self.event_loop_id
                         );
                         if let Err(error) = self.send_command_inner(&ContentCommand::Shutdown) {
-                            eprintln!("failed to send shutdown command to content: {error}");
+                            error!("failed to send shutdown command to content: {error}");
                         }
                         break;
                     };
@@ -651,7 +652,7 @@ impl EventLoopWorker {
                         if let Some(reply) = self.stop_reply.take() {
                             let _ = reply.send(Err(error.clone()));
                         }
-                        eprintln!("content bridge command handling error: {error}");
+                        error!("content bridge command handling error: {error}");
                         break;
                     }
                 }
@@ -662,7 +663,7 @@ impl EventLoopWorker {
                             if let Some(reply) = self.stop_reply.take() {
                                 let _ = reply.send(Err(error.clone()));
                             }
-                            eprintln!("content bridge route error: {error}");
+                            error!("content bridge route error: {error}");
                             break;
                         }
                         Err(error) => {
@@ -679,7 +680,7 @@ impl EventLoopWorker {
                             } else {
                                 String::from("missing child handle")
                             };
-                            eprintln!(
+                            error!(
                                 "content event route closed for event loop {}: {error}; child status: {child_status}",
                                 self.event_loop_id
                             );
@@ -702,7 +703,7 @@ impl EventLoopWorker {
                             if let Some(reply) = self.stop_reply.take() {
                                 let _ = reply.send(Err(error.clone()));
                             }
-                            eprintln!("content bridge event handling error: {error}");
+                            error!("content bridge event handling error: {error}");
                             break;
                         }
                     }

--- a/user_agent/src/fetch.rs
+++ b/user_agent/src/fetch.rs
@@ -1,3 +1,4 @@
+use log::error;
 use crossbeam_channel::{Receiver, Sender, select, unbounded};
 use ipc_channel::ipc::{IpcOneShotServer, IpcSender};
 use ipc_channel::router::ROUTER;
@@ -410,14 +411,14 @@ fn completion_for_network_result(
 ) -> FetchCompletion {
     if record.is_aborted() {
         if let Err(error) = result {
-            eprintln!("ignored aborted fetch failure: {error}");
+            error!("ignored aborted fetch failure: {error}");
         }
         return FetchCompletion::Ignored;
     }
 
     if record.is_canceled() {
         if let Err(error) = result {
-            eprintln!("ignored canceled fetch failure: {error}");
+            error!("ignored canceled fetch failure: {error}");
         }
         return FetchCompletion::Ignored;
     }
@@ -499,14 +500,14 @@ fn finish_shutdown(mut child: Option<Child>) {
             Ok(true) => {}
             Ok(false) => {
                 if let Err(error) = child.kill() {
-                    eprintln!("failed to kill network process: {error}");
+                    error!("failed to kill network process: {error}");
                 }
                 if let Err(error) = child.wait() {
-                    eprintln!("failed to wait for network process exit: {error}");
+                    error!("failed to wait for network process exit: {error}");
                 }
             }
             Err(error) => {
-                eprintln!("fetch shutdown poll error: {error}");
+                error!("fetch shutdown poll error: {error}");
             }
         }
     }
@@ -653,7 +654,7 @@ impl FetchWorker {
                             }
                         }
                     }
-                    eprintln!("failed to send document fetch request to network process: {error}");
+                    error!("failed to send document fetch request to network process: {error}");
                 }
             }
             FetchCommand::StartNavigationFetch { fetch_id, request } => {
@@ -677,7 +678,7 @@ impl FetchWorker {
                     let _ = self
                         .user_agent_command_sender
                         .send(UserAgentCommand::NavigationFetchFailed { fetch_id });
-                    eprintln!(
+                    error!(
                         "failed to send navigation fetch request to network process: {error}"
                     );
                 }
@@ -699,7 +700,7 @@ impl FetchWorker {
         let completion = match response.result {
             Ok(fetch_response) => completion_for_network_result(fetch_record, Ok(fetch_response)),
             Err(error) => {
-                eprintln!("fetch failed: {error}");
+                error!("fetch failed: {error}");
                 completion_for_network_result(fetch_record, Err(error))
             }
         };
@@ -778,11 +779,11 @@ impl FetchWorker {
                     let response = match response {
                         Ok(Ok(response)) => response,
                         Ok(Err(error)) => {
-                            eprintln!("network process route error: {error}");
+                            error!("network process route error: {error}");
                             break;
                         }
                         Err(error) => {
-                            eprintln!("network response route closed: {error}");
+                            error!("network response route closed: {error}");
                             break;
                         }
                     };
@@ -809,7 +810,7 @@ pub fn run_fetch_thread(
         match FetchWorker::new(command_receiver, user_agent_command_sender, trace_sender) {
             Ok(worker) => worker,
             Err(error) => {
-                eprintln!("fetch thread startup failed: {error}");
+                error!("fetch thread startup failed: {error}");
                 return;
             }
         };

--- a/user_agent/src/timer.rs
+++ b/user_agent/src/timer.rs
@@ -1,6 +1,7 @@
 use crossbeam_channel::{Receiver, Sender, select};
 use ipc_messages::content::{DocumentFetchId, DocumentId, EventLoopId, WindowTimerKey};
 use std::collections::HashMap;
+use log::debug;
 use std::time::{Duration, Instant};
 use uuid::Uuid;
 use verification::TraceSender;
@@ -67,7 +68,7 @@ struct TimerWorker {
 /// timer debug output related to schedule, clear, and fire operations.
 fn log_timer_debug(message: impl AsRef<str>) {
     if std::env::var_os("FORMAL_WEB_DEBUG_TIMERS").is_some() {
-        eprintln!("[timer-debug][user-agent] {}", message.as_ref());
+        debug!("[timer-debug][user-agent] {}", message.as_ref());
     }
 }
 

--- a/user_agent/src/user_agent.rs
+++ b/user_agent/src/user_agent.rs
@@ -13,6 +13,7 @@ use ipc_messages::content::{
     UserNavigationInvolvement, WebviewId, WebviewProviderMessage, WindowTimerKey,
     iframe_target_name,
 };
+use log::{debug, error, trace};
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -996,7 +997,7 @@ impl Drop for UserAgent {
     /// best-effort shutdown of the owned user-agent thread.
     fn drop(&mut self) {
         if let Err(error) = self.shutdown_inner() {
-            eprintln!("failed to shut down user-agent thread: {error}");
+            error!("failed to shut down user-agent thread: {error}");
         }
     }
 }
@@ -1104,7 +1105,7 @@ impl UserAgent {
 /// render-state debug output on the user-agent thread.
 fn log_render_state_debug(message: impl AsRef<str>) {
     if std::env::var_os("FORMAL_WEB_DEBUG_RENDER_STATE").is_some() {
-        eprintln!("[render-state][user-agent] {}", message.as_ref());
+        debug!("[render-state][user-agent] {}", message.as_ref());
     }
 }
 
@@ -1540,7 +1541,7 @@ impl UserAgentWorker {
             .ok_or_else(|| format!("missing event loop entry for id {}", agent.event_loop_id))?;
 
         if startup_debug_enabled() {
-            eprintln!(
+            trace!(
                 "[startup-debug][user-agent] create_new_top_level_traversable sending CreateEmptyDocument traversable={} document={} event_loop={}",
                 traversable_id, document_id, agent.event_loop_id
             );
@@ -1563,7 +1564,7 @@ impl UserAgentWorker {
         )?;
 
         if startup_debug_enabled() {
-            eprintln!(
+            trace!(
                 "[startup-debug][user-agent] create_new_top_level_traversable CreateEmptyDocument queued traversable={} document={} event_loop={}",
                 traversable_id, document_id, agent.event_loop_id
             );
@@ -1666,7 +1667,7 @@ impl UserAgentWorker {
         // The embedder notification is the model's observable hook for a new top-level
         // traversable.
         if startup_debug_enabled() {
-            eprintln!(
+            trace!(
                 "[startup-debug][user-agent] create_new_top_level_traversable traversable={} target_name={}",
                 traversable_id, target_name
             );
@@ -2303,7 +2304,7 @@ impl UserAgentWorker {
     /// supplied startup URL.
     fn create_a_fresh_top_level_traversable(&mut self, destination_url: String) {
         if startup_debug_enabled() {
-            eprintln!(
+            trace!(
                 "[startup-debug][user-agent] create_fresh_top_level_traversable destination_url={}",
                 destination_url
             );
@@ -2321,7 +2322,7 @@ impl UserAgentWorker {
             )
         })();
         if let Err(error) = result {
-            eprintln!("failed to create a fresh top-level traversable: {error}");
+            error!("failed to create a fresh top-level traversable: {error}");
         }
     }
 
@@ -2648,7 +2649,7 @@ impl UserAgentWorker {
             Ok(())
         })();
         if let Err(error) = result {
-            eprintln!("failed to run navigate: {error}");
+            error!("failed to run navigate: {error}");
         }
     }
 
@@ -2837,7 +2838,7 @@ impl UserAgentWorker {
     /// <https://html.spec.whatwg.org/multipage/#checking-if-unloading-is-canceled>
     fn handle_complete_before_unload(&mut self, result: BeforeUnloadResult) {
         if let Err(error) = self.handle_complete_before_unload_result(result) {
-            eprintln!("failed to complete beforeunload: {error}");
+            error!("failed to complete beforeunload: {error}");
         }
     }
 
@@ -2960,7 +2961,7 @@ impl UserAgentWorker {
                             document_id: previous_document_id,
                         },
                     ) {
-                        eprintln!("[user-agent] failed to destroy previous document: {error}");
+                        error!("[user-agent] failed to destroy previous document: {error}");
                     }
                 }
                 self.state.documents.remove(&previous_document_id);
@@ -2993,7 +2994,7 @@ impl UserAgentWorker {
     /// <https://html.spec.whatwg.org/multipage/#finalize-a-cross-document-navigation>
     fn handle_finalize_cross_document_navigation(&mut self, finalized: ContentFinalizeNavigation) {
         if let Err(error) = self.finalize_cross_document_navigation(finalized) {
-            eprintln!("failed to finalize cross-document navigation: {error}");
+            error!("failed to finalize cross-document navigation: {error}");
         }
     }
 
@@ -3146,7 +3147,7 @@ impl UserAgentWorker {
         };
 
         if input_debug_enabled() {
-            eprintln!(
+            trace!(
                 "[input-debug][user-agent] dispatch_event traversable={} event_loop={} document={} bytes={}",
                 traversable_id,
                 handle,
@@ -3183,7 +3184,7 @@ impl UserAgentWorker {
         };
 
         if input_debug_enabled() {
-            eprintln!(
+            trace!(
                 "[input-debug][user-agent] rendering_opportunity traversable={} event_loop={} document={}",
                 traversable_id, handle, document_id,
             );
@@ -3288,7 +3289,7 @@ impl UserAgentWorker {
                         webview_id: WebviewId(pending.traversable_id),
                         status: NavigationCompletion::Aborted { message: error },
                     }) {
-                        eprintln!(
+                        error!(
                             "[user-agent] failed to report navigation completed (init doc): {error}"
                         );
                     }
@@ -3308,7 +3309,7 @@ impl UserAgentWorker {
                     webview_id: WebviewId(pending.traversable_id),
                     status: NavigationCompletion::Aborted { message: error },
                 }) {
-                    eprintln!(
+                    error!(
                         "[user-agent] failed to report navigation completed (command sender): {error}"
                     );
                 }
@@ -3394,7 +3395,7 @@ impl UserAgentWorker {
                     webview_id: WebviewId(pending.traversable_id),
                     status: NavigationCompletion::Aborted { message: error },
                 }) {
-                    eprintln!("[user-agent] failed to report navigation completed (send): {error}");
+                    error!("[user-agent] failed to report navigation completed (send): {error}");
                 }
             }
         }
@@ -3416,7 +3417,7 @@ impl UserAgentWorker {
                 message: format!("navigation fetch failed for {}", pending.request.url),
             },
         }) {
-            eprintln!("[user-agent] failed to report navigation completed (fetch failed): {error}");
+            error!("[user-agent] failed to report navigation completed (fetch failed): {error}");
         }
     }
 

--- a/verification/Cargo.toml
+++ b/verification/Cargo.toml
@@ -18,4 +18,6 @@ clap = { version = "4.5", features = ["derive"] }
 image = { version = "0.25", default-features = false, features = ["png"] }
 ipc-channel = "0.21"
 serde = { version = "1", features = ["derive"] }
+log = "0.4"
+env_logger = "0.11"
 serde_json = "1"

--- a/verification/src/bin/tla_validate.rs
+++ b/verification/src/bin/tla_validate.rs
@@ -1,10 +1,13 @@
+use log::error;
 use std::process::ExitCode;
 
 fn main() -> ExitCode {
+    env_logger::init();
+
     match verification::run_validation_from_iter(std::env::args_os()) {
         Ok(exit_code) => exit_code,
         Err(error) => {
-            eprintln!("tla-validate: {error}");
+            error!("tla-validate: {error}");
             ExitCode::from(1)
         }
     }

--- a/verification/src/bin/webdriver_screenshot_check.rs
+++ b/verification/src/bin/webdriver_screenshot_check.rs
@@ -1,4 +1,5 @@
 use clap::{Args, Parser, Subcommand};
+use log::error;
 use image::{ImageReader, RgbaImage};
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
@@ -97,10 +98,12 @@ struct DiffMetrics {
 }
 
 fn main() -> ExitCode {
+    env_logger::init();
+
     match run() {
         Ok(()) => ExitCode::SUCCESS,
         Err(error) => {
-            eprintln!("webdriver-screenshot-check: {error}");
+            error!("webdriver-screenshot-check: {error}");
             ExitCode::from(1)
         }
     }

--- a/verification/src/tracer.rs
+++ b/verification/src/tracer.rs
@@ -1,3 +1,4 @@
+use log::error;
 use std::mem;
 
 use crate::{LogEntry, TraceSender, VarUpdate};
@@ -89,7 +90,7 @@ impl TLATracer {
         };
 
         if let Err(error) = sender.send(entry) {
-            eprintln!("verification trace send failed: {error}");
+            error!("verification trace send failed: {error}");
         }
     }
 }

--- a/verification/src/validate.rs
+++ b/verification/src/validate.rs
@@ -1,6 +1,7 @@
 use clap::{Args, Parser, Subcommand};
 use serde::Serialize;
 use serde_json::Value;
+use log::error;
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::ffi::OsStr;
 use std::fs::{self, File};
@@ -493,7 +494,7 @@ fn run_tlc(
     if let Some(config_path) = spec.trace_config_path().as_ref().or(spec.config.as_ref()) {
         let Some(config_name) = config_path.file_name() else {
             if let Err(error) = fs::remove_file(&generated_trace_data_path) {
-                eprintln!("[validate] failed to remove generated trace data: {error}");
+                error!("[validate] failed to remove generated trace data: {error}");
             }
             return Err(format!("invalid config path {}", config_path.display()));
         };

--- a/webview/Cargo.toml
+++ b/webview/Cargo.toml
@@ -15,4 +15,5 @@ peniko = "0.6"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 user_agent = { path = "../user_agent" }
+log = "0.4"
 verification = { path = "../verification" }

--- a/webview/src/compositor.rs
+++ b/webview/src/compositor.rs
@@ -1,3 +1,4 @@
+use log::trace;
 use anyrender::{PaintScene, Scene as RenderScene};
 use ipc_messages::content::{
     EmbedBackgroundPolicy, FontTransportReceiver, FrameCompositionMetadata, FrameEmbedSite,
@@ -112,7 +113,7 @@ impl Compositor {
     ) {
         if input_debug_enabled() {
             let summary = scene.summary();
-            eprintln!(
+            trace!(
                 "[input-debug][compositor] store_frame frame={} root_candidate={} viewport=({},{}) embed_sites={} commands={}",
                 frame_id.0,
                 is_root_candidate,
@@ -202,7 +203,7 @@ impl Compositor {
                 .and_then(|frame| frame.resolved_viewport.as_ref())
                 .is_none();
         if input_debug_enabled() {
-            eprintln!(
+            trace!(
                 "[input-debug][compositor] hit_test client=({x:.1},{y:.1}) refresh_needed={refresh_needed}"
             );
         }
@@ -230,7 +231,7 @@ impl Compositor {
         frame_local_to_root: Affine,
     ) -> Option<RenderScene> {
         if input_debug_enabled() {
-            eprintln!("[input-debug][compositor] composing frame {}", frame_id.0);
+            trace!("[input-debug][compositor] composing frame {}", frame_id.0);
         }
         let parent_viewport = self
             .committed_frames
@@ -288,7 +289,7 @@ impl Compositor {
                 composed_scene.append_scene(child_scene, child_transform);
                 composed_scene.pop_layer();
                 if input_debug_enabled() {
-                    eprintln!(
+                    trace!(
                         "[input-debug][compositor] composed embed site {} with child frame {}",
                         embed_site.embed_site_id.0, child_frame_id.0
                     );
@@ -347,7 +348,7 @@ impl Compositor {
     ) -> Option<Affine> {
         let Some(layout) = self.navigable_container_layout(parent_local_to_root, embed_site) else {
             if input_debug_enabled() {
-                eprintln!(
+                trace!(
                     "[input-debug][compositor] parent={} child={} record=skip reason=no-layout",
                     parent_frame_id.0, embed_site.child_frame_id.0,
                 );
@@ -357,7 +358,7 @@ impl Compositor {
 
         if !parent_viewport.intersects_local_rect(layout.clip_bounds) {
             if input_debug_enabled() {
-                eprintln!(
+                trace!(
                     "[input-debug][compositor] parent={} child={} record=skip visible=false clip=({:.1},{:.1})-({:.1},{:.1}) parent_viewport=({:.1},{:.1})",
                     parent_frame_id.0,
                     embed_site.child_frame_id.0,
@@ -375,7 +376,7 @@ impl Compositor {
         let child_local_to_root = parent_local_to_root * layout.child_local_from_parent.inverse();
 
         if input_debug_enabled() {
-            eprintln!(
+            trace!(
                 "[input-debug][compositor] parent={} child={} record=ok clip=({:.1},{:.1})-({:.1},{:.1})",
                 parent_frame_id.0,
                 embed_site.child_frame_id.0,

--- a/webview/src/lib.rs
+++ b/webview/src/lib.rs
@@ -11,6 +11,7 @@ use ipc_messages::content::{
     UserNavigationInvolvement, WebviewId, WebviewProviderMessage,
 };
 use kurbo::Affine;
+use log::{debug, error, trace};
 use std::collections::HashMap;
 use std::env;
 use std::path::PathBuf;
@@ -194,7 +195,7 @@ impl WebviewProvider {
     pub fn note_rendering_opportunity(&self, webview_id: WebviewId, reason: &str) {
         let _ = reason;
         if let Err(error) = self.user_agent.note_rendering_opportunity(webview_id.0) {
-            eprintln!("failed to note rendering opportunity for webview {webview_id:?}: {error}");
+            error!("failed to note rendering opportunity for webview {webview_id:?}: {error}");
         }
     }
 
@@ -240,7 +241,7 @@ impl WebviewProvider {
     ) -> Result<serde_json::Value, String> {
         let cdp_debug_enabled = std::env::var_os("FORMAL_WEB_DEBUG_CDP").is_some();
         if cdp_debug_enabled {
-            eprintln!(
+            debug!(
                 "[cdp][webview] evaluate enter traversable={:?} len={} timeout_ms={}",
                 traversable_id,
                 source.len(),
@@ -251,7 +252,7 @@ impl WebviewProvider {
             .user_agent
             .evaluate_script(traversable_id.0, source, timeout);
         if cdp_debug_enabled {
-            eprintln!(
+            debug!(
                 "[cdp][webview] evaluate exit ok={} traversable={:?}",
                 result.is_ok(),
                 traversable_id
@@ -319,7 +320,7 @@ impl WebviewProvider {
         let viewport_height = frame.viewport_height;
         let composition = frame.composition.clone();
         if input_debug_enabled() {
-            eprintln!(
+            trace!(
                 "[input-debug][webview] on_paint_frame traversable={} frame={} embeds={}",
                 traversable_id.0,
                 frame_id.0,
@@ -364,7 +365,7 @@ impl WebviewProvider {
             let parent_traversable_id = child_navigable_host.parent_traversable_id;
             let content_frame_id = child_navigable_host.content_frame_id;
             if input_debug_enabled() {
-                eprintln!(
+                trace!(
                     "[input-debug][webview] navigation_committed child_webview={} parent_webview={} content_frame={}",
                     webview_id.0, parent_traversable_id.0, content_frame_id.0,
                 );
@@ -388,7 +389,7 @@ impl WebviewProvider {
         }
 
         if input_debug_enabled() {
-            eprintln!(
+            trace!(
                 "[input-debug][webview] navigation_committed top_level_webview={}",
                 webview_id.0
             );
@@ -427,7 +428,7 @@ impl WebviewProvider {
             return false;
         };
         if input_debug_enabled() {
-            eprintln!(
+            trace!(
                 "[input-debug][webview] append_web_content_scene webview={}",
                 webview_id.0
             );
@@ -493,7 +494,7 @@ impl WebviewProvider {
                 .map(|frame_id| self.webview_id_for_frame(root_webview_id, frame_id))
                 .unwrap_or(root_webview_id);
             if input_debug_enabled() {
-                eprintln!(
+                trace!(
                     "[input-debug][webview] root={} frame={} child={} target={} nonpositional=true",
                     root_webview_id.0,
                     target_frame_id
@@ -529,7 +530,7 @@ impl WebviewProvider {
             }
             self.publish_visible_child_viewports(viewports);
             if input_debug_enabled() {
-                eprintln!(
+                trace!(
                     "[input-debug][webview] root={} client=({client_x:.1},{client_y:.1}) hit=none target={}",
                     root_webview_id.0, root_webview_id.0,
                 );
@@ -546,7 +547,7 @@ impl WebviewProvider {
         if input_debug_enabled() {
             let logical_local_x = hit.local_x / viewport_scale;
             let logical_local_y = hit.local_y / viewport_scale;
-            eprintln!(
+            trace!(
                 "[input-debug][webview] root={} client=({client_x:.1},{client_y:.1}) frame={} child={} children={} target={} local=({:.1},{:.1})",
                 root_webview_id.0,
                 hit.frame_id.0,
@@ -589,7 +590,7 @@ impl WebviewProvider {
             next_published_child_viewports.insert(child_webview_id, published_viewport.clone());
 
             if input_debug_enabled() {
-                eprintln!(
+                trace!(
                     "[input-debug][webview] publish_child_viewport child_webview={} frame={} changed={} size=({},{}) offset=({:.1},{:.1}) scale={:.2}",
                     child_webview_id.0,
                     viewport.frame_id.0,
@@ -617,7 +618,7 @@ impl WebviewProvider {
                 published_viewport.offset_x,
                 published_viewport.offset_y,
             ) {
-                eprintln!("[webview] failed to set traversable viewport: {error}");
+                error!("[webview] failed to set traversable viewport: {error}");
             }
             // Do NOT call note_rendering_opportunity or request_redraw here.
             // Child viewport publishing during composition (composed_scene_for_webview)


### PR DESCRIPTION
   Convert all eprintln! calls across the project to proper structured
   logging using the log crate with env_logger. Log levels:
   - error! for operation failures and system errors
   - warn! for non-critical issues and unimplemented features
   - debug! for toggle-gated debug traces (timer, stream, render-state, cdp)
   - trace! for verbose debugging (input, startup)

   The ConsoleSink::Stderr variant in console.rs is exempted as it
   implements the browser Console API output, not error logging.