### PR TITLE
fetch: implement initial stream-backed response

### DIFF
--- a/content/src/html.rs
+++ b/content/src/html.rs
@@ -1,4 +1,5 @@
 mod environment_settings_object;
+mod fetch;
 mod global_scope;
 mod html_anchor_element;
 mod html_dom_tree;
@@ -20,6 +21,8 @@ use ipc_messages::content::{
 };
 
 pub use environment_settings_object::EnvironmentSettingsObject;
+pub(crate) use fetch::header_list_from_value;
+pub use fetch::{Headers, Response};
 pub(crate) use global_scope::TimerHandler;
 pub use global_scope::{GlobalScope, GlobalScopeKind};
 pub use html_anchor_element::HTMLAnchorElement;

--- a/content/src/html/fetch.rs
+++ b/content/src/html/fetch.rs
@@ -1,0 +1,900 @@
+use boa_engine::{
+    Context, JsArgs, JsData, JsNativeError, JsResult, JsString, JsValue,
+    builtins::promise::ResolvingFunctions,
+    native_function::NativeFunction,
+    object::{
+        JsObject,
+        builtins::{JsArray, JsPromise, JsUint8Array},
+    },
+    property::PropertyKey,
+};
+use boa_gc::{Finalize, Gc, GcRef, GcRefCell, Trace};
+use ipc_messages::content::{
+    FetchResponse as ContentFetchResponse, HeaderList as ContentHeaderList,
+};
+
+use crate::streams::{
+    ReadableStream, ReadableStreamDefaultReader, acquire_readable_stream_default_reader,
+    readable_stream_from_iterable, with_readable_stream_default_reader_ref,
+    with_readable_stream_ref,
+};
+use crate::webidl::bindings::{
+    AttributeDef, InterfaceDefinition, OperationDef, WebIdlInterface, create_interface_instance,
+};
+use crate::webidl::{mark_promise_as_handled, rejected_promise};
+
+/// <https://fetch.spec.whatwg.org/#headers-class>
+#[derive(Clone, Trace, Finalize, JsData)]
+pub struct Headers {
+    /// <https://fetch.spec.whatwg.org/#concept-headers-header-list>
+    #[unsafe_ignore_trace]
+    header_list: ContentHeaderList,
+}
+
+impl Headers {
+    pub(crate) fn new(header_list: ContentHeaderList) -> Self {
+        Self { header_list }
+    }
+
+    pub(crate) fn header_list(&self) -> ContentHeaderList {
+        self.header_list.clone()
+    }
+
+    /// <https://fetch.spec.whatwg.org/#concept-header-list-get>
+    fn get(&self, name: &str) -> Option<String> {
+        // Step 1: "If list does not contain name, then return null."
+        let values = self
+            .header_list
+            .headers
+            .iter()
+            .filter(|(header_name, _value)| header_name.eq_ignore_ascii_case(name))
+            .map(|(_header_name, value)| value.as_str())
+            .collect::<Vec<_>>();
+
+        if values.is_empty() {
+            None
+        } else {
+            // Step 2: "Return the values of all headers in list whose name is a
+            // byte-case-insensitive match for name, separated from each other by 0x2C 0x20, in
+            // order."
+            Some(values.join(", "))
+        }
+    }
+}
+
+impl WebIdlInterface for Headers {
+    const NAME: &'static str = "Headers";
+
+    fn create_platform_object(
+        _new_target: &JsValue,
+        args: &[JsValue],
+        context: &mut Context,
+    ) -> JsResult<Self> {
+        // Step 1: "Set this’s guard to \"none\"."
+        // Note: The Headers guard is not represented yet; all exposed Headers objects behave as
+        // guard "none" until Request/Response guards are modeled.
+        let header_list = if args.get_or_undefined(0).is_null_or_undefined() {
+            ContentHeaderList::default()
+        } else {
+            // Step 2: "If init is given, then fill this with init."
+            header_list_from_value(args.get_or_undefined(0), context)?
+        };
+        Ok(Self::new(header_list))
+    }
+
+    fn define_members(def: &mut InterfaceDefinition) {
+        def.add_operation(OperationDef {
+            id: "get",
+            length: 1,
+            method: headers_get_method,
+            static_: false,
+            unforgeable: false,
+            promise_type: false,
+        });
+    }
+}
+
+/// <https://fetch.spec.whatwg.org/#concept-body>
+#[derive(Clone, Trace, Finalize)]
+struct FetchBody {
+    stream: ReadableStream,
+    stream_object: JsObject,
+}
+
+impl FetchBody {
+    /// <https://fetch.spec.whatwg.org/#concept-body>
+    fn from_bytes(bytes: Vec<u8>, context: &mut Context) -> JsResult<Self> {
+        // Step: "To get a byte sequence bytes as a body, return the body of the result of safely extracting bytes."
+        // Note: Formal-web currently supports byte-sequence bodies as a one-chunk Uint8Array
+        // ReadableStream. The Fetch body source and length fields are deferred until the broader
+        // BodyInit extraction algorithm is implemented.
+        let chunk = JsUint8Array::from_iter(bytes, context)?;
+        let chunks = JsArray::from_iter([JsValue::from(chunk)], context);
+        let stream_object = readable_stream_from_iterable(JsValue::from(chunks), context)?;
+        let stream = with_readable_stream_ref(&stream_object, |stream| stream.clone())?;
+
+        Ok(Self {
+            stream,
+            stream_object,
+        })
+    }
+
+    fn stream_object(&self) -> JsObject {
+        self.stream_object.clone()
+    }
+
+    /// <https://fetch.spec.whatwg.org/#body-unusable>
+    fn unusable(&self) -> bool {
+        // Step: "An object including the Body interface mixin is said to be unusable if its body is
+        // non-null and its body’s stream is disturbed or locked."
+        self.stream.disturbed() || self.stream.locked()
+    }
+
+    fn disturbed(&self) -> bool {
+        self.stream.disturbed()
+    }
+}
+
+/// <https://fetch.spec.whatwg.org/#response-class>
+#[derive(Trace, Finalize, JsData)]
+pub struct Response {
+    /// <https://fetch.spec.whatwg.org/#concept-response-url-list>
+    #[unsafe_ignore_trace]
+    url_list: Vec<String>,
+
+    /// <https://fetch.spec.whatwg.org/#concept-response-status>
+    #[unsafe_ignore_trace]
+    status: u16,
+
+    /// <https://fetch.spec.whatwg.org/#concept-response-status-message>
+    #[unsafe_ignore_trace]
+    status_text: String,
+
+    /// <https://fetch.spec.whatwg.org/#dom-response-headers>
+    headers: JsObject,
+
+    /// <https://fetch.spec.whatwg.org/#concept-response-body>
+    body: Option<FetchBody>,
+}
+
+impl Response {
+    /// <https://fetch.spec.whatwg.org/#response-create>
+    pub(crate) fn from_content_fetch_response(
+        response: ContentFetchResponse,
+        context: &mut Context,
+    ) -> JsResult<Self> {
+        // Step 1: "Let responseObject be a new Response object with realm."
+        // Note: The caller performs the Web IDL object allocation after this helper converts the
+        // completed content fetch response into Response backing data.
+
+        // Step 2: "Set responseObject’s response to response."
+        let final_url = response.final_url.clone();
+        let url_list = if response.url_list.is_empty() {
+            vec![final_url]
+        } else {
+            response.url_list
+        };
+        // Step 3: "Set responseObject’s headers to a new Headers object with realm, whose headers
+        // list is response’s headers list and guard is guard."
+        // Note: The Headers guard is not represented yet; fetch-created Response objects therefore
+        // expose the response header list without enforcing guard "immutable".
+        let headers = create_interface_instance::<Headers>(
+            Headers::new(response.header_list.clone()),
+            context,
+        )?;
+        // Note: The HTTP-network fetch steps produce a null body for null-body status responses.
+        // The request method is not available in this content callback yet, so HEAD response body
+        // nulling remains deferred to the request/response plumbing.
+        let body = if is_null_body_status(response.status) {
+            None
+        } else {
+            Some(FetchBody::from_bytes(response.body, context)?)
+        };
+
+        // Step 4: "Return responseObject."
+        Ok(Self {
+            url_list,
+            status: response.status,
+            status_text: response.status_text,
+            headers,
+            body,
+        })
+    }
+
+    fn new(
+        body: Option<FetchBody>,
+        status: u16,
+        status_text: String,
+        headers: JsObject,
+    ) -> Self {
+        Self {
+            url_list: Vec::new(),
+            status,
+            status_text,
+            body,
+            headers,
+        }
+    }
+
+    fn body_used(&self) -> bool {
+        self.body.as_ref().is_some_and(FetchBody::disturbed)
+    }
+
+    fn body_unusable(&self) -> bool {
+        self.body.as_ref().is_some_and(FetchBody::unusable)
+    }
+}
+
+impl WebIdlInterface for Response {
+    const NAME: &'static str = "Response";
+
+    fn create_platform_object(
+        _new_target: &JsValue,
+        args: &[JsValue],
+        context: &mut Context,
+    ) -> JsResult<Self> {
+        // Step 1: "Set this’s response to a new response."
+
+        // Step 3: "Let bodyWithType be null."
+        let body = if args.get_or_undefined(0).is_null_or_undefined() {
+            None
+        } else {
+            // Step 4: "If body is non-null, then set bodyWithType to the result of extracting body."
+            // Note: Full BodyInit extraction is not implemented yet. The current constructor path
+            // extracts non-null bodies through Web IDL string conversion and stores the resulting
+            // bytes in a Fetch body stream.
+            Some(FetchBody::from_bytes(
+                args.get_or_undefined(0)
+                    .to_string(context)?
+                    .to_std_string_escaped()
+                    .into_bytes(),
+                context,
+            )?)
+        };
+        // Step 2: "Set this’s headers to a new Headers object with this’s relevant realm, whose
+        // header list is this’s response’s header list and guard is \"response\"."
+        // Note: The Headers guard is not represented yet; the stable Headers object below exposes
+        // the initialized response header list but does not enforce guard "response". Construction
+        // is delayed until after ResponseInit parsing because headers are stored directly on
+        // `Response` instead of through a separate internal response object.
+        let init = response_init(args.get_or_undefined(1), context)?;
+        // Step 5: "Perform initialize a response given this, init, and bodyWithType."
+        if body.is_some() {
+            // Step 6.1: "If response’s status is a null body status, then throw a TypeError."
+            if is_null_body_status(init.status) {
+                return Err(type_error("Response body is not allowed for this status"));
+            }
+            // Step 6.2: "Set response’s body to body’s body."
+            // Note: The `body` field already holds the extracted Fetch body used to initialize
+            // the Response below.
+            // TODO: Step 6.3: "If body’s type is non-null and response’s header list does not
+            // contain `Content-Type`, then append (`Content-Type`, body’s type) to response’s
+            // header list."
+        }
+        let headers =
+            create_interface_instance::<Headers>(Headers::new(init.header_list.clone()), context)?;
+        Ok(Self::new(
+            body,
+            init.status,
+            init.status_text,
+            headers,
+        ))
+    }
+
+    fn define_members(def: &mut InterfaceDefinition) {
+        def.add_attribute(readonly_attribute("headers", response_headers_getter));
+        def.add_attribute(readonly_attribute("ok", response_ok_getter));
+        def.add_attribute(readonly_attribute("status", response_status_getter));
+        def.add_attribute(readonly_attribute(
+            "statusText",
+            response_status_text_getter,
+        ));
+        def.add_attribute(readonly_attribute("url", response_url_getter));
+        def.add_attribute(readonly_attribute("body", response_body_getter));
+        def.add_attribute(readonly_attribute("bodyUsed", response_body_used_getter));
+        def.add_operation(OperationDef {
+            id: "text",
+            length: 0,
+            method: response_text_method,
+            static_: false,
+            unforgeable: false,
+            promise_type: false,
+        });
+    }
+}
+
+struct ResponseInit {
+    status: u16,
+    status_text: String,
+    header_list: ContentHeaderList,
+}
+
+pub(crate) fn header_list_from_value(
+    value: &JsValue,
+    context: &mut Context,
+) -> JsResult<ContentHeaderList> {
+    // Note: This implements the `fill a Headers object with a given object` hook for the
+    // currently-supported HeadersInit shapes. Sequence support is incomplete; enumerable object
+    // records and existing Headers objects are preserved for current callers.
+    let Some(object) = value.as_object() else {
+        return Err(type_error("Headers init must be an object"));
+    };
+
+    if let Some(headers) = object.downcast_ref::<Headers>() {
+        return Ok(headers.header_list());
+    }
+
+    let keys = object.own_property_keys(context)?;
+    let mut headers = Vec::new();
+    for key in keys {
+        if !object.has_own_property(key.clone(), context)? {
+            continue;
+        }
+        let desc = object.borrow().properties().get(&key);
+        let enumerable = desc.as_ref().and_then(|d| d.enumerable()).unwrap_or(false);
+        if !enumerable {
+            continue;
+        }
+
+        let Some(name) = header_name_from_property_key(&key) else {
+            continue;
+        };
+        if !is_header_name(&name) {
+            return Err(type_error(format!("invalid header name `{name}`")));
+        }
+        let value = object
+            .get(key, context)?
+            .to_string(context)?
+            .to_std_string_escaped();
+        headers.push((name.to_ascii_lowercase(), value));
+    }
+
+    Ok(ContentHeaderList { headers })
+}
+
+/// <https://fetch.spec.whatwg.org/#initialize-a-response>
+fn response_init(value: &JsValue, context: &mut Context) -> JsResult<ResponseInit> {
+    // Note: This parses ResponseInit for the Response constructor's `initialize a response` step.
+    let mut init = ResponseInit {
+        status: 200,
+        status_text: String::new(),
+        header_list: ContentHeaderList::default(),
+    };
+
+    if value.is_null_or_undefined() {
+        return Ok(init);
+    }
+
+    let Some(object) = value.as_object() else {
+        return Err(type_error("Response init must be an object"));
+    };
+
+    let status = object.get(js_string("status"), context)?;
+    if !status.is_null_or_undefined() {
+        let status = status.to_u32(context)?;
+        // Step 1: "If init[\"status\"] is not in the range 200 to 599, inclusive, then throw a
+        // RangeError."
+        if !(200..=599).contains(&status) {
+            return Err(range_error(
+                "Response status must be in the range 200 to 599",
+            ));
+        }
+        // Step 3: "Set response’s response’s status to init[\"status\"]."
+        init.status = status as u16;
+    }
+
+    let status_text = object.get(js_string("statusText"), context)?;
+    if !status_text.is_null_or_undefined() {
+        let status_text = status_text.to_string(context)?.to_std_string_escaped();
+        // Step 2: "If init[\"statusText\"] is not the empty string and does not match the
+        // reason-phrase token production, then throw a TypeError."
+        if !status_text.is_empty() && !is_reason_phrase(&status_text) {
+            return Err(type_error("Response statusText must match reason-phrase"));
+        }
+        // Step 4: "Set response’s response’s status message to init[\"statusText\"]."
+        init.status_text = status_text;
+    }
+
+    let headers = object.get(js_string("headers"), context)?;
+    if !headers.is_null_or_undefined() {
+        // Step 5: "If init[\"headers\"] exists, then fill response’s headers with
+        // init[\"headers\"]."
+        init.header_list = header_list_from_value(&headers, context)?;
+    }
+
+    Ok(init)
+}
+
+fn headers_get_method(
+    this: &JsValue,
+    args: &[JsValue],
+    context: &mut Context,
+) -> JsResult<JsValue> {
+    let name = args
+        .get_or_undefined(0)
+        .to_string(context)?
+        .to_std_string_escaped();
+
+    // Step 1: "If name is not a header name, then throw a TypeError."
+    if !is_header_name(&name) {
+        return Err(type_error(format!("invalid header name `{name}`")));
+    }
+
+    with_headers_ref(this, |headers| {
+        // Step 2: "Return the result of getting name from this’s header list."
+        Ok(headers
+            .get(&name)
+            .map(|value| JsValue::from(JsString::from(value.as_str())))
+            .unwrap_or_else(JsValue::null))
+    })?
+}
+
+/// <https://fetch.spec.whatwg.org/#dom-response-headers>
+fn response_headers_getter(
+    this: &JsValue,
+    _args: &[JsValue],
+    _context: &mut Context,
+) -> JsResult<JsValue> {
+    with_response_ref(this, |response| {
+        // Step: "The headers getter steps are to return this’s headers."
+        JsValue::from(response.headers.clone())
+    })
+}
+
+/// <https://fetch.spec.whatwg.org/#dom-response-ok>
+fn response_ok_getter(
+    this: &JsValue,
+    _args: &[JsValue],
+    _context: &mut Context,
+) -> JsResult<JsValue> {
+    with_response_ref(this, |response| {
+        // Step: "The ok getter steps are to return true if this’s response’s status is an ok
+        // status; otherwise false."
+        JsValue::from((200..=299).contains(&response.status))
+    })
+}
+
+/// <https://fetch.spec.whatwg.org/#dom-response-status>
+fn response_status_getter(
+    this: &JsValue,
+    _args: &[JsValue],
+    _context: &mut Context,
+) -> JsResult<JsValue> {
+    with_response_ref(this, |response| {
+        // Step: "The status getter steps are to return this’s response’s status."
+        JsValue::from(response.status)
+    })
+}
+
+/// <https://fetch.spec.whatwg.org/#dom-response-statustext>
+fn response_status_text_getter(
+    this: &JsValue,
+    _args: &[JsValue],
+    _context: &mut Context,
+) -> JsResult<JsValue> {
+    with_response_ref(this, |response| {
+        // Step: "The statusText getter steps are to return this’s response’s status message."
+        JsValue::from(JsString::from(response.status_text.as_str()))
+    })
+}
+
+/// <https://fetch.spec.whatwg.org/#dom-response-url>
+fn response_url_getter(
+    this: &JsValue,
+    _args: &[JsValue],
+    _context: &mut Context,
+) -> JsResult<JsValue> {
+    with_response_ref(this, |response| {
+        // Step: "The url getter steps are to return the empty string if this’s response’s URL is
+        // null; otherwise this’s response’s URL, serialized with exclude fragment set to true."
+        let url = response
+            .url_list
+            .last()
+            .map(|url| serialized_url_without_fragment(url))
+            .unwrap_or_default();
+        JsValue::from(JsString::from(url.as_str()))
+    })
+}
+
+/// <https://fetch.spec.whatwg.org/#dom-body-body>
+fn response_body_getter(
+    this: &JsValue,
+    _args: &[JsValue],
+    _context: &mut Context,
+) -> JsResult<JsValue> {
+    with_response_ref(this, |response| {
+        // Step: "The body getter steps are to return null if this’s body is null; otherwise this’s
+        // body’s stream."
+        response
+            .body
+            .as_ref()
+            .map(|body| JsValue::from(body.stream_object()))
+            .unwrap_or_else(JsValue::null)
+    })
+}
+
+/// <https://fetch.spec.whatwg.org/#dom-body-bodyused>
+fn response_body_used_getter(
+    this: &JsValue,
+    _args: &[JsValue],
+    _context: &mut Context,
+) -> JsResult<JsValue> {
+    // Step: "The bodyUsed getter steps are to return true if this’s body is non-null and this’s
+    // body’s stream is disturbed; otherwise false."
+    with_response_ref(this, |response| JsValue::from(response.body_used()))
+}
+
+/// <https://fetch.spec.whatwg.org/#dom-body-text>
+fn response_text_method(
+    this: &JsValue,
+    _args: &[JsValue],
+    context: &mut Context,
+) -> JsResult<JsValue> {
+    // Step: "The text() method steps are to return the result of running consume body with this and UTF-8 decode."
+    with_response_ref(this, |response| consume_body_as_text(&response, context))?
+}
+
+/// <https://fetch.spec.whatwg.org/#concept-body-consume-body>
+fn consume_body_as_text(response: &Response, context: &mut Context) -> JsResult<JsValue> {
+    // Step 1: "If object is unusable, then return a promise rejected with a TypeError."
+    if response.body_unusable() {
+        let reason = JsNativeError::typ()
+            .with_message("body has already been consumed")
+            .into_opaque(context)
+            .into();
+        return rejected_promise(reason, context).map(JsValue::from);
+    }
+
+    // Step 2: "Let promise be a new promise."
+    let (promise, resolvers) = JsPromise::new_pending(context);
+    let promise_object: JsObject = promise.into();
+
+    // Step 3: "Let errorSteps given error be to reject promise with error."
+    // Note: `BodyTextReadState::reject` stores the promise resolver used by these steps.
+
+    // Step 4: "Let successSteps given a byte sequence data be to resolve promise with the result of
+    // running convertBytesToJSValue with data."
+    // Note: `BodyTextReadState::resolve_with_utf8_decode` performs the UTF-8 decode conversion for
+    // Body.text().
+
+    // Step 5: "If object’s body is null, then run successSteps with an empty byte sequence."
+    let Some(body) = response.body.as_ref() else {
+        let text = JsValue::from(JsString::from(""));
+        resolvers
+            .resolve
+            .call(&JsValue::undefined(), &[text], context)?;
+        return Ok(JsValue::from(promise_object));
+    };
+
+    // Step 6: "Otherwise, fully read object’s body given successSteps, errorSteps, and object’s
+    // relevant global object."
+    let reader_object = acquire_readable_stream_default_reader(body.stream.clone(), context)?;
+    let reader =
+        with_readable_stream_default_reader_ref(&reader_object, |reader| reader.clone())?;
+    let state = BodyTextReadState::new(reader, resolvers);
+    queue_body_text_read(state, context)?;
+
+    // Step 7: "Return promise."
+    Ok(JsValue::from(promise_object))
+}
+
+/// <https://streams.spec.whatwg.org/#readablestreamdefaultreader-read-all-bytes>
+fn queue_body_text_read(state: BodyTextReadState, context: &mut Context) -> JsResult<()> {
+    // Step: "To read all bytes from a ReadableStreamDefaultReader reader... read-loop given reader,
+    // a new byte sequence, successSteps, and failureSteps."
+    // Step 1: "Let readRequest be a new read request with the following items:"
+    // Note: The local Streams API exposes the read request through `ReadableStreamDefaultReader.read()`;
+    // the fulfillment and rejection callbacks below implement the read request items.
+    // Step 2: "Perform ! ReadableStreamDefaultReaderRead(reader, readRequest)."
+    let read_promise = state.reader.read(context)?;
+    let on_fulfilled = NativeFunction::from_copy_closure_with_captures(
+        |_, args, state: &BodyTextReadState, context| {
+            handle_body_text_read_result(args.get_or_undefined(0), state.clone(), context)?;
+            Ok(JsValue::undefined())
+        },
+        state.clone(),
+    )
+    .to_js_function(context.realm());
+    let on_rejected = NativeFunction::from_copy_closure_with_captures(
+        |_, args, state: &BodyTextReadState, context| {
+            // Step error steps 1: "Call failureSteps with e."
+            state.reject(args.get_or_undefined(0).clone(), context)?;
+            Ok(JsValue::undefined())
+        },
+        state,
+    )
+    .to_js_function(context.realm());
+    let reaction: JsObject = JsPromise::from_object(read_promise)?
+        .then(Some(on_fulfilled), Some(on_rejected), context)?
+        .into();
+    mark_promise_as_handled(&reaction, context)?;
+    Ok(())
+}
+
+/// <https://streams.spec.whatwg.org/#read-loop>
+fn handle_body_text_read_result(
+    read_result: &JsValue,
+    state: BodyTextReadState,
+    context: &mut Context,
+) -> JsResult<()> {
+    let read_result_object = read_result.as_object().ok_or_else(|| {
+        JsNativeError::typ().with_message("ReadableStream reader result must be an object")
+    })?;
+    let done = read_result_object
+        .get(js_string("done"), context)?
+        .to_boolean();
+
+    if done {
+        // Step close steps 1: "Call successSteps with bytes."
+        state.resolve_with_utf8_decode(context)?;
+        return Ok(());
+    }
+
+    let chunk = read_result_object.get(js_string("value"), context)?;
+    let chunk_bytes = match bytes_from_uint8_array(&chunk, context) {
+        Ok(bytes) => bytes,
+        Err(error) => {
+            // Step chunk steps 1: "If chunk is not a Uint8Array object, call failureSteps with a
+            // TypeError and abort these steps."
+            state.reject(error.into_opaque(context)?.into(), context)?;
+            return Ok(());
+        }
+    };
+
+    // Step chunk steps 2: "Append the bytes represented by chunk to bytes."
+    state.bytes.borrow_mut().extend(chunk_bytes);
+
+    // Step chunk steps 3: "Read-loop given reader, bytes, successSteps, and failureSteps."
+    queue_body_text_read(state, context)
+}
+
+#[derive(Clone, Trace, Finalize)]
+struct BodyTextReadState {
+    reader: ReadableStreamDefaultReader,
+    bytes: Gc<GcRefCell<Vec<u8>>>,
+    resolvers: ResolvingFunctions,
+}
+
+impl BodyTextReadState {
+    fn new(reader: ReadableStreamDefaultReader, resolvers: ResolvingFunctions) -> Self {
+        Self {
+            reader,
+            bytes: Gc::new(GcRefCell::new(Vec::new())),
+            resolvers,
+        }
+    }
+
+    fn resolve_with_utf8_decode(&self, context: &mut Context) -> JsResult<()> {
+        let bytes = self.bytes.borrow();
+        let decoded_text = String::from_utf8_lossy(&bytes).into_owned();
+        // Note: Fetch's Body.text() conversion uses UTF-8 decode, which strips one leading BOM.
+        let text = decoded_text
+            .strip_prefix('\u{feff}')
+            .unwrap_or(decoded_text.as_str());
+        self.resolvers.resolve.call(
+            &JsValue::undefined(),
+            &[JsValue::from(JsString::from(text))],
+            context,
+        )?;
+        Ok(())
+    }
+
+    fn reject(&self, reason: JsValue, context: &mut Context) -> JsResult<()> {
+        self.resolvers
+            .reject
+            .call(&JsValue::undefined(), &[reason], context)?;
+        Ok(())
+    }
+}
+
+fn readonly_attribute(
+    id: &'static str,
+    getter: fn(&JsValue, &[JsValue], &mut Context) -> JsResult<JsValue>,
+) -> AttributeDef {
+    AttributeDef {
+        id,
+        getter,
+        setter: None,
+        static_: false,
+        unforgeable: false,
+        promise_type: false,
+        legacy_lenient_this: false,
+        replaceable: false,
+        put_forwards: None,
+        legacy_lenient_setter: false,
+    }
+}
+
+fn serialized_url_without_fragment(url: &str) -> String {
+    let Ok(mut parsed_url) = url::Url::parse(url) else {
+        return url.to_owned();
+    };
+    parsed_url.set_fragment(None);
+    parsed_url.to_string()
+}
+
+fn bytes_from_uint8_array(value: &JsValue, context: &mut Context) -> JsResult<Vec<u8>> {
+    let object = value
+        .as_object()
+        .ok_or_else(|| JsNativeError::typ().with_message("chunk is not a Uint8Array object"))?;
+    let array = JsUint8Array::from_object(object.clone())?;
+    array.to_vec(context)
+}
+
+fn with_headers_ref<R>(this: &JsValue, f: impl FnOnce(GcRef<'_, Headers>) -> R) -> JsResult<R> {
+    let Some(object) = this.as_object() else {
+        return Err(type_error("receiver is not a Headers"));
+    };
+    let Some(headers) = object.downcast_ref::<Headers>() else {
+        return Err(type_error("receiver is not a Headers"));
+    };
+    Ok(f(headers))
+}
+
+fn with_response_ref<R>(this: &JsValue, f: impl FnOnce(GcRef<'_, Response>) -> R) -> JsResult<R> {
+    let Some(object) = this.as_object() else {
+        return Err(type_error("receiver is not a Response"));
+    };
+    let Some(response) = object.downcast_ref::<Response>() else {
+        return Err(type_error("receiver is not a Response"));
+    };
+    Ok(f(response))
+}
+
+fn header_name_from_property_key(key: &PropertyKey) -> Option<String> {
+    match key {
+        PropertyKey::String(name) => Some(name.to_std_string_escaped()),
+        PropertyKey::Index(index) => Some(index.get().to_string()),
+        PropertyKey::Symbol(_) => None,
+    }
+}
+
+fn is_header_name(name: &str) -> bool {
+    !name.is_empty()
+        && name.bytes().all(|byte| {
+            matches!(
+                byte,
+                b'!' | b'#'
+                    | b'$'
+                    | b'%'
+                    | b'&'
+                    | b'\''
+                    | b'*'
+                    | b'+'
+                    | b'-'
+                    | b'.'
+                    | b'^'
+                    | b'_'
+                    | b'`'
+                    | b'|'
+                    | b'~'
+                    | b'0'..=b'9'
+                    | b'A'..=b'Z'
+                    | b'a'..=b'z'
+            )
+        })
+}
+
+fn is_null_body_status(status: u16) -> bool {
+    matches!(status, 101 | 103 | 204 | 205 | 304)
+}
+
+fn is_reason_phrase(value: &str) -> bool {
+    value
+        .chars()
+        .all(|character| matches!(character, '\t' | ' '..='~' | '\u{80}'..='\u{ff}'))
+}
+
+fn js_string(value: &'static str) -> JsString {
+    JsString::from(value)
+}
+
+fn range_error(message: impl Into<String>) -> boa_engine::JsError {
+    JsNativeError::range().with_message(message.into()).into()
+}
+
+fn type_error(message: impl Into<String>) -> boa_engine::JsError {
+    JsNativeError::typ().with_message(message.into()).into()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{cell::RefCell, rc::Rc};
+
+    use blitz_dom::{BaseDocument, DocumentConfig};
+    use url::Url;
+
+    use crate::html::EnvironmentSettingsObject;
+
+    fn environment_settings_object() -> EnvironmentSettingsObject {
+        let document = Rc::new(RefCell::new(BaseDocument::new(DocumentConfig::default())));
+        EnvironmentSettingsObject::new(
+            document,
+            Url::parse("https://example.test/").expect("test URL must parse"),
+            None,
+            None,
+            None,
+        )
+        .expect("environment settings object must initialize")
+    }
+
+    #[test]
+    fn headers_get_combines_case_insensitive_values() {
+        let mut settings = environment_settings_object();
+        let value = settings
+            .evaluate_script_to_json(
+                r#"
+                const headers = new Headers({ "X-Test": "one", "x-test": "two" });
+                ({
+                    exact: headers.get("x-test"),
+                    missing: headers.get("missing") === null,
+                });
+                "#,
+            )
+            .expect("headers script must evaluate");
+
+        assert_eq!(
+            value,
+            serde_json::json!({
+                "exact": "one, two",
+                "missing": true,
+            })
+        );
+    }
+
+    #[test]
+    fn response_text_consumes_body_once() {
+        let mut settings = environment_settings_object();
+        settings
+            .evaluate_script(
+                r#"
+                globalThis.fetchTestResult = null;
+                const response = new Response("hello", {
+                    status: 201,
+                    statusText: "Created",
+                    headers: { "Content-Type": "text/plain" },
+                });
+                const before = response.bodyUsed;
+                response.text().then(text => {
+                    const afterFirst = response.bodyUsed;
+                    response.text().then(
+                        () => { globalThis.fetchTestResult = { unexpected: true }; },
+                        error => {
+                            globalThis.fetchTestResult = {
+                                text,
+                                before,
+                                afterFirst,
+                                afterSecond: response.bodyUsed,
+                                ok: response.ok,
+                                status: response.status,
+                                statusText: response.statusText,
+                                contentType: response.headers.get("content-type"),
+                                errorName: error.name,
+                            };
+                        },
+                    );
+                });
+                "#,
+            )
+            .expect("response script must evaluate");
+
+        let value = settings
+            .evaluate_script_to_json("globalThis.fetchTestResult")
+            .expect("result must serialize");
+
+        assert_eq!(
+            value,
+            serde_json::json!({
+                "text": "hello",
+                "before": false,
+                "afterFirst": true,
+                "afterSecond": true,
+                "ok": true,
+                "status": 201,
+                "statusText": "Created",
+                "contentType": "text/plain",
+                "errorName": "TypeError",
+            })
+        );
+    }
+}

--- a/content/src/html/global_scope.rs
+++ b/content/src/html/global_scope.rs
@@ -7,14 +7,12 @@ use std::{
 use super::environment_settings_object::EnvironmentSettingsObject;
 
 use blitz_dom::BaseDocument;
-use boa_engine::{JsValue, object::JsObject};
+use boa_engine::{JsValue, builtins::promise::ResolvingFunctions, object::JsObject};
 use boa_gc::{Finalize, GcRefCell, Trace};
 use ipc_channel::ipc::IpcSender;
-use ipc_messages::{
-    content::{
-        DocumentId, Event as ContentEvent, NavigableId, WindowTimerClearRequest,
-        WindowTimerKey, WindowTimerRequest,
-    },
+use ipc_messages::content::{
+    DocumentFetchId, DocumentId, Event as ContentEvent, NavigableId, WindowTimerClearRequest,
+    WindowTimerKey, WindowTimerRequest,
 };
 
 use crate::webidl::Callback;
@@ -97,6 +95,17 @@ pub struct WindowTimer {
     pub timeout_ms: u32,
 }
 
+#[derive(Trace, Finalize)]
+pub struct PendingFetchPromise {
+    // Note: This stores the JavaScript promise resolver for an in-flight
+    // formal-web fetch request. The key is a formal-web callback ID, not a
+    // Fetch Standard concept.
+    #[unsafe_ignore_trace]
+    handler_id: DocumentFetchId,
+
+    resolving_functions: ResolvingFunctions,
+}
+
 #[derive(Clone)]
 struct TimerHost {
     document_id: DocumentId,
@@ -141,6 +150,8 @@ pub struct GlobalScope {
     #[unsafe_ignore_trace]
     current_timer_nesting_level: Cell<Option<u32>>,
 
+    pending_fetch_promises: GcRefCell<Vec<PendingFetchPromise>>,
+
     #[unsafe_ignore_trace]
     timer_host: RefCell<Option<TimerHost>>,
 
@@ -178,7 +189,6 @@ pub struct GlobalScope {
     /// The creation URL of this window's Document.
     #[unsafe_ignore_trace]
     creation_url: RefCell<Option<url::Url>>,
-
 }
 
 impl GlobalScope {
@@ -194,6 +204,7 @@ impl GlobalScope {
             timer_callback_identifier: Cell::new(0),
             window_timers: GcRefCell::new(Vec::new()),
             current_timer_nesting_level: Cell::new(None),
+            pending_fetch_promises: GcRefCell::new(Vec::new()),
             timer_host: RefCell::new(None),
             source_navigable_id: Cell::new(None),
             parent_traversable_id: Cell::new(None),
@@ -273,6 +284,39 @@ impl GlobalScope {
 
     pub(crate) fn event_sender(&self) -> Option<IpcSender<ContentEvent>> {
         self.event_sender.borrow().clone()
+    }
+
+    pub(crate) fn document_id(&self) -> Option<DocumentId> {
+        self.timer_host
+            .borrow()
+            .as_ref()
+            .map(|host| host.document_id)
+    }
+
+    pub(crate) fn store_fetch_resolvers(
+        &self,
+        handler_id: DocumentFetchId,
+        resolving_functions: ResolvingFunctions,
+    ) {
+        self.pending_fetch_promises
+            .borrow_mut()
+            .push(PendingFetchPromise {
+                handler_id,
+                resolving_functions,
+            });
+    }
+
+    pub(crate) fn take_fetch_resolvers(
+        &self,
+        handler_id: DocumentFetchId,
+    ) -> Option<ResolvingFunctions> {
+        let mut promises = self.pending_fetch_promises.borrow_mut();
+        let index = promises
+            .iter()
+            .position(|promise| promise.handler_id == handler_id)?;
+        let resolving_functions = promises[index].resolving_functions.clone();
+        promises.remove(index);
+        Some(resolving_functions)
     }
 
     pub(crate) fn set_timer_host(

--- a/content/src/html/window_or_worker_global_scope.rs
+++ b/content/src/html/window_or_worker_global_scope.rs
@@ -1,7 +1,16 @@
-use boa_engine::{Context, JsError, JsNativeError, JsResult, JsValue};
+use boa_engine::{
+    Context, JsError, JsNativeError, JsResult, JsString, JsValue,
+    builtins::promise::ResolvingFunctions,
+    object::{JsObject, builtins::JsPromise},
+};
+use ipc_messages::content::{
+    Event as ContentEvent, FetchRequest as ContentFetchRequest, HeaderList as ContentHeaderList,
+};
+use url::Url;
 
-use crate::html::{GlobalScope, TimerHandler, Window};
-use crate::webidl::Callback;
+use crate::html::{GlobalScope, TimerHandler, Window, header_list_from_value};
+use crate::new_document_fetch_id;
+use crate::webidl::{Callback, error_to_rejection_reason};
 
 use crate::html::safe_passing_of_structured_data::{self, StructuredCloneOptions};
 
@@ -69,6 +78,74 @@ pub(crate) trait WindowOrWorkerGlobalScope {
         self.global_scope().clear_timer(timer_id);
     }
 
+    /// <https://fetch.spec.whatwg.org/#fetch-method>
+    fn fetch(&self, input: &JsValue, init: &JsValue, context: &mut Context) -> JsResult<JsValue> {
+        // Step 1: "Let p be a new promise."
+        let (promise, resolvers) = JsPromise::new_pending(context);
+        let promise_object: JsObject = promise.into();
+
+        if let Err(error) = self.queue_fetch(input, init, &resolvers, context) {
+            let reason = error_to_rejection_reason(error, context);
+            reject_fetch_promise(&resolvers, reason, context)?;
+        }
+
+        // Step 13: "Return p."
+        Ok(JsValue::from(promise_object))
+    }
+
+    fn queue_fetch(
+        &self,
+        input: &JsValue,
+        init: &JsValue,
+        resolvers: &ResolvingFunctions,
+        context: &mut Context,
+    ) -> JsResult<()> {
+        // Step 2: "Let requestObject be the result of invoking the initial value of Request as constructor with input and init as arguments. If this throws an exception, reject p with it and return p."
+        // Note: Formal-web does not expose the Request class yet. The helper below constructs the
+        // subset of request fields that the existing IPC path can transport.
+        let request = fetch_request_from_input_and_init(input, init, self.global_scope(), context)?;
+
+        // TODO: Step 3: "Let request be requestObject’s request."
+        // TODO: Step 4: "If requestObject’s signal is aborted, then:"
+        // TODO: Step 5: "Let globalObject be request’s client’s global object."
+        // TODO: Step 6: "If globalObject is a ServiceWorkerGlobalScope object, then set request’s service-workers mode to \"none\"."
+        // TODO: Step 7: "Let responseObject be null."
+        // TODO: Step 8: "Let relevantRealm be this’s relevant realm."
+        // TODO: Step 9: "Let locallyAborted be false."
+        // TODO: Step 10: "Let controller be null."
+        // TODO: Step 11: "Add the following abort steps to requestObject’s signal:"
+        // TODO: Step 12: "Set controller to the result of calling fetch given request and processResponse given response being these steps:"
+        // TODO: Step 12 processResponse 1: "If locallyAborted is true, then abort these steps."
+        // TODO: Step 12 processResponse 2: "If response’s aborted flag is set, then:"
+        // TODO: Step 12 processResponse 3: "If response is a network error, then reject p with a TypeError and abort these steps."
+        // Note: The IPC request below is formal-web callback plumbing. It starts the user-agent
+        // fetch worker and resumes the Fetch method's processResponse continuation in the content
+        // process when the callback ID completes.
+        let handler_id = new_document_fetch_id();
+        self.global_scope()
+            .store_fetch_resolvers(handler_id, resolvers.clone());
+
+        let Some(event_sender) = self.global_scope().event_sender() else {
+            self.global_scope().take_fetch_resolvers(handler_id);
+            return Err(type_error(
+                "fetch is not available without a content event sender",
+            ));
+        };
+
+        event_sender
+            .send(ContentEvent::DocumentFetchRequested(ContentFetchRequest {
+                handler_id,
+                url: request.url.to_string(),
+                method: request.method,
+                header_list: request.header_list,
+                body: request.body,
+            }))
+            .map_err(|error| {
+                self.global_scope().take_fetch_resolvers(handler_id);
+                type_error(format!("failed to send fetch request: {error}"))
+            })
+    }
+
     /// <https://html.spec.whatwg.org/#timer-initialisation-steps>
     fn timer_initialization_steps(
         &self,
@@ -134,6 +211,96 @@ impl WindowOrWorkerGlobalScope for Window {
     }
 }
 
+struct WindowFetchRequest {
+    url: Url,
+    method: String,
+    header_list: ContentHeaderList,
+    body: String,
+}
+
+fn fetch_request_from_input_and_init(
+    input: &JsValue,
+    init: &JsValue,
+    global_scope: &GlobalScope,
+    context: &mut Context,
+) -> JsResult<WindowFetchRequest> {
+    let input = input.to_string(context)?.to_std_string_escaped();
+    let base_url = global_scope
+        .creation_url()
+        .ok_or_else(|| type_error("fetch is not available without a creation URL"))?;
+    let url = base_url
+        .join(&input)
+        .map_err(|error| type_error(format!("failed to parse fetch URL `{input}`: {error}")))?;
+    if !url.username().is_empty() || url.password().is_some() {
+        return Err(type_error("fetch URL must not include credentials"));
+    }
+    if global_scope.document_id().is_none() {
+        return Err(type_error("fetch is not available without a document"));
+    }
+
+    let init = fetch_request_init(init, context)?;
+    Ok(WindowFetchRequest {
+        url,
+        method: init.method,
+        header_list: init.header_list,
+        body: init.body,
+    })
+}
+
+struct WindowFetchRequestInit {
+    method: String,
+    header_list: ContentHeaderList,
+    body: String,
+}
+
+fn fetch_request_init(value: &JsValue, context: &mut Context) -> JsResult<WindowFetchRequestInit> {
+    let mut init = WindowFetchRequestInit {
+        method: String::from("GET"),
+        header_list: ContentHeaderList::default(),
+        body: String::new(),
+    };
+
+    if value.is_null_or_undefined() {
+        return Ok(init);
+    }
+
+    let Some(object) = value.as_object() else {
+        return Err(type_error("fetch init must be an object"));
+    };
+
+    let method = object.get(js_string("method"), context)?;
+    if !method.is_null_or_undefined() {
+        init.method = method.to_string(context)?.to_std_string_escaped();
+    }
+
+    let headers = object.get(js_string("headers"), context)?;
+    if !headers.is_null_or_undefined() {
+        init.header_list = header_list_from_value(&headers, context)?;
+    }
+
+    let body = object.get(js_string("body"), context)?;
+    if !body.is_null_or_undefined() {
+        init.body = body.to_string(context)?.to_std_string_escaped();
+    }
+
+    Ok(init)
+}
+
+fn reject_fetch_promise(
+    resolvers: &ResolvingFunctions,
+    reason: JsValue,
+    context: &mut Context,
+) -> JsResult<()> {
+    resolvers
+        .reject
+        .call(&JsValue::undefined(), &[reason], context)
+        .map(|_| ())
+}
+
+fn js_string(value: &'static str) -> JsString {
+    JsString::from(value)
+}
+
 fn timer_handler(value: &JsValue, context: &mut Context) -> JsResult<TimerHandler> {
     if let Some(object) = value.as_object() {
         if object.is_callable() {
@@ -158,4 +325,8 @@ fn timeout_ms(value: &JsValue, context: &mut Context) -> JsResult<u32> {
 
 fn internal_error(message: String) -> JsError {
     JsError::from(JsNativeError::typ().with_message(message))
+}
+
+fn type_error(message: impl Into<String>) -> JsError {
+    JsError::from(JsNativeError::typ().with_message(message.into()))
 }

--- a/content/src/js/bindings/html/host_hooks.rs
+++ b/content/src/js/bindings/html/host_hooks.rs
@@ -17,7 +17,8 @@ use crate::dom::{
     UIEvent,
 };
 use crate::html::{
-    GlobalScope, HTMLAnchorElement, HTMLElement, HTMLIFrameElement, Location, Window,
+    GlobalScope, HTMLAnchorElement, HTMLElement, HTMLIFrameElement, Headers, Location, Response,
+    Window,
 };
 use crate::streams::{
     ByteLengthQueuingStrategy, CountQueuingStrategy, ReadableByteStreamController, ReadableStream,
@@ -89,6 +90,8 @@ pub(crate) fn build_boa_context(document: Rc<RefCell<BaseDocument>>) -> Result<C
     reg!(HTMLIFrameElement);
     reg!(Window);
     reg!(Location);
+    reg!(Headers);
+    reg!(Response);
     reg!(ByteLengthQueuingStrategy);
     reg!(CountQueuingStrategy);
     reg!(ReadableStream);

--- a/content/src/js/bindings/html/window.rs
+++ b/content/src/js/bindings/html/window.rs
@@ -157,7 +157,22 @@ impl WebIdlInterface for Window {
             unforgeable: false,
             promise_type: false,
         });
+        def.add_operation(OperationDef {
+            id: "fetch",
+            length: 1,
+            method: fetch_method,
+            static_: false,
+            unforgeable: false,
+            promise_type: false,
+        });
     }
+}
+
+fn fetch_method(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    let window_object = current_window_object(this, context);
+    let window = downcast_window(&window_object)?;
+
+    window.fetch(args.get_or_undefined(0), args.get_or_undefined(1), context)
 }
 
 fn structured_clone_method(

--- a/content/src/main.rs
+++ b/content/src/main.rs
@@ -15,16 +15,19 @@ use crate::dom::{
 };
 use crate::html::{
     EnvironmentSettingsObject, JsHtmlParserProvider, PendingParserScript,
-    attach_same_origin_child_document_for_traversable, execute_parser_scripts,
-    parse_html_into_document, run_dom_post_connection_steps_for_document,
+    Response as FetchResponseObject, attach_same_origin_child_document_for_traversable,
+    execute_parser_scripts, parse_html_into_document, run_dom_post_connection_steps_for_document,
     run_dom_removing_steps_for_document, run_iframe_load_event_steps_for_traversable,
 };
+use crate::js::platform_objects::with_global_scope;
 use crate::ui_event::deserialize_ui_event;
+use crate::webidl::bindings::create_interface_instance;
 use anyrender::Scene as RenderScene;
 use blitz_dom::{BaseDocument, DocumentConfig};
 use blitz_paint::paint_scene;
 use blitz_traits::net::{Body, Bytes, NetHandler, NetProvider, Request};
 use blitz_traits::shell::{ClipboardError, ColorScheme, ShellProvider, Viewport};
+use boa_engine::{JsNativeError, JsValue};
 use data_url::DataUrl;
 use ipc_channel::ipc::{self, IpcSender};
 use ipc_messages::content::Command::{
@@ -37,9 +40,10 @@ use ipc_messages::content::{
     ColorScheme as MessageColorScheme, Command, DispatchEventEntry, DocumentFetchId, DocumentId,
     ElementClickResult, EmbedBackgroundPolicy, EmbedSiteId, Event as ContentEvent, EventLoopId,
     FetchRequest as ContentFetchRequest, FetchResponse as ContentFetchResponse,
-    FontTransportSender, FrameCompositionMetadata, FrameEmbedSite, FrameId, LoadedDocumentResponse,
-    NavigableId, NavigationId, PaintFrame, ScriptEvaluationResult, TraversableViewport,
-    ViewportSnapshot, WebviewId, WindowTimerKey,
+    FontTransportSender, FrameCompositionMetadata, FrameEmbedSite, FrameId,
+    HeaderList as ContentHeaderList, LoadedDocumentResponse, NavigableId, NavigationId,
+    PaintFrame, ScriptEvaluationResult, TraversableViewport, ViewportSnapshot, WebviewId,
+    WindowTimerKey,
 };
 use std::{
     cell::RefCell,
@@ -78,12 +82,27 @@ fn is_javascript_mime_essence(essence: &str) -> bool {
     )
 }
 
+fn response_content_type(response: &ContentFetchResponse) -> String {
+    if !response.content_type.is_empty() {
+        return response.content_type.clone();
+    }
+
+    response
+        .header_list
+        .headers
+        .iter()
+        .find(|(name, _value)| name.eq_ignore_ascii_case("content-type"))
+        .map(|(_name, value)| value.clone())
+        .unwrap_or_default()
+}
+
 fn deferred_script_response_is_executable(response: &ContentFetchResponse) -> bool {
     if !(200..=299).contains(&response.status) {
         return false;
     }
 
-    let essence = normalized_content_type_essence(&response.content_type);
+    let content_type = response_content_type(response);
+    let essence = normalized_content_type_essence(&content_type);
     essence.is_empty() || is_javascript_mime_essence(&essence)
 }
 
@@ -186,6 +205,30 @@ fn request_body_string(body: &Body) -> String {
     }
 }
 
+fn request_header_list(request: &Request) -> ContentHeaderList {
+    let mut headers = request
+        .headers
+        .iter()
+        .map(|(name, value)| {
+            (
+                name.as_str().to_owned(),
+                String::from_utf8_lossy(value.as_bytes()).into_owned(),
+            )
+        })
+        .collect::<Vec<_>>();
+
+    if let Some(content_type) = request.content_type.as_ref() {
+        let has_content_type = headers
+            .iter()
+            .any(|(name, _value)| name.eq_ignore_ascii_case("content-type"));
+        if !has_content_type {
+            headers.push((String::from("content-type"), content_type.clone()));
+        }
+    }
+
+    ContentHeaderList { headers }
+}
+
 fn viewport_of_snapshot(snapshot: &ViewportSnapshot) -> Viewport {
     let color_scheme = match snapshot.color_scheme {
         MessageColorScheme::Light => ColorScheme::Light,
@@ -273,6 +316,8 @@ struct ContentNetProvider {
 impl NetProvider for ContentNetProvider {
     fn fetch(&self, _doc_id: usize, request: Request, handler: Box<dyn NetHandler>) {
         match request.url.scheme() {
+            // Note: data: resource fetches still use the local content shortcut and bypass the
+            // Fetch-shaped response metadata pipeline.
             "data" => match DataUrl::process(request.url.as_str()) {
                 Ok(data_url) => match data_url.decode_to_vec() {
                     Ok((bytes, _fragment)) => {
@@ -302,6 +347,7 @@ impl NetProvider for ContentNetProvider {
                         handler_id,
                         url: request.url.to_string(),
                         method: request.method.to_string(),
+                        header_list: request_header_list(&request),
                         body: request_body_string(&request.body),
                     },
                 )) {
@@ -501,6 +547,7 @@ impl ContentProcess {
                 handler_id,
                 url: request.url.to_string(),
                 method: request.method.to_string(),
+                header_list: request_header_list(&request),
                 body: request_body_string(&request.body),
             }))
             .map_err(|error| {
@@ -575,6 +622,8 @@ impl ContentProcess {
             .map_err(|error| format!("failed to resolve deferred script URL `{src}`: {error}"))?;
 
         if resolved_url.scheme() == "data" {
+            // Note: data: deferred scripts still use the local content shortcut and bypass the
+            // Fetch-shaped response metadata pipeline.
             let (bytes, _fragment) = DataUrl::process(resolved_url.as_str())
                 .map_err(|error| format!("failed to decode deferred data script URL: {error}"))?
                 .decode_to_vec()
@@ -890,6 +939,7 @@ impl ContentProcess {
             status: _,
             content_type: _,
             body,
+            ..
         } = response;
         let viewport_state = self.document_viewport_state(traversable_id);
         let frame_id = frame_id.unwrap_or_else(FrameId::new);
@@ -951,7 +1001,9 @@ impl ContentProcess {
 
         // Set the navigable hierarchy on the GlobalScope so that `window.open`
         // can resolve `_parent`/`_top` targets.
-        let _ = self.set_navigable_hierarchy_on_global_scope(document_id);
+        if let Err(error) = self.set_navigable_hierarchy_on_global_scope(document_id) {
+            eprintln!("failed to set navigable hierarchy on global scope: {error}");
+        }
 
         run_dom_post_connection_steps_for_document(self, document_id)?;
 
@@ -1358,7 +1410,7 @@ impl ContentProcess {
     ) -> Result<(), String> {
         let response_url = response.final_url.clone();
         let response_status = response.status;
-        let response_type = response.content_type.clone();
+        let response_type = response_content_type(&response);
         let pending_handler = {
             let mut local_state = self
                 .local_state
@@ -1368,6 +1420,7 @@ impl ContentProcess {
         };
 
         let Some(pending_handler) = pending_handler else {
+            self.complete_window_fetch(handler_id, response)?;
             return Ok(());
         };
 
@@ -1410,7 +1463,7 @@ impl ContentProcess {
                 } else {
                     eprintln!(
                         "content deferred script rejected: url={} status={} content-type={}",
-                        response.final_url, response.status, response.content_type,
+                        response.final_url, response.status, response_type,
                     );
                     self.mark_deferred_script_failed(document_id, script_index);
                 }
@@ -1442,6 +1495,57 @@ impl ContentProcess {
         }
     }
 
+    fn complete_window_fetch(
+        &mut self,
+        handler_id: DocumentFetchId,
+        response: ContentFetchResponse,
+    ) -> Result<bool, String> {
+        let mut response = Some(response);
+
+        for content_document in self.documents.values_mut() {
+            let resolvers = with_global_scope(&content_document.settings.context, |global_scope| {
+                Ok(global_scope.take_fetch_resolvers(handler_id))
+            })
+            .map_err(|error| error.to_string())?;
+
+            let Some(resolvers) = resolvers else {
+                continue;
+            };
+
+            let response = response
+                .take()
+                .expect("window fetch response should be consumed once");
+            // Note: This is formal-web callback plumbing for the `fetch(input, init)` method's
+            // processResponse continuation. The Fetch method stored the JavaScript promise
+            // resolver under `handler_id`; this branch resumes it after the user-agent fetch worker
+            // returns response metadata and body bytes.
+            // Step 12 processResponse 4: "Set responseObject to the result of creating a Response object, given response, \"immutable\", and relevantRealm."
+            let response_data = FetchResponseObject::from_content_fetch_response(
+                response,
+                &mut content_document.settings.context,
+            )
+            .map_err(|error| error.to_string())?;
+            let response_object = create_interface_instance::<FetchResponseObject>(
+                response_data,
+                &mut content_document.settings.context,
+            )
+            .map_err(|error| error.to_string())?;
+            // Step 12 processResponse 5: "Resolve p with responseObject."
+            resolvers
+                .resolve
+                .call(
+                    &JsValue::undefined(),
+                    &[JsValue::from(response_object)],
+                    &mut content_document.settings.context,
+                )
+                .map_err(|error| error.to_string())?;
+            content_document.settings.perform_a_microtask_checkpoint()?;
+            return Ok(true);
+        }
+
+        Ok(false)
+    }
+
     fn fail_document_fetch(&mut self, handler_id: DocumentFetchId) -> Result<(), String> {
         let pending_handler = {
             let mut local_state = self
@@ -1452,6 +1556,7 @@ impl ContentProcess {
         };
 
         let Some(pending_handler) = pending_handler else {
+            self.fail_window_fetch(handler_id)?;
             return Ok(());
         };
 
@@ -1500,6 +1605,39 @@ impl ContentProcess {
                 Ok(())
             }
         }
+    }
+
+    fn fail_window_fetch(&mut self, handler_id: DocumentFetchId) -> Result<bool, String> {
+        for content_document in self.documents.values_mut() {
+            let resolvers = with_global_scope(&content_document.settings.context, |global_scope| {
+                Ok(global_scope.take_fetch_resolvers(handler_id))
+            })
+            .map_err(|error| error.to_string())?;
+
+            let Some(resolvers) = resolvers else {
+                continue;
+            };
+
+            // Step 12 processResponse 3: "If response is a network error, then reject p with a TypeError and abort these steps."
+            // Note: Formal-web reports transport failure through `DocumentFetchFailed` rather than
+            // constructing a Fetch Standard network error response object.
+            let reason = JsNativeError::typ()
+                .with_message("fetch failed")
+                .into_opaque(&mut content_document.settings.context)
+                .into();
+            resolvers
+                .reject
+                .call(
+                    &JsValue::undefined(),
+                    &[reason],
+                    &mut content_document.settings.context,
+                )
+                .map_err(|error| error.to_string())?;
+            content_document.settings.perform_a_microtask_checkpoint()?;
+            return Ok(true);
+        }
+
+        Ok(false)
     }
 
     fn run_window_timer(

--- a/content/src/streams/readablestream.rs
+++ b/content/src/streams/readablestream.rs
@@ -122,6 +122,11 @@ impl ReadableStream {
         self.disturbed.set(disturbed);
     }
 
+    /// <https://streams.spec.whatwg.org/#readablestream-disturbed>
+    pub(crate) fn disturbed(&self) -> bool {
+        self.disturbed.get()
+    }
+
     /// <https://streams.spec.whatwg.org/#initialize-readable-stream>
     fn initialize_readable_stream(&mut self) {
         // Step 1: "Set stream.[[state]] to \"readable\"."

--- a/ipc_messages/src/content.rs
+++ b/ipc_messages/src/content.rs
@@ -83,18 +83,33 @@ pub struct Bootstrap {
     pub event_loop_id: EventLoopId,
 }
 
+// Note: Transport mirror of Fetch's header-list shape.
+// Fetch semantics are owned by user_agent/fetch.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HeaderList {
+    pub headers: Vec<(String, String)>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct FetchRequest {
     pub handler_id: DocumentFetchId,
     pub url: String,
     pub method: String,
+    #[serde(default)]
+    pub header_list: HeaderList,
     pub body: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct LoadedDocumentResponse {
     pub final_url: String,
+    #[serde(default)]
+    pub url_list: Vec<String>,
     pub status: u16,
+    #[serde(default)]
+    pub status_text: String,
+    #[serde(default)]
+    pub header_list: HeaderList,
     pub content_type: String,
     pub body: String,
 }
@@ -102,7 +117,13 @@ pub struct LoadedDocumentResponse {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct FetchResponse {
     pub final_url: String,
+    #[serde(default)]
+    pub url_list: Vec<String>,
     pub status: u16,
+    #[serde(default)]
+    pub status_text: String,
+    #[serde(default)]
+    pub header_list: HeaderList,
     pub content_type: String,
     pub body: Vec<u8>,
 }
@@ -762,12 +783,16 @@ pub enum Event {
 #[cfg(test)]
 mod tests {
     use super::{
-        Command, DocumentFetchId, FetchResponse, FontTransportReceiver, FontTransportSender,
-        FrameCompositionMetadata, FrameId, LoadedDocumentResponse, NavigableId, PaintFrame,
-        PaintTransportSummary, SceneSummary, WebviewId,
+        Command, DocumentFetchId, DocumentId, FetchResponse, FontTransportReceiver,
+        FontTransportSender, FrameCompositionMetadata, FrameId, HeaderList,
+        LoadedDocumentResponse, NavigableId, PaintFrame, PaintTransportSummary, SceneSummary,
+        WebviewId,
     };
     use anyrender::{Glyph, PaintScene, Scene, recording::RenderCommand};
-    use peniko::{Color, Fill, FontData, kurbo::Affine};
+    use peniko::{
+        Color, Fill, FontData,
+        kurbo::{Affine, Vec2},
+    };
 
     fn scene_with_glyph(font: &FontData, glyph_id: u16, x: f32, y: f32) -> Scene {
         let mut scene = Scene::new();
@@ -776,6 +801,7 @@ mod tests {
             16.0,
             true,
             &[],
+            Vec2::default(),
             Fill::NonZero,
             Color::BLACK,
             1.0,
@@ -848,6 +874,7 @@ mod tests {
             16.0,
             true,
             &[],
+            Vec2::default(),
             Fill::NonZero,
             Color::BLACK,
             1.0,
@@ -958,11 +985,19 @@ mod tests {
     fn create_loaded_document_command_round_trips_response_metadata() {
         let encoded = postcard::to_allocvec(&Command::CreateLoadedDocument {
             traversable_id: NavigableId::from_u128(3),
-            document_id: 7,
+            document_id: DocumentId::from_u128(7),
             frame_id: None,
             response: LoadedDocumentResponse {
                 final_url: String::from("https://example.test/final"),
+                url_list: vec![String::from("https://example.test/final")],
                 status: 201,
+                status_text: String::from("Created"),
+                header_list: HeaderList {
+                    headers: vec![(
+                        String::from("content-type"),
+                        String::from("text/html; charset=utf-8"),
+                    )],
+                },
                 content_type: String::from("text/html; charset=utf-8"),
                 body: String::from("<p>ok</p>"),
             },
@@ -983,7 +1018,7 @@ mod tests {
                 top_level_traversable_id,
             } => {
                 assert_eq!(traversable_id, NavigableId::from_u128(3));
-                assert_eq!(document_id, 7);
+                assert_eq!(document_id, DocumentId::from_u128(7));
                 assert_eq!(frame_id, None);
                 assert_eq!(parent_traversable_id, Some(NavigableId::from_u128(2)));
                 assert_eq!(top_level_traversable_id, NavigableId::from_u128(1));
@@ -991,7 +1026,15 @@ mod tests {
                     response,
                     LoadedDocumentResponse {
                         final_url: String::from("https://example.test/final"),
+                        url_list: vec![String::from("https://example.test/final")],
                         status: 201,
+                        status_text: String::from("Created"),
+                        header_list: HeaderList {
+                            headers: vec![(
+                                String::from("content-type"),
+                                String::from("text/html; charset=utf-8"),
+                            )],
+                        },
                         content_type: String::from("text/html; charset=utf-8"),
                         body: String::from("<p>ok</p>"),
                     }
@@ -1008,7 +1051,12 @@ mod tests {
             handler_id,
             response: FetchResponse {
                 final_url: String::from("https://example.test/script.js"),
+                url_list: vec![String::from("https://example.test/script.js")],
                 status: 404,
+                status_text: String::from("Not Found"),
+                header_list: HeaderList {
+                    headers: vec![(String::from("content-type"), String::from("text/html"))],
+                },
                 content_type: String::from("text/html"),
                 body: vec![1, 2, 3, 4],
             },
@@ -1027,7 +1075,15 @@ mod tests {
                     response,
                     FetchResponse {
                         final_url: String::from("https://example.test/script.js"),
+                        url_list: vec![String::from("https://example.test/script.js")],
                         status: 404,
+                        status_text: String::from("Not Found"),
+                        header_list: HeaderList {
+                            headers: vec![(
+                                String::from("content-type"),
+                                String::from("text/html"),
+                            )],
+                        },
                         content_type: String::from("text/html"),
                         body: vec![1, 2, 3, 4],
                     }

--- a/net/src/main.rs
+++ b/net/src/main.rs
@@ -1,12 +1,11 @@
 use ipc_channel::ipc::{self, IpcSender};
-use ipc_messages::content::{FetchRequest, FetchResponse};
+use ipc_messages::content::{FetchRequest, FetchResponse, HeaderList};
 use ipc_messages::network::{Bootstrap, Request, Response};
 use reqwest::Method;
 use reqwest::blocking::Client;
-use reqwest::header::CONTENT_TYPE;
+use reqwest::header::{CONTENT_TYPE, HeaderMap, HeaderName, HeaderValue};
 use std::env;
 use std::fs;
-use std::net::{Ipv4Addr, SocketAddr};
 use url::Url;
 use verification::TraceSender;
 
@@ -23,6 +22,43 @@ fn net_token_from_args() -> Result<Option<String>, String> {
     Ok(None)
 }
 
+fn content_type_from_header_list(header_list: &HeaderList) -> String {
+    header_list
+        .headers
+        .iter()
+        .find(|(name, _value)| name.eq_ignore_ascii_case(CONTENT_TYPE.as_str()))
+        .map(|(_name, value)| value.clone())
+        .unwrap_or_default()
+}
+
+// Note: Header values are currently carried as Strings for IPC compatibility.
+// Non-UTF-8 header bytes are lossy-decoded until the transport can carry bytes.
+fn header_list_from_header_map(headers: &HeaderMap) -> HeaderList {
+    HeaderList {
+        headers: headers
+            .iter()
+            .map(|(name, value)| {
+                (
+                    name.as_str().to_owned(),
+                    String::from_utf8_lossy(value.as_bytes()).into_owned(),
+                )
+            })
+            .collect(),
+    }
+}
+
+fn header_map_from_header_list(header_list: &HeaderList) -> Result<HeaderMap, String> {
+    let mut headers = HeaderMap::new();
+    for (name, value) in &header_list.headers {
+        let header_name = HeaderName::from_bytes(name.as_bytes())
+            .map_err(|error| format!("invalid request header name `{name}`: {error}"))?;
+        let header_value = HeaderValue::from_bytes(value.as_bytes())
+            .map_err(|error| format!("invalid request header value for `{name}`: {error}"))?;
+        headers.append(header_name, header_value);
+    }
+    Ok(headers)
+}
+
 fn fetch_file_url(url: &str) -> Result<FetchResponse, String> {
     let parsed = Url::parse(url).map_err(|error| format!("invalid file URL: {error}"))?;
     let path = parsed
@@ -33,9 +69,18 @@ fn fetch_file_url(url: &str) -> Result<FetchResponse, String> {
         .first_raw()
         .unwrap_or("application/octet-stream")
         .to_owned();
+    // Note: The Fetch Standard leaves `file:` fetching implementation-defined. Formal-web maps a
+    // successful local file read to a 200 OK response with the request URL as the one-item URL list
+    // and a synthesized Content-Type header inferred from the path.
+    let header_list = HeaderList {
+        headers: vec![(String::from("content-type"), content_type.clone())],
+    };
     Ok(FetchResponse {
         final_url: url.to_owned(),
+        url_list: vec![url.to_owned()],
         status: 200,
+        status_text: String::from("OK"),
+        header_list,
         content_type,
         body,
     })
@@ -50,10 +95,17 @@ fn fetch_request(client: &Client, request: &FetchRequest) -> Result<FetchRespons
     // Handle about:blank locally — return an empty HTML document.
     // Reqwest cannot construct an HTTP request for about: URLs.
     if parsed.scheme() == "about" && parsed.path() == "blank" {
+        let content_type = String::from("text/html; charset=utf-8");
+        let header_list = HeaderList {
+            headers: vec![(String::from("content-type"), content_type.clone())],
+        };
         return Ok(FetchResponse {
             final_url: String::from("about:blank"),
+            url_list: vec![String::from("about:blank")],
             status: 200,
-            content_type: String::from("text/html; charset=utf-8"),
+            status_text: String::from("OK"),
+            header_list,
+            content_type,
             body: Vec::new(),
         });
     }
@@ -61,6 +113,10 @@ fn fetch_request(client: &Client, request: &FetchRequest) -> Result<FetchRespons
     let method = Method::from_bytes(request.method.as_bytes())
         .map_err(|error| format!("invalid HTTP method: {error}"))?;
     let mut builder = client.request(method, parsed);
+    let headers = header_map_from_header_list(&request.header_list)?;
+    if !headers.is_empty() {
+        builder = builder.headers(headers);
+    }
     if !request.body.is_empty() {
         builder = builder.body(request.body.clone());
     }
@@ -69,21 +125,27 @@ fn fetch_request(client: &Client, request: &FetchRequest) -> Result<FetchRespons
         .send()
         .map_err(|error| format!("network request failed: {error}"))?;
     let final_url = response.url().to_string();
-    let status = response.status().as_u16();
-    let content_type = response
-        .headers()
-        .get(CONTENT_TYPE)
-        .and_then(|value| value.to_str().ok())
-        .unwrap_or("")
-        .to_owned();
+    let status_code = response.status();
+    let status = status_code.as_u16();
+    // Note: reqwest exposes the status code and canonical reason phrase, not the HTTP/1 wire
+    // reason phrase. HTTP/2 responses do not carry a reason phrase; the empty string remains the
+    // fallback when reqwest has no canonical text for the status.
+    let status_text = status_code.canonical_reason().unwrap_or("").to_owned();
+    let header_list = header_list_from_header_map(response.headers());
+    let content_type = content_type_from_header_list(&header_list);
     let body = response
         .bytes()
         .map_err(|error| format!("failed to read response body: {error}"))?
         .to_vec();
 
     Ok(FetchResponse {
-        final_url,
+        final_url: final_url.clone(),
+        // Note: reqwest follows redirects before returning the response exposed here. Redirect
+        // URL-list fidelity is left to future redirect handling work.
+        url_list: vec![final_url.clone()],
         status,
+        status_text,
+        header_list,
         content_type,
         body,
     })
@@ -105,7 +167,6 @@ pub fn run_net_process(token: String) -> Result<(), String> {
     let mut _trace_sender: Option<TraceSender> = None;
 
     let client = Client::builder()
-        .resolve("localhost", SocketAddr::from((Ipv4Addr::LOCALHOST, 0)))
         .build()
         .map_err(|error| format!("failed to build reqwest client: {error}"))?;
 
@@ -124,7 +185,10 @@ pub fn run_net_process(token: String) -> Result<(), String> {
                     .map_err(|error| format!("failed to send fetch response: {error}"))?;
             }
             Ok(Request::Shutdown) => break,
-            Err(_error) => break,
+            Err(error) => {
+                eprintln!("net request channel closed: {error}");
+                break;
+            }
         }
     }
 

--- a/user_agent/src/fetch.rs
+++ b/user_agent/src/fetch.rs
@@ -3,7 +3,7 @@ use ipc_channel::ipc::{IpcOneShotServer, IpcSender};
 use ipc_channel::router::ROUTER;
 use ipc_messages::content::{
     DocumentFetchId, EventLoopId, FetchRequest as ContentFetchRequest,
-    FetchResponse as ContentFetchResponse, NavigationFetchId,
+    FetchResponse as ContentFetchResponse, HeaderList as ContentHeaderList, NavigationFetchId,
 };
 use ipc_messages::network::{
     Bootstrap as NetworkBootstrap, Request as NetworkRequest, Response as NetworkResponse,
@@ -18,7 +18,7 @@ use verification::TraceSender;
 
 use crate::{UserAgentCommand, sidecar_executable_path};
 
-/// graceful shutdown of the network sidecar owned by the fetch worker.
+/// graceful shutdown of the network process owned by the fetch worker.
 const FETCH_SHUTDOWN_GRACE_TIMEOUT: Duration = Duration::from_millis(150);
 
 /// <https://fetch.spec.whatwg.org/#concept-header-list>
@@ -29,19 +29,37 @@ pub(crate) struct HeaderList {
 }
 
 impl HeaderList {
-    fn new() -> Self {
-        Self::default()
+    fn from_content_header_list(header_list: ContentHeaderList) -> Self {
+        Self {
+            headers: header_list.headers,
+        }
     }
 
-    fn from_content_type(content_type: &str) -> Self {
-        // Note: Phase 1 maps the existing content IPC `content_type` field into a one-entry
-        // header list. Full response headers belong in a later net/content IPC shape.
-        if content_type.is_empty() {
-            return Self::new();
+    fn to_content_header_list(&self) -> ContentHeaderList {
+        // Note: Formal-web plumbing converts the fetch worker's header-list storage back into the
+        // content IPC header-list transport shape.
+        ContentHeaderList {
+            headers: self.headers.clone(),
         }
+    }
 
-        Self {
-            headers: vec![(String::from("content-type"), content_type.to_owned())],
+    /// <https://fetch.spec.whatwg.org/#concept-header-list-get>
+    fn get(&self, name: &str) -> Option<String> {
+        // Step 1: "If list does not contain name, then return null."
+        let values = self
+            .headers
+            .iter()
+            .filter(|(header_name, _value)| header_name.eq_ignore_ascii_case(name))
+            .map(|(_header_name, value)| value.as_str())
+            .collect::<Vec<_>>();
+
+        if values.is_empty() {
+            None
+        } else {
+            // Step 2: "Return the values of all headers in list whose name is a
+            // byte-case-insensitive match for name, separated from each other by 0x2C 0x20, in
+            // order."
+            Some(values.join(", "))
         }
     }
 }
@@ -57,8 +75,8 @@ pub(crate) struct InternalFetchRequest {
     header_list: HeaderList,
     /// <https://fetch.spec.whatwg.org/#concept-request-body>
     ///
-    /// Note: Phase 1 preserves the current IPC body string here instead of modeling a Fetch body
-    /// stream. Body streaming remains out of scope for this PR.
+    /// Note: This keeps the existing IPC body string transport instead of modeling a Fetch body
+    /// stream.
     body: String,
     /// <https://fetch.spec.whatwg.org/#done-flag>
     done: bool,
@@ -72,13 +90,14 @@ impl InternalFetchRequest {
             handler_id: _,
             url,
             method,
+            header_list,
             body,
         } = request;
 
         Self {
             url,
             method,
-            header_list: HeaderList::new(),
+            header_list: HeaderList::from_content_header_list(header_list),
             body,
             done: false,
             keepalive: false,
@@ -86,10 +105,13 @@ impl InternalFetchRequest {
     }
 
     fn to_content_fetch_request(&self, handler_id: DocumentFetchId) -> ContentFetchRequest {
+        // Note: Formal-web plumbing converts the fetch worker's request snapshot into the content
+        // IPC request shape consumed by the net process.
         ContentFetchRequest {
             handler_id,
             url: self.url.clone(),
             method: self.method.clone(),
+            header_list: self.header_list.to_content_header_list(),
             body: self.body.clone(),
         }
     }
@@ -106,6 +128,8 @@ pub(crate) struct InternalFetchResponse {
     url_list: Vec<String>,
     /// <https://fetch.spec.whatwg.org/#concept-response-status>
     status: u16,
+    /// <https://fetch.spec.whatwg.org/#concept-response-status-message>
+    status_text: String,
     /// <https://fetch.spec.whatwg.org/#concept-response-header-list>
     header_list: HeaderList,
     // Note: Formal-web's current content IPC exposes `content_type` as a separate convenience
@@ -113,25 +137,49 @@ pub(crate) struct InternalFetchResponse {
     // trip the existing `FetchResponse` transport without changing behavior.
     content_type: String,
     /// <https://fetch.spec.whatwg.org/#concept-response-body>
+    ///
+    /// Note: This keeps the existing buffered byte transport and does not yet distinguish a null
+    /// body from an empty body.
     body: Vec<u8>,
 }
 
 impl InternalFetchResponse {
     fn from_content_fetch_response(response: ContentFetchResponse) -> Self {
+        let header_list = HeaderList::from_content_header_list(response.header_list);
+        let content_type = if response.content_type.is_empty() {
+            header_list.get("content-type").unwrap_or_default()
+        } else {
+            response.content_type
+        };
         Self {
-            url_list: vec![response.final_url],
+            url_list: if response.url_list.is_empty() {
+                vec![response.final_url]
+            } else {
+                response.url_list
+            },
             status: response.status,
-            header_list: HeaderList::from_content_type(&response.content_type),
-            content_type: response.content_type,
+            status_text: response.status_text,
+            header_list,
+            content_type,
             body: response.body,
         }
     }
 
     fn into_content_fetch_response(self) -> ContentFetchResponse {
+        // Note: Formal-web plumbing converts the fetch worker's response snapshot into the content
+        // IPC response shape used by document and navigation continuations.
+        let content_type = if self.content_type.is_empty() {
+            self.header_list.get("content-type").unwrap_or_default()
+        } else {
+            self.content_type
+        };
         ContentFetchResponse {
             final_url: self.url_list.last().cloned().unwrap_or_default(),
+            url_list: self.url_list,
             status: self.status,
-            content_type: self.content_type,
+            status_text: self.status_text,
+            header_list: self.header_list.to_content_header_list(),
+            content_type,
             body: self.body,
         }
     }
@@ -161,30 +209,27 @@ impl FetchController {
     }
 
     /// <https://fetch.spec.whatwg.org/#fetch-controller-abort>
-    // TODO: Wire this to AbortSignal/controller integration once content can initiate aborts and
-    // formal-web can carry structured abort reasons across content, user-agent, and net.
-    // Note: Phase 1 keeps the spec algorithm present so upcoming AbortSignal work has a precise
-    // controller entry point, but no production path calls it yet.
+    // TODO: Content cannot initiate fetch aborts yet, so no production path calls this algorithm.
+    // Note: Structured abort reasons are not carried across content, user-agent, and net yet.
     #[allow(dead_code)]
     pub(crate) fn abort(&mut self, error: Option<String>) {
-        // Step 1. Set controller's state to "aborted".
+        // Step 1: "Set controller's state to \"aborted\"."
         self.state = FetchControllerState::Aborted;
-        // Step 2. Let fallbackError be an "AbortError" DOMException.
+        // Step 2: "Let fallbackError be an \"AbortError\" DOMException."
         let fallback_error = String::from("AbortError");
-        // Step 3. Set error to fallbackError if it is not given.
+        // Step 3: "Set error to fallbackError if it is not given."
         let error = error.unwrap_or_else(|| fallback_error.clone());
-        // Step 4. Let serializedError be StructuredSerialize(error).
-        // TODO: Step 4. Replace this placeholder with StructuredSerialize(error).
-        // Note: formal-web does not yet expose DOMException or structured clone values across
-        // this worker boundary, so Phase 1 stores the serialized reason as a string placeholder.
+        // TODO: Step 4: "Let serializedError be StructuredSerialize(error)."
+        // Note: This stores the serialized abort reason as a string placeholder until structured
+        // clone / DOMException-shaped values are available across this boundary.
         let serialized_error = error;
-        // Step 5. Set controller's serialized abort reason to serializedError.
+        // Step 5: "Set controller's serialized abort reason to serializedError."
         self.serialized_abort_reason = Some(serialized_error);
     }
 
     /// <https://fetch.spec.whatwg.org/#fetch-controller-terminate>
     pub(crate) fn terminate(&mut self) {
-        // Step 1. Set controller's state to "terminated".
+        // Step 1: "Set controller's state to \"terminated\"."
         self.state = FetchControllerState::Terminated;
     }
 }
@@ -265,17 +310,16 @@ pub(crate) struct FetchRecord {
     request: InternalFetchRequest,
     /// <https://fetch.spec.whatwg.org/#concept-fetch-record-fetch>
     controller: Option<FetchController>,
-    /// Formal-web continuation resumed when the network process completes this fetch.
+    // Note: Formal-web continuation resumed when the network process completes this fetch.
     continuation: PendingFetch,
 }
 
 impl FetchRecord {
     fn navigation_transport_handler_id() -> DocumentFetchId {
         // Note: Navigation fetches are keyed by `NavigationFetchId` in the user agent, and the net
-        // process ignores `FetchRequest.handler_id`. This placeholder exists only because Phase 1
-        // still reuses the content document-fetch IPC request shape for all network fetches. It
-        // is stable to make the intentionally-unused value obvious, and should disappear when net
-        // receives a Fetch-owned request type.
+        // process ignores `FetchRequest.handler_id`. This placeholder exists because the current
+        // network path reuses the content document-fetch IPC request shape for all network fetches.
+        // The stable value makes the intentionally-unused field obvious.
         DocumentFetchId::from_u128(0)
     }
 
@@ -327,14 +371,15 @@ impl FetchRecord {
 }
 
 // Note: Placeholder item for the fetch group's deferred fetch records list. The actual
-// `deferred fetch record` fields are intentionally deferred until deferred fetch processing exists.
+// `deferred fetch record` fields are not modeled because deferred fetch processing is not
+// implemented.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct DeferredFetchRecord;
 
 /// <https://fetch.spec.whatwg.org/#concept-fetch-group>
-// Note: Phase 1 keeps one fetch group on the fetch worker. The Fetch Standard associates a fetch
-// group with an environment settings object; that ownership split will be introduced when content
-// exposes environment-scoped Fetch API state.
+// Note: formal-web keeps one fetch group on the fetch worker. The Fetch Standard associates a
+// fetch group with an environment settings object, but content does not expose environment-scoped
+// Fetch API state yet.
 #[derive(Debug, Default)]
 pub(crate) struct FetchGroup {
     /// <https://fetch.spec.whatwg.org/#concept-fetch-record>
@@ -365,9 +410,9 @@ impl FetchGroup {
 
     /// <https://fetch.spec.whatwg.org/#concept-fetch-group-terminate>
     pub(crate) fn terminate(&mut self) {
-        // Step 1. For each fetch record record of fetchGroup's fetch records, if record's
+        // Step 1: "For each fetch record record of fetchGroup's fetch records, if record's
         // controller is non-null and record's request's done flag is unset and keepalive is
-        // false, terminate record's controller.
+        // false, terminate record's controller."
         for record in self.fetch_records.values_mut() {
             if let Some(controller) = record.controller.as_mut() {
                 if !record.request.done && !record.request.keepalive {
@@ -375,7 +420,7 @@ impl FetchGroup {
                 }
             }
         }
-        // TODO: Step 2. "Process deferred fetches for fetchGroup."
+        // TODO: Step 2: "Process deferred fetches for fetchGroup."
         let _has_deferred_fetch_records = !self.deferred_fetch_records.is_empty();
     }
 }
@@ -459,21 +504,21 @@ struct FetchWorker {
     command_receiver: Receiver<FetchCommand>,
     /// Sender back into the user-agent thread for navigation/document fetch completions.
     user_agent_command_sender: Sender<UserAgentCommand>,
-    /// IPC sender to the dedicated network sidecar process.
+    /// IPC sender to the dedicated network process.
     network_request_sender: IpcSender<NetworkRequest>,
-    /// IPC receiver for network sidecar responses.
+    /// IPC receiver for network process responses.
     network_event_receiver: Receiver<Result<NetworkResponse, String>>,
-    /// Child process handle for the network sidecar.
+    /// Child process handle for the network process.
     child: Option<Child>,
     /// Transport-local request id allocator for the network IPC bridge.
     next_request_id: u64,
     /// <https://fetch.spec.whatwg.org/#concept-fetch-group>
     fetch_group: FetchGroup,
-    /// Deferred shutdown reply completed after the network sidecar exits.
+    /// Deferred shutdown reply completed after the network process exits.
     shutdown_reply: Option<Sender<Result<(), String>>>,
 }
 
-/// waiting on the network sidecar during shutdown.
+/// waiting on the network process during shutdown.
 fn wait_for_child_exit(child: &mut Child, timeout: Duration) -> Result<bool, String> {
     let deadline = Instant::now() + timeout;
     loop {
@@ -492,7 +537,7 @@ fn wait_for_child_exit(child: &mut Child, timeout: Duration) -> Result<bool, Str
     }
 }
 
-/// gracefully shutting down the network sidecar owned by the fetch worker.
+/// gracefully shutting down the network process owned by the fetch worker.
 fn finish_shutdown(mut child: Option<Child>) {
     if let Some(child) = child.as_mut() {
         match wait_for_child_exit(child, FETCH_SHUTDOWN_GRACE_TIMEOUT) {
@@ -512,7 +557,7 @@ fn finish_shutdown(mut child: Option<Child>) {
     }
 }
 
-/// bootstrapping the dedicated network sidecar process used by
+/// bootstrapping the dedicated network process used by
 /// fetch-backed navigation and document fetch continuations.
 pub fn start_network_bridge(
     trace_sender: Option<TraceSender>,
@@ -550,11 +595,12 @@ pub fn start_network_bridge(
     ROUTER.add_typed_route(
         bootstrap.response_receiver,
         Box::new(move |message| {
-            let _ =
-                event_sender
-                    .send(message.map_err(|error| {
-                        format!("failed to decode network IPC response: {error}")
-                    }));
+            if let Err(error) = event_sender.send(
+                message
+                    .map_err(|error| format!("failed to decode network IPC response: {error}")),
+            ) {
+                eprintln!("failed to route network IPC response to fetch worker: {error}");
+            }
         }),
     );
 
@@ -562,7 +608,7 @@ pub fn start_network_bridge(
 }
 
 impl FetchWorker {
-    /// starting the fetch worker with its owned network sidecar.
+    /// starting the fetch worker with its owned network process.
     fn new(
         command_receiver: Receiver<FetchCommand>,
         user_agent_command_sender: Sender<UserAgentCommand>,
@@ -582,7 +628,15 @@ impl FetchWorker {
         })
     }
 
-    /// failing every pending fetch if the network sidecar stops before
+    fn send_user_agent_command(&self, command: UserAgentCommand, operation: &str) {
+        // Note: Formal-web plumbing logs failed cross-thread user-agent notifications before
+        // dropping them so fetch failures keep their diagnostic path.
+        if let Err(error) = self.user_agent_command_sender.send(command) {
+            eprintln!("{operation}: {error}");
+        }
+    }
+
+    /// failing every pending fetch if the network process stops before
     /// producing a response.
     fn fail_pending_fetches(&mut self) {
         // If the network bridge stops early, report every outstanding fetch back through the
@@ -590,18 +644,20 @@ impl FetchWorker {
         for fetch_record in self.fetch_group.drain_fetch_records() {
             match fetch_record.continuation {
                 PendingFetch::Document(pending_fetch) => {
-                    let _ = self.user_agent_command_sender.send(
+                    self.send_user_agent_command(
                         UserAgentCommand::DocumentFetchFailed {
                             event_loop_id: pending_fetch.event_loop_id,
                             handler_id: pending_fetch.handler_id,
                         },
+                        "failed to report pending document fetch failure",
                     );
                 }
                 PendingFetch::Navigation(pending_fetch) => {
-                    let _ = self.user_agent_command_sender.send(
+                    self.send_user_agent_command(
                         UserAgentCommand::NavigationFetchFailed {
                             fetch_id: pending_fetch.fetch_id,
                         },
+                        "failed to report pending navigation fetch failure",
                     );
                 }
             }
@@ -615,7 +671,7 @@ impl FetchWorker {
                 event_loop_id,
                 request,
             } => {
-                // Document fetches reuse the same network sidecar, but the completion returns
+                // Note: Document fetches reuse the same network process, but the completion returns
                 // directly to the owning event loop instead of the navigation finalization path.
                 let request_id = self.next_request_id;
                 self.next_request_id += 1;
@@ -637,18 +693,20 @@ impl FetchWorker {
                     if let Some(fetch_record) = self.fetch_group.remove_fetch_record(request_id) {
                         match fetch_record.continuation {
                             PendingFetch::Document(pending_fetch) => {
-                                let _ = self.user_agent_command_sender.send(
+                                self.send_user_agent_command(
                                     UserAgentCommand::DocumentFetchFailed {
                                         event_loop_id: pending_fetch.event_loop_id,
                                         handler_id: pending_fetch.handler_id,
                                     },
+                                    "failed to report document fetch send failure",
                                 );
                             }
                             PendingFetch::Navigation(pending_fetch) => {
-                                let _ = self.user_agent_command_sender.send(
+                                self.send_user_agent_command(
                                     UserAgentCommand::NavigationFetchFailed {
                                         fetch_id: pending_fetch.fetch_id,
                                     },
+                                    "failed to report navigation fetch send failure",
                                 );
                             }
                         }
@@ -674,9 +732,10 @@ impl FetchWorker {
                     request: network_request,
                 }) {
                     self.fetch_group.remove_fetch_record(request_id);
-                    let _ = self
-                        .user_agent_command_sender
-                        .send(UserAgentCommand::NavigationFetchFailed { fetch_id });
+                    self.send_user_agent_command(
+                        UserAgentCommand::NavigationFetchFailed { fetch_id },
+                        "failed to report navigation fetch send failure",
+                    );
                     eprintln!(
                         "failed to send navigation fetch request to network process: {error}"
                     );
@@ -684,7 +743,9 @@ impl FetchWorker {
             }
             FetchCommand::Shutdown { reply } => {
                 self.fetch_group.terminate();
-                let _ = self.network_request_sender.send(NetworkRequest::Shutdown);
+                if let Err(error) = self.network_request_sender.send(NetworkRequest::Shutdown) {
+                    eprintln!("failed to send network process shutdown request: {error}");
+                }
                 self.shutdown_reply = Some(reply);
             }
         }
@@ -712,13 +773,14 @@ impl FetchWorker {
             } => {
                 // Successful document fetches resume the owning event loop's content-side
                 // continuation.
-                let _ =
-                    self.user_agent_command_sender
-                        .send(UserAgentCommand::DocumentFetchCompleted {
-                            event_loop_id,
-                            handler_id,
-                            response,
-                        });
+                self.send_user_agent_command(
+                    UserAgentCommand::DocumentFetchCompleted {
+                        event_loop_id,
+                        handler_id,
+                        response,
+                    },
+                    "failed to report document fetch completion",
+                );
             }
             FetchCompletion::DocumentFailed {
                 event_loop_id,
@@ -726,31 +788,32 @@ impl FetchWorker {
             } => {
                 // Document fetch failures reenter the owning event loop so the content-side
                 // fetch algorithm can fail the handler in place.
-                let _ =
-                    self.user_agent_command_sender
-                        .send(UserAgentCommand::DocumentFetchFailed {
-                            event_loop_id,
-                            handler_id,
-                        });
+                self.send_user_agent_command(
+                    UserAgentCommand::DocumentFetchFailed {
+                        event_loop_id,
+                        handler_id,
+                    },
+                    "failed to report document fetch failure",
+                );
             }
             FetchCompletion::NavigationCompleted { fetch_id, response } => {
                 // Successful navigation fetches resume the user-agent-side document creation
                 // and finalization continuation keyed by `fetch_id`.
-                let _ = self.user_agent_command_sender.send(
+                self.send_user_agent_command(
                     UserAgentCommand::NavigationFetchCompleted {
                         fetch_id,
                         response,
                     },
+                    "failed to report navigation fetch completion",
                 );
             }
             FetchCompletion::NavigationFailed { fetch_id } => {
                 // Navigation fetch failures resume the same pending navigation record so the
                 // user agent can clear `ongoing_navigation_id` and surface failure to the embedder.
-                let _ =
-                    self.user_agent_command_sender
-                        .send(UserAgentCommand::NavigationFetchFailed {
-                            fetch_id,
-                        });
+                self.send_user_agent_command(
+                    UserAgentCommand::NavigationFetchFailed { fetch_id },
+                    "failed to report navigation fetch failure",
+                );
             }
             FetchCompletion::Ignored => {}
         }
@@ -759,7 +822,7 @@ impl FetchWorker {
     /// <https://html.spec.whatwg.org/multipage/#create-navigation-params-by-fetching>
     fn run(&mut self) {
         // The fetch worker owns the network-facing half of HTML's parallel fetch branch and
-        // drains either new user-agent requests or sidecar responses until shutdown.
+        // drains either new user-agent requests or network-process responses until shutdown.
         loop {
             let command_receiver = &self.command_receiver;
             let network_event_receiver = &self.network_event_receiver;

--- a/user_agent/src/user_agent.rs
+++ b/user_agent/src/user_agent.rs
@@ -8,8 +8,9 @@ use ipc_messages::content::{
     AgentClusterId, AgentId, BeforeUnloadCheckId, BeforeUnloadResult, BrowsingContextGroupId,
     BrowsingContextId, Command as ContentCommand, DispatchEventEntry, DocumentFetchId, DocumentId,
     EventLoopId, FetchRequest as ContentFetchRequest, FetchResponse as ContentFetchResponse,
-    FinalizeNavigation as ContentFinalizeNavigation, FrameId, LoadedDocumentResponse, NavigableId,
-    NavigateRequest, NavigationFetchId, NavigationId, NewTraversableInfo,
+    FinalizeNavigation as ContentFinalizeNavigation, FrameId, HeaderList as ContentHeaderList,
+    LoadedDocumentResponse, NavigableId, NavigateRequest, NavigationFetchId, NavigationId,
+    NewTraversableInfo,
     UserNavigationInvolvement, WebviewId, WebviewProviderMessage, WindowTimerKey,
     iframe_target_name,
 };
@@ -400,6 +401,7 @@ impl NavigationRequest {
             handler_id: DocumentFetchId::new(),
             url: self.url.clone(),
             method: self.method.clone(),
+            header_list: ContentHeaderList::default(),
             body: self.body.clone().unwrap_or_default(),
         }
     }
@@ -3325,7 +3327,14 @@ impl UserAgentWorker {
             .and_then(|n| n.frame_id);
         let loaded_response = LoadedDocumentResponse {
             final_url: final_url.clone(),
+            url_list: if response.url_list.is_empty() {
+                vec![final_url.clone()]
+            } else {
+                response.url_list.clone()
+            },
             status: response.status,
+            status_text: response.status_text.clone(),
+            header_list: response.header_list.clone(),
             content_type: response.content_type.clone(),
             body: String::from_utf8_lossy(&response.body).into_owned(),
         };


### PR DESCRIPTION
This PR adds an initial spec-grounded end-to-end Fetch path.

It wires:

window.fetch()
minimal Headers
minimal Response
response status/statusText/ok/url/headers
stream-backed Response.body
Response.bodyUsed
Response.text()
response metadata/body transport through content, user-agent fetch, and net

Out of scope for this PR:

full Request
full Headers mutation/iteration/sequence init
arrayBuffer()
Blob
FormData
full BodyInit extraction
redirect policy
CORS
HTTP cache
Service Workers
AbortSignal
permissive WPT .asis raw-response handling in net

<img width="1594" height="1264" alt="image" src="https://github.com/user-attachments/assets/97da4bc5-f574-40e1-8057-a478fe88905d" />
