### PR TITLE
Simplify media build and readme

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,7 +114,6 @@ Plans and temporary task notes go under `scratchpad/`.
 - `rustup toolchain install 1.94.0` — installs the pinned Rust toolchain.
 - `rustup run 1.94.0 cargo check` — type-checks the workspace.
 - `rustup run 1.94.0 cargo run --release` — default windowed embedder.
-- `rustup run 1.94.0 cargo run --release -- --no-media` — windowed embedder without media support (no media process, HTMLMediaElement constructors throw `NotSupportedError`).
 - `rustup run 1.94.0 cargo build --no-default-features` — build without GStreamer/media dependency entirely.
 - `rustup run 1.94.0 cargo run --release -- --headless` — headless mode.
 - `rustup run 1.94.0 cargo run --release -- --verify` — with trace recording and shutdown-time TLA+ validation.

--- a/README.md
+++ b/README.md
@@ -11,58 +11,18 @@ rustup run 1.92.0 cargo run --release
 
 This builds and runs the default windowed embedder for local development.
 
-For a build without media support (no GStreamer dependency, no media process):
+Media support (GStreamer-based video decoding) is enabled by default. See the
+[gstreamer crate documentation](https://docs.rs/gstreamer/latest/gstreamer/)
+for platform-specific installation instructions.
+
+To build entirely without media support (no GStreamer dependency):
 
 ```bash
 cargo run --release --no-default-features
 ```
 
-This builds without the `media` Cargo feature, removing the GStreamer dependency
-entirely. The `--no-media` flag is forwarded to the embedder at runtime to
-prevent the media worker from spawning and to stub out
-`HTMLMediaElement`/`HTMLVideoElement` constructors (they throw
-`NotSupportedError`).
-
-With default features (media support compiled in), pass `--no-media` as a
-runtime flag to skip the media worker without changing the build:
-
-```bash
-cargo run --release -- --no-media
-```
-
-## Build configuration
-
-### `media` feature
-
-Media support (GStreamer-based video decoding) is enabled by default via the
-`media` Cargo feature. To build entirely without media support:
-
-```bash
-cargo build --no-default-features
-```
-
-This removes the GStreamer dependency entirely (no need to install GStreamer
-development libraries) and stubs out `HTMLMediaElement`/`HTMLVideoElement` at
-the compile level. Any JS constructor call to these interfaces throws
-`NotSupportedError`. The `--no-media` CLI flag is forwarded as a runtime signal
-to the embedder to skip spawning the media worker (the flag is implied
-automatically when the `media` feature is disabled at build time).
-
-### GStreamer dependency
-
-When the `media` feature is enabled (the default), the `media` crate depends on
-[GStreamer](https://gstreamer.freedesktop.org/) for video decoding. See the
-[gstreamer crate documentation](https://docs.rs/gstreamer/latest/gstreamer/)
-for platform-specific installation instructions.
-
-To build without GStreamer, pass `--no-default-features` to Cargo:
-
-```bash
-cargo build --no-default-features
-```
-
-This excludes the `media` crate from compilation. The `--no-media` runtime flag
-is then implied automatically.
+This excludes the `media` Cargo feature from compilation. `HTMLMediaElement`
+and `HTMLVideoElement` constructors throw `NotSupportedError` at runtime.
 
 
 ## Project structure

--- a/embedder/Cargo.toml
+++ b/embedder/Cargo.toml
@@ -8,6 +8,10 @@ publish = false
 name = "formal-web-embedder"
 path = "src/main.rs"
 
+[features]
+default = ["media"]
+media = ["webview/media"]
+
 [dependencies]
 anyrender = { version = "0.10", features = ["serde"] }
 anyrender_vello = "0.10.1"
@@ -34,4 +38,4 @@ winit = "0.30"
 uuid = { version = "1", features = ["v4"] }
 log = "0.4"
 env_logger = "0.11"
-webview = { path = "../webview" }
+webview = { path = "../webview", default-features = false }

--- a/embedder/src/event_loop.rs
+++ b/embedder/src/event_loop.rs
@@ -202,7 +202,6 @@ pub fn event_loop_is_ready() -> bool {
 
 fn run_embedder_event_loop<A, MakeApp>(
     trace_sender: Option<TraceSender>,
-    no_media: bool,
     make_app: MakeApp,
 ) -> Result<(), String>
 where
@@ -222,7 +221,7 @@ where
 
     let event_loop_embedder = Arc::new(EventLoopEmbedder::new(dispatcher));
     let embedder: Arc<dyn Embedder> = event_loop_embedder.clone();
-    let provider = match WebviewProvider::new(embedder, trace_sender, no_media) {
+    let provider = match WebviewProvider::new(embedder, trace_sender) {
         Ok(provider) => provider,
         Err(error) => {
             let mut guard = EVENT_LOOP_PROXY
@@ -252,9 +251,8 @@ where
 
 pub fn run_headed_event_loop(
     trace_sender: Option<TraceSender>,
-    no_media: bool,
 ) -> Result<(), String> {
-    run_embedder_event_loop(trace_sender, no_media, |provider| WindowedApp {
+    run_embedder_event_loop(trace_sender, |provider| WindowedApp {
         provider: Some(provider),
         ..WindowedApp::default()
     })
@@ -262,9 +260,8 @@ pub fn run_headed_event_loop(
 
 pub fn run_headless_event_loop(
     trace_sender: Option<TraceSender>,
-    no_media: bool,
 ) -> Result<(), String> {
-    run_embedder_event_loop(trace_sender, no_media, |provider| HeadlessEmbedderApp {
+    run_embedder_event_loop(trace_sender, |provider| HeadlessEmbedderApp {
         provider: Some(provider),
         ..HeadlessEmbedderApp::default()
     })

--- a/embedder/src/main.rs
+++ b/embedder/src/main.rs
@@ -16,10 +16,6 @@ struct Cli {
     #[arg(long, global = true, default_value_t = false)]
     headless: bool,
 
-    /// Disable media support (no media process, HTMLMediaElement creation throws).
-    #[arg(long, global = true, default_value_t = false)]
-    no_media: bool,
-
     #[command(subcommand)]
     command: Option<CommandKind>,
 }
@@ -36,7 +32,6 @@ enum CommandKind {
 #[derive(Clone, Default)]
 struct AppRunOptions {
     headless: bool,
-    no_media: bool,
     startup_url: Option<String>,
     window_title: Option<String>,
     trace_sender: Option<TraceSender>,
@@ -51,12 +46,10 @@ fn run_app_with_options(options: AppRunOptions) -> Result<(), String> {
     let event_loop_result = if options.headless {
         event_loop::run_headless_event_loop(
             options.trace_sender.clone(),
-            options.no_media,
         )
     } else {
         event_loop::run_headed_event_loop(
             options.trace_sender.clone(),
-            options.no_media,
         )
     };
     event_loop::clear_event_loop_options();
@@ -67,7 +60,6 @@ fn run_app_with_options(options: AppRunOptions) -> Result<(), String> {
 fn run_webdriver(
     args: automation::WebDriverArgs,
     trace_sender: Option<TraceSender>,
-    no_media: bool,
 ) -> Result<(), String> {
     let runtime = automation::automation_bridge(
         |command| event_loop::send_user_event(event_loop::FormalWebUserEvent::Automation(command)),
@@ -85,7 +77,6 @@ fn run_webdriver(
         .transpose()?;
     let result = run_app_with_options(AppRunOptions {
         headless: args.headless,
-        no_media,
         startup_url: args
             .startup_url
             .or_else(|| Some(String::from("about:blank"))),
@@ -97,7 +88,7 @@ fn run_webdriver(
     result
 }
 
-fn run_cdp(args: automation::CdpArgs, trace_sender: Option<TraceSender>, no_media: bool) -> Result<(), String> {
+fn run_cdp(args: automation::CdpArgs, trace_sender: Option<TraceSender>) -> Result<(), String> {
     let runtime = automation::automation_bridge(
         |command| event_loop::send_user_event(event_loop::FormalWebUserEvent::Automation(command)),
         || event_loop::send_user_event(event_loop::FormalWebUserEvent::Exit),
@@ -106,7 +97,6 @@ fn run_cdp(args: automation::CdpArgs, trace_sender: Option<TraceSender>, no_medi
     let server = automation::CdpServerHandle::start(args.port, runtime)?;
     let result = run_app_with_options(AppRunOptions {
         headless: args.headless,
-        no_media,
         startup_url: args
             .startup_url
             .or_else(|| Some(String::from("about:blank"))),
@@ -174,8 +164,8 @@ fn main() -> ExitCode {
             trace_sender: trace_sender.clone(),
             ..AppRunOptions::default()
         }),
-        Some(CommandKind::WebDriver(args)) => run_webdriver(args, trace_sender.clone(), cli.no_media),
-        Some(CommandKind::Cdp(args)) => run_cdp(args, trace_sender.clone(), cli.no_media),
+        Some(CommandKind::WebDriver(args)) => run_webdriver(args, trace_sender.clone()),
+        Some(CommandKind::Cdp(args)) => run_cdp(args, trace_sender.clone()),
     };
     drop(trace_sender);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -57,6 +57,9 @@ fn run_embedder_process(embedder_args: Vec<OsString>) -> Result<(), String> {
     if !cfg!(debug_assertions) {
         command.arg("--release");
     }
+    if cfg!(not(feature = "media")) {
+        command.arg("--no-default-features");
+    }
     command
         .arg("--manifest-path")
         .arg("embedder/Cargo.toml")

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,10 +14,6 @@ struct Cli {
     #[arg(long, default_value_t = false)]
     headless: bool,
 
-    /// Disable media support (no media process, HTMLMediaElement creation throws).
-    #[arg(long, global = true, default_value_t = false)]
-    no_media: bool,
-
     #[command(subcommand)]
     command: Option<CommandKind>,
 }
@@ -88,7 +84,7 @@ fn run_embedder_process(embedder_args: Vec<OsString>) -> Result<(), String> {
     }
 }
 
-fn run_embedder_default(verify: bool, headless: bool, no_media: bool) -> Result<(), String> {
+fn run_embedder_default(verify: bool, headless: bool) -> Result<(), String> {
     let mut args = Vec::<OsString>::new();
     if verify {
         args.push(OsString::from("--verify"));
@@ -96,23 +92,13 @@ fn run_embedder_default(verify: bool, headless: bool, no_media: bool) -> Result<
     if headless {
         args.push(OsString::from("--headless"));
     }
-    if no_media {
-        args.push(OsString::from("--no-media"));
-    }
     run_embedder_process(args)
 }
 
-fn run_embedder_webdriver(
-    verify: bool,
-    no_media: bool,
-    args: automation::WebDriverArgs,
-) -> Result<(), String> {
+fn run_embedder_webdriver(verify: bool, args: automation::WebDriverArgs) -> Result<(), String> {
     let mut embedder_args = Vec::<OsString>::new();
     if verify {
         embedder_args.push(OsString::from("--verify"));
-    }
-    if no_media {
-        embedder_args.push(OsString::from("--no-media"));
     }
     embedder_args.push(OsString::from("webdriver"));
     embedder_args.push(OsString::from("--port"));
@@ -134,13 +120,10 @@ fn run_embedder_webdriver(
     run_embedder_process(embedder_args)
 }
 
-fn run_embedder_cdp(verify: bool, no_media: bool, args: automation::CdpArgs) -> Result<(), String> {
+fn run_embedder_cdp(verify: bool, args: automation::CdpArgs) -> Result<(), String> {
     let mut embedder_args = Vec::<OsString>::new();
     if verify {
         embedder_args.push(OsString::from("--verify"));
-    }
-    if no_media {
-        embedder_args.push(OsString::from("--no-media"));
     }
     embedder_args.push(OsString::from("cdp"));
     embedder_args.push(OsString::from("--port"));
@@ -177,11 +160,10 @@ fn main() -> ExitCode {
         };
     }
 
-    let no_media = cli.no_media || cfg!(not(feature = "media"));
     let result = match command {
-        None => run_embedder_default(cli.verify, cli.headless, no_media),
-        Some(CommandKind::WebDriver(args)) => run_embedder_webdriver(cli.verify, no_media, args),
-        Some(CommandKind::Cdp(args)) => run_embedder_cdp(cli.verify, no_media, args),
+        None => run_embedder_default(cli.verify, cli.headless),
+        Some(CommandKind::WebDriver(args)) => run_embedder_webdriver(cli.verify, args),
+        Some(CommandKind::Cdp(args)) => run_embedder_cdp(cli.verify, args),
         Some(CommandKind::Wpt { .. }) => Ok(()),
     };
 

--- a/user_agent/src/user_agent.rs
+++ b/user_agent/src/user_agent.rs
@@ -934,7 +934,6 @@ impl UserAgent {
         host: Arc<dyn Embedder>,
         webview_provider_sender: Sender<WebviewProviderMessage>,
         trace_sender: Option<TraceSender>,
-        no_media: bool,
     ) -> Result<Self, String> {
         let (command_sender, command_receiver) = unbounded();
         let mut worker = UserAgentWorker::new(
@@ -943,7 +942,6 @@ impl UserAgent {
             host,
             webview_provider_sender,
             trace_sender,
-            no_media,
         );
         let join_handle = thread::Builder::new()
             .name(String::from("formal-web:user-agent"))
@@ -1299,7 +1297,6 @@ impl UserAgentWorker {
         host: Arc<dyn Embedder>,
         webview_provider_sender: Sender<WebviewProviderMessage>,
         trace_sender: Option<TraceSender>,
-        no_media: bool,
     ) -> Self {
         let (fetch_command_sender, fetch_command_receiver) = unbounded();
         let fetch_user_agent_command_sender = user_agent_command_sender.clone();
@@ -1329,12 +1326,8 @@ impl UserAgentWorker {
             .unwrap_or_else(|error| panic!("failed to spawn formal-web-timer thread: {error}"));
 
         let (media_command_sender, media_command_receiver) = unbounded();
-        #[cfg(not(feature = "media"))]
-        let _ = no_media; // suppress unused warning when media feature is disabled
         #[cfg(feature = "media")]
-        let media_join_handle = if no_media {
-            None
-        } else {
+        let media_join_handle = {
             let media_user_agent_command_sender = user_agent_command_sender.clone();
             Some(
                 thread::Builder::new()
@@ -3711,8 +3704,8 @@ impl UserAgentWorker {
         video_paint_id: VideoPaintId,
     ) {
         if self.media_join_handle.is_none() {
-            // No media worker thread — media support is disabled (either via
-            // --no-media flag or media feature compiled out). Silently ignore.
+            // No media worker thread — media support is disabled (media feature
+            // compiled out). Silently ignore.
             debug!(
                 "[media] load requested but media disabled url={} traversable={}",
                 url, traversable_id.0,

--- a/webview/Cargo.toml
+++ b/webview/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.1.0"
 edition = "2024"
 publish = false
 
+[features]
+default = ["media"]
+media = ["user_agent/media"]
+
 [dependencies]
 anyrender = { version = "0.10", features = ["serde"] }
 blitz-traits = { path = "../vendor/blitz/packages/blitz-traits", default-features = false }
@@ -15,6 +19,6 @@ kurbo = "0.13"
 peniko = "0.6"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-user_agent = { path = "../user_agent" }
+user_agent = { path = "../user_agent", default-features = false }
 log = "0.4"
 verification = { path = "../verification" }

--- a/webview/src/lib.rs
+++ b/webview/src/lib.rs
@@ -112,14 +112,12 @@ impl WebviewProvider {
     pub fn new(
         embedder: Arc<dyn Embedder>,
         trace_sender: Option<TraceSender>,
-        no_media: bool,
     ) -> Result<Self, String> {
         let (provider_message_sender, provider_message_receiver) = unbounded();
         let user_agent = UserAgent::start(
             embedder.clone(),
             provider_message_sender,
             trace_sender,
-            no_media,
         )?;
 
         Ok(Self {


### PR DESCRIPTION
   Media support is now purely compile-time: either the `media` Cargo feature
   is enabled (default, requires GStreamer) or disabled with
   `--no-default-features`. The `--no-media` runtime flag and all its internal
   plumbing have been removed — there is no longer a way to skip the media
   worker while keeping GStreamer linked.

   Files changed:
   - src/main.rs, embedder/src/main.rs, embedder/src/event_loop.rs, webview/src/lib.rs, user_agent/src/user_agent.rs — removed no_media from CLI args, function signatures, struct fields, and parameter passing
   - README.md, AGENTS.md — consolidated media docs and removed --no-media references