### PR TITLE
Implement WindowProxy as a native JavaScript Proxy via ProxyCreate

### DIFF
--- a/.pi/extensions/web_standards/README.md
+++ b/.pi/extensions/web_standards/README.md
@@ -118,3 +118,44 @@ Any spec that serves a complete, queryable HTML document. Common targets:
 - All downloaded spec HTML stays in memory for the session and is cleared on `session_shutdown`.
 - `spec_ref_links` matches the `ref-for-{id}` prefix on any element; the WHATWG spec uses `<a>` elements with this pattern. Circled-digit suffixes (U+2460–U+2473, compound) distinguish multiple references.
 - URL fragments use `encodeURI` to percent-encode non-ASCII characters (circled digits) for correct browser navigation.
+
+## Finding Boa API matches via spec anchors
+
+When implementing Web IDL or HTML algorithms in Rust with Boa, the ECMAScript
+operations referenced by web specs (e.g. `ProxyCreate`, `CreateBuiltinFunction`,
+`SetImmutablePrototype`) map to Boa's Rust API.  The ECMAScript spec anchor
+(e.g. `#sec-proxycreate`) pinpoints the implementation location.
+
+**Methodology:**
+1. Web IDL/HTML specs link to ECMAScript operations with URLs like
+   `https://tc39.es/ecma262/#sec-proxycreate`.
+2. Search for that anchor (`sec-proxycreate`) within vendored Boa to find the
+   corresponding Rust function (e.g. `Proxy::create`).
+3. The spec anchor often appears in Boa's doc comments directly:
+   ```rust
+   // `10.5.14 ProxyCreate ( target, handler )`
+   //
+   // [spec]: https://tc39.es/ecma262/#sec-proxycreate
+   pub fn create(target, handler, context) { ... }
+   ```
+4. If the function is `pub(crate)`, check whether a public alternative exists
+   or whether making it `pub` is appropriate (e.g. `Proxy::create` and
+   `Proxy::try_data` in `vendor/boa/core/engine/src/builtins/proxy/mod.rs`).
+
+**Common ECMAScript → Boa mappings:**
+
+| Spec operation | Boa API | Notes |
+|---|---|---|
+| `ProxyCreate(target, handler)` | `boa_engine::builtins::proxy::Proxy::create(target, handler, context)` | Returns `JsResult<JsObject>` |
+| `CreateBuiltinFunction(steps, length, name, ...)` | `FunctionObjectBuilder::new(realm, NativeFunction::from_copy_closure_with_captures(...)).name(name).length(length).build()` | `NativeFunction::from_copy_closure_with_captures` for state-carrying traps |
+| `OrdinaryObjectCreate(null, slots)` | `JsObject::with_null_proto()` | Creates object with null prototype |
+| `CreateDataPropertyOrThrow(O, P, V)` | `handler.create_data_property_or_throw(key, value, context)` | Method on `JsObject` |
+| `SetImmutablePrototype(O, V)` | Check `window.prototype()` then `JsObject::equals` | Use the public `prototype()` method, not `__get_prototype_of__` |
+| `IsCallable(target)` | `target.is_callable()` | Method on `JsObject` |
+| `IsConstructor(target)` | `target.is_constructor()` | Method on `JsObject` |
+| `ToPropertyDescriptor(obj)` | `obj.to_property_descriptor(context)` | Method on `JsObject` |
+| `GetMethod(V, P)` | `handler.get_method(key, context)` | Currently `pub(crate)` in Boa |
+
+When the spec anchor URL is shortened (e.g. `https://tc39.es/ecma262/#sec-proxycreate`
+without the multipage path), search for just the anchor (`sec-proxycreate`) in the
+Boa codebase.  Boa's doc comments use both full multipage URLs and shortened ones.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -302,7 +302,7 @@ At the end of each task, run the following steps **in order**:
      ./verification/verify-navigation.sh
      ```
 
-7. **Suggest a commit message** — Propose a commit message for changes tracked by git.
+7. **Suggest a commit message** — Whenever asked for a commit message (whether at end-of-task or any other time), propose a message for the current `git diff HEAD` (the uncommitted changes), not for the entire session's work.  Run `git diff --stat HEAD` to see what changed, and `git diff HEAD` to read the diff before writing the message.
 
 8. Do NOT use `collect_session` — that tool has been removed. Sessions are collected automatically on shutdown.
 

--- a/content/src/html.rs
+++ b/content/src/html.rs
@@ -50,12 +50,8 @@ pub(crate) use location::LocationError;
 pub use window::Window;
 pub(crate) use window::window_computed_style_properties_for_element;
 pub(crate) use window_or_worker_global_scope::WindowOrWorkerGlobalScope;
-// Kept for future WindowProxy exotic-object implementation.
-// Currently unused because the transparent proxy returns the Window
-// directly (same-origin fast path).  Will be used when cross-origin
-// WindowProxy exotic objects are implemented.
-#[allow(unused_imports)]
-pub(crate) use windowproxy::WindowProxy;
+pub(crate) use windowproxy::create_window_proxy;
+pub(crate) use windowproxy::resolve_window;
 
 use blitz_dom::{BaseDocument, DocumentConfig};
 use std::{cell::RefCell, rc::Rc};

--- a/content/src/html/window.rs
+++ b/content/src/html/window.rs
@@ -285,7 +285,7 @@ pub(crate) fn window_open_steps(
     let window = result
         .return_window
         .expect("window_open_steps: all navigable branches set a return window");
-    Ok(crate::js::bindings::html::create_window_proxy(window))
+    crate::html::create_window_proxy(&window, context)
 }
 
 /// <https://html.spec.whatwg.org/#get-noopener-for-window-open>

--- a/content/src/html/windowproxy.rs
+++ b/content/src/html/windowproxy.rs
@@ -20,6 +20,8 @@ struct WindowProxyHandler {
 
 impl JsData for WindowProxyHandler {}
 
+// Step 1 of every WindowProxy internal method:
+// "Let W be the value of the [[Window]] internal slot of this."
 fn handler_window(this: &JsValue) -> JsResult<JsObject> {
     let obj = this.as_object().ok_or_else(|| {
         JsNativeError::typ()
@@ -87,6 +89,7 @@ fn trap_define_property(
     let key = args.get(1).unwrap_or(&undefined_val);
     let desc_obj = args.get(2).unwrap_or(&undefined_val);
 
+    // Step 2: "If IsPlatformObjectSameOrigin(W) is true:"
     // Step 2.1: "If P is an array index property name, return false."
     if is_array_index_key(key) {
         return Ok(JsValue::new(false));
@@ -112,7 +115,12 @@ fn trap_get(
     let undefined_val = JsValue::undefined();
     let key_val = args.get(1).unwrap_or(&undefined_val);
 
-    // Step 3: "Return ? OrdinaryGet(this, P, Receiver)."
+    // Step 2: "Check if an access between two browsing contexts should be
+    //           reported, given the current global object's browsing context,
+    //           W's browsing context, P, and the current settings object."
+    // Note: Access reporting is not yet implemented.
+    // Step 3: "If IsPlatformObjectSameOrigin(W) is true, then return ?
+    //           OrdinaryGet(this, P, Receiver)."
     let prop_key = key_val.to_property_key(context)?;
     win.get(prop_key, context)
 }
@@ -128,6 +136,11 @@ fn trap_set(
     let undefined_val = JsValue::undefined();
     let key = args.get(1).unwrap_or(&undefined_val);
 
+    // Step 2: "Check if an access between two browsing contexts should be
+    //           reported, given the current global object's browsing context,
+    //           W's browsing context, P, and the current settings object."
+    // Note: Access reporting is not yet implemented.
+    // Step 3: "If IsPlatformObjectSameOrigin(W) is true:"
     // Step 3.1: "If P is an array index property name, return false."
     if is_array_index_key(key) {
         return Ok(JsValue::new(false));
@@ -151,9 +164,16 @@ fn trap_delete_property(
     let undefined_val = JsValue::undefined();
     let key = args.get(1).unwrap_or(&undefined_val);
 
+    // Step 2: "If IsPlatformObjectSameOrigin(W) is true:"
     // Step 2.1: "If P is an array index property name:"
     if is_array_index_key(key) {
         let prop_key = key.to_property_key(context)?;
+        // Step 2.1.1: "Let desc be ! this.[[GetOwnProperty]](P)."
+        // Note: Uses has_own_property (public API) instead of
+        // [[GetOwnProperty]] (pub(crate)).  The result is equivalent:
+        // if desc is undefined, return true; otherwise return false.
+        // Step 2.1.2: "If desc is undefined, then return true."
+        // Step 2.1.3: "Return false."
         let has = win.has_own_property(prop_key, context)?;
         return Ok(JsValue::new(!has));
     }
@@ -175,6 +195,9 @@ fn trap_has(
     let undefined_val = JsValue::undefined();
     let key = args.get(1).unwrap_or(&undefined_val);
 
+    // Note: The WindowProxy spec does not override [[HasProperty]].  This
+    // trap is provided for completeness.  "length" returns true (child
+    // frame count); all other keys delegate to the target's [[HasProperty]].
     if let Some(s) = key.as_string() {
         if s == "length" {
             return Ok(JsValue::new(true));
@@ -194,9 +217,12 @@ fn trap_get_prototype_of(
     _context: &mut Context,
 ) -> JsResult<JsValue> {
     let win = handler_window(this)?;
+    // Step 2: "If IsPlatformObjectSameOrigin(W) is true, then return !
+    //           OrdinaryGetPrototypeOf(W)."
     let proto = win.prototype();
     match proto {
         Some(p) => Ok(JsValue::from(p)),
+        // Step 3: "Return null."
         None => Ok(JsValue::null()),
     }
 }
@@ -213,7 +239,9 @@ fn trap_own_keys(
     // Step 2: "Let maxProperties be W's associated Document's document-tree
     //          child navigables's size."
     // Note: Child navigable support not yet implemented — keys is empty.
-    // Step 4: "Return the concatenation of keys and OrdinaryOwnPropertyKeys(W)."
+    // Step 3: "Let keys be the range 0 to maxProperties, exclusive."
+    // Step 4: "If IsPlatformObjectSameOrigin(W) is true, then return the
+    //           concatenation of keys and OrdinaryOwnPropertyKeys(W)."
     let window_keys = win.own_property_keys(context)?;
     let key_values: Vec<JsValue> = window_keys.into_iter().map(JsValue::from).collect();
 

--- a/content/src/html/windowproxy.rs
+++ b/content/src/html/windowproxy.rs
@@ -5,7 +5,7 @@ use boa_engine::{
     builtins::proxy::Proxy,
     js_string,
     native_function::NativeFunction,
-    object::{FunctionObjectBuilder, JsPrototype, ObjectInitializer},
+    object::{FunctionObjectBuilder, JsPrototype},
     property::{PropertyDescriptor, PropertyKey},
 };
 use boa_gc::{Finalize, Trace};
@@ -75,32 +75,6 @@ fn trap_is_extensible(
     Ok(JsValue::new(true))
 }
 
-/// <https://html.spec.whatwg.org/#windowproxy-getownproperty>
-fn trap_get_own_property_descriptor(
-    this: &JsValue,
-    args: &[JsValue],
-    _captures: &WindowProxyHandler,
-    context: &mut Context,
-) -> JsResult<JsValue> {
-    let win = handler_window(this)?;
-    let undefined_val = JsValue::undefined();
-    let key = args.get(1).unwrap_or(&undefined_val);
-
-    // Step 2: "If P is an array index property name:"
-    if is_array_index_key(key) {
-        // Note: Child navigable lookup not yet implemented.
-        return Ok(JsValue::undefined());
-    }
-
-    // Step 3: "Return ! OrdinaryGetOwnProperty(W, P)."
-    let prop_key = property_key_from_value_with_ctx(key, context);
-    let desc = win.borrow().properties().get(&prop_key);
-    match desc {
-        None => Ok(JsValue::undefined()),
-        Some(desc) => Ok(descriptor_to_js_value(&desc, context)),
-    }
-}
-
 /// <https://html.spec.whatwg.org/#windowproxy-defineownproperty>
 fn trap_define_property(
     this: &JsValue,
@@ -120,7 +94,7 @@ fn trap_define_property(
 
     // Step 2.2: "Return ? OrdinaryDefineOwnProperty(W, P, Desc)."
     let desc = desc_from_obj(desc_obj, context)?;
-    let prop_key = property_key_from_value_with_ctx(key, context);
+    let prop_key = key.to_property_key(context)?;
     match win.define_property_or_throw(prop_key, desc, context) {
         Ok(_) => Ok(JsValue::new(true)),
         Err(_) => Ok(JsValue::new(false)),
@@ -139,7 +113,7 @@ fn trap_get(
     let key_val = args.get(1).unwrap_or(&undefined_val);
 
     // Step 3: "Return ? OrdinaryGet(this, P, Receiver)."
-    let prop_key = property_key_from_value_with_ctx(key_val, context);
+    let prop_key = key_val.to_property_key(context)?;
     win.get(prop_key, context)
 }
 
@@ -161,7 +135,7 @@ fn trap_set(
 
     // Step 3.2: "Return ? OrdinarySet(W, P, V, Receiver)."
     let value = args.get(2).cloned().unwrap_or(JsValue::undefined());
-    let prop_key = property_key_from_value_with_ctx(key, context);
+    let prop_key = key.to_property_key(context)?;
     let result = win.set(prop_key, value, false, context)?;
     Ok(JsValue::new(result))
 }
@@ -179,13 +153,13 @@ fn trap_delete_property(
 
     // Step 2.1: "If P is an array index property name:"
     if is_array_index_key(key) {
-        let prop_key = property_key_from_value_with_ctx(key, context);
+        let prop_key = key.to_property_key(context)?;
         let has = win.has_own_property(prop_key, context)?;
         return Ok(JsValue::new(!has));
     }
 
     // Step 2.2: "Return ? OrdinaryDelete(W, P)."
-    let prop_key = property_key_from_value_with_ctx(key, context);
+    let prop_key = key.to_property_key(context)?;
     let result = win.delete_property_or_throw(prop_key, context)?;
     Ok(JsValue::new(result))
 }
@@ -207,7 +181,7 @@ fn trap_has(
         }
     }
 
-    let prop_key = property_key_from_value_with_ctx(key, context);
+    let prop_key = key.to_property_key(context)?;
     let result = win.has_property(prop_key, context)?;
     Ok(JsValue::new(result))
 }
@@ -288,7 +262,7 @@ pub(crate) fn create_window_proxy(
         ("setPrototypeOf", 2, trap_set_prototype_of as _),
         ("isExtensible", 1, trap_is_extensible as _),
         ("preventExtensions", 1, trap_prevent_extensions as _),
-        ("getOwnPropertyDescriptor", 2, trap_get_own_property_descriptor as _),
+
         ("defineProperty", 3, trap_define_property as _),
         ("get", 3, trap_get as _),
         ("set", 4, trap_set as _),
@@ -316,7 +290,7 @@ pub(crate) fn create_window_proxy(
         handler.create_data_property_or_throw(name, fn_obj, context)?;
     }
 
-        Proxy::create(&JsValue::from(window.clone()), &handler.into(), context)
+    Proxy::create(&JsValue::from(window.clone()), &handler.into(), context)
         .map(JsValue::from)
 }
 
@@ -331,54 +305,6 @@ pub(crate) fn resolve_window(value: &JsValue, context: &Context) -> JsObject {
         return object.clone();
     }
     context.global_object()
-}
-
-fn descriptor_to_js_value(desc: &PropertyDescriptor, context: &mut Context) -> JsValue {
-    if desc.is_data_descriptor() {
-        let mut obj = ObjectInitializer::new(context);
-        obj.property(js_string!("value"), desc.expect_value().clone(), Default::default());
-        obj.property(js_string!("writable"), desc.expect_writable(), Default::default());
-        obj.property(js_string!("enumerable"), desc.expect_enumerable(), Default::default());
-        obj.property(js_string!("configurable"), desc.expect_configurable(), Default::default());
-        obj.build().into()
-    } else if desc.is_accessor_descriptor() {
-        let mut obj = ObjectInitializer::new(context);
-        if let Some(get) = desc.get() {
-            if !get.is_undefined() {
-                obj.property(js_string!("get"), get.clone(), Default::default());
-            }
-        }
-        if let Some(set) = desc.set() {
-            if !set.is_undefined() {
-                obj.property(js_string!("set"), set.clone(), Default::default());
-            }
-        }
-        obj.property(js_string!("enumerable"), desc.expect_enumerable(), Default::default());
-        obj.property(js_string!("configurable"), desc.expect_configurable(), Default::default());
-        obj.build().into()
-    } else {
-        let mut obj = ObjectInitializer::new(context);
-        obj.property(js_string!("enumerable"), desc.expect_enumerable(), Default::default());
-        obj.property(js_string!("configurable"), desc.expect_configurable(), Default::default());
-        obj.build().into()
-    }
-}
-
-fn property_key_from_value_with_ctx(key: &JsValue, context: &mut Context) -> PropertyKey {
-    if let Some(s) = key.as_string() {
-        PropertyKey::String(s.clone())
-    } else if let Some(n) = key.as_number() {
-        if n.fract() == 0.0 && n >= 0.0 && n < u32::MAX as f64 {
-            PropertyKey::from(n as u32)
-        } else {
-            PropertyKey::from(n)
-        }
-    } else if let Some(sym) = key.as_symbol() {
-        PropertyKey::Symbol(sym)
-    } else {
-        let s = key.to_string(context).unwrap_or_else(|_| js_string!(""));
-        PropertyKey::String(s)
-    }
 }
 
 fn desc_from_obj(desc_obj: &JsValue, context: &mut Context) -> JsResult<PropertyDescriptor> {

--- a/content/src/html/windowproxy.rs
+++ b/content/src/html/windowproxy.rs
@@ -1,48 +1,43 @@
 //! <https://html.spec.whatwg.org/#the-windowproxy-exotic-object>
 //!
 //! The WindowProxy is an exotic object that wraps a Window ordinary object
-//! and is implemented as a JavaScript Proxy (see Web IDL observable array
-//! pattern in §3.10).  The Proxy target is the inner Window and the handler
-//! is an ordinary object whose trap functions implement the WindowProxy
-//! semantics per HTML §7.2.3.
+//! and is implemented as a JavaScript Proxy following the Web IDL observable
+//! array pattern (§3.10).  The Proxy target is the inner Window and the
+//! handler is an ordinary object whose trap functions implement the
+//! WindowProxy semantics per HTML §7.2.3.
 //!
-//! For same-origin access (currently always true) most operations delegate
-//! to the inner Window object via the default Proxy behavior.  Only traps
-//! that differ from the default Proxy behavior are provided:
-//! - [[SetPrototypeOf]]: SetImmutablePrototype
-//! - [[PreventExtensions]]: always false
-//!
-//! [[IsExtensible]] is left to the default (delegates to target), which
-//! satisfies the Proxy invariant (trap result must match target result)
-//! while still returning the correct value for an extensible Window.
+//! Each trap matches a WindowProxy internal method.  Traps that differ from
+//! the default Proxy behavior (which delegates to the target) are explicitly
+//! implemented.  Traps whose default behavior matches the WindowProxy spec
+//! for the same-origin case are omitted — the Proxy spec's default
+//! [[GetOwnProperty]] / [[Get]] / [[Set]] / [[Delete]] / [[DefineOwnProperty]]
+//! / [[HasProperty]] / [[OwnPropertyKeys]] all delegate to the target's
+//! ordinary operations, which IS the WindowProxy same-origin algorithm.
 
 use boa_engine::{
-    Context, JsObject, JsResult, JsValue,
+    Context, JsNativeError, JsObject, JsResult, JsValue,
     builtins::proxy::Proxy,
     js_string,
     native_function::NativeFunction,
     object::FunctionObjectBuilder,
+    property::{PropertyDescriptor, PropertyKey},
 };
 
 /// <https://html.spec.whatwg.org/#the-windowproxy-exotic-object>
-///
-/// Create a WindowProxy exotic object wrapping the given Window, using a
-/// JavaScript Proxy with custom handler traps.
 pub(crate) fn create_window_proxy(
     window: &JsObject,
     context: &mut Context,
 ) -> JsResult<JsValue> {
-    // Create handler with null prototype, matching the Web IDL observable
-    // array pattern.
+    // Create handler with null prototype (Web IDL observable array pattern).
     let handler = JsObject::with_null_proto();
 
-    // ── setPrototypeOf trap ──
+    // ── [[SetPrototypeOf]] trap ──
     // <https://html.spec.whatwg.org/#windowproxy-setprototypeof>
-    // Implements SetImmutablePrototype: only succeeds if V matches current.
+    // Step 1: "Return ! SetImmutablePrototype(this, V)."
     {
         let trap = NativeFunction::from_copy_closure_with_captures(
-            |_this, args, window: &JsObject, _context| {
-                let current = window.prototype();
+            |_this, args, win: &JsObject, _context| {
+                let current = win.prototype();
                 let undefined_val = JsValue::undefined();
                 let val = args.get(1).unwrap_or(&undefined_val);
 
@@ -56,40 +51,163 @@ pub(crate) fn create_window_proxy(
             },
             window.clone(),
         );
-        let set_prototype_of_fn = FunctionObjectBuilder::new(context.realm(), trap)
+        let fn_obj = FunctionObjectBuilder::new(context.realm(), trap)
             .name(js_string!("setPrototypeOf"))
             .length(2)
             .build();
-        handler.create_data_property_or_throw(
-            js_string!("setPrototypeOf"),
-            set_prototype_of_fn,
-            context,
-        )?;
+        handler.create_data_property_or_throw(js_string!("setPrototypeOf"), fn_obj, context)?;
     }
 
-    // ── preventExtensions trap ──
+    // ── [[PreventExtensions]] trap ──
     // <https://html.spec.whatwg.org/#windowproxy-preventextensions>
+    // Step 1: "Return false."
     {
         let trap = NativeFunction::from_copy_closure_with_captures(
-            |_this, _args, _window: &JsObject, _context| Ok(JsValue::new(false)),
+            |_this, _args, _win: &JsObject, _context| Ok(JsValue::new(false)),
             window.clone(),
         );
-        let prevent_extensions_fn = FunctionObjectBuilder::new(context.realm(), trap)
+        let fn_obj = FunctionObjectBuilder::new(context.realm(), trap)
             .name(js_string!("preventExtensions"))
             .length(1)
             .build();
         handler.create_data_property_or_throw(
             js_string!("preventExtensions"),
-            prevent_extensions_fn,
+            fn_obj,
             context,
         )?;
     }
 
-    // All other traps (get, set, has, deleteProperty, defineProperty,
-    // getOwnPropertyDescriptor, ownKeys, getPrototypeOf) are NOT provided.
-    // The default Proxy behavior delegates them to the target (Window),
-    // which is correct for the same-origin case.
+    // ── [[DefineOwnProperty]] trap ──
+    // <https://html.spec.whatwg.org/#windowproxy-defineownproperty>
+    // Array index: return false (spec step 2.1).
+    // Non-array-index: Return ? OrdinaryDefineOwnProperty(W, P, Desc).
+    {
+        let trap = NativeFunction::from_copy_closure_with_captures(
+            |_this, args, win: &JsObject, context| {
+                let undefined_val = JsValue::undefined();
+                let key = args.get(1).unwrap_or(&undefined_val);
+                let desc_obj = args.get(2).unwrap_or(&undefined_val);
 
+                // Step 2.1: "If P is an array index property name, return false."
+                if is_array_index_key(key) {
+                    return Ok(JsValue::new(false));
+                }
+
+                // Step 2.2: "Return ? OrdinaryDefineOwnProperty(W, P, Desc)."
+                let desc = desc_from_obj(desc_obj, context)?;
+                let prop_key = property_key_from_value_with_ctx(key, context);
+                match win.define_property_or_throw(prop_key, desc, context) {
+                    Ok(_) => Ok(JsValue::new(true)),
+                    Err(_) => Ok(JsValue::new(false)),
+                }
+            },
+            window.clone(),
+        );
+        let fn_obj = FunctionObjectBuilder::new(context.realm(), trap)
+            .name(js_string!("defineProperty"))
+            .length(3)
+            .build();
+        handler.create_data_property_or_throw(js_string!("defineProperty"), fn_obj, context)?;
+    }
+
+    // ── [[Set]] trap ──
+    // <https://html.spec.whatwg.org/#windowproxy-set>
+    // Array index: return false (spec step 3.1).
+    // Non-array-index: Return ? OrdinarySet(W, P, V, Receiver).
+    {
+        let trap = NativeFunction::from_copy_closure_with_captures(
+            |_this, args, win: &JsObject, context| {
+                let undefined_val = JsValue::undefined();
+                let key = args.get(1).unwrap_or(&undefined_val);
+
+                // Step 3.1: "If P is an array index property name, return false."
+                if is_array_index_key(key) {
+                    return Ok(JsValue::new(false));
+                }
+
+                // Step 3.2: "Return ? OrdinarySet(W, P, V, Receiver)."
+                let value = args.get(2).cloned().unwrap_or(JsValue::undefined());
+                let prop_key = property_key_from_value_with_ctx(key, context);
+                // target.set() uses self as receiver, which is correct here
+                // because OrdinarySet(W, P, V, Receiver) starts property
+                // lookup on W (the Window), not on the proxy.
+                let result = win.set(prop_key, value, false, context)?;
+                Ok(JsValue::new(result))
+            },
+            window.clone(),
+        );
+        let fn_obj = FunctionObjectBuilder::new(context.realm(), trap)
+            .name(js_string!("set"))
+            .length(4)
+            .build();
+        handler.create_data_property_or_throw(js_string!("set"), fn_obj, context)?;
+    }
+
+    // ── [[Delete]] trap ──
+    // <https://html.spec.whatwg.org/#windowproxy-delete>
+    // Array index: check own property (spec step 2.1).
+    // Non-array-index: Return ? OrdinaryDelete(W, P).
+    {
+        let trap = NativeFunction::from_copy_closure_with_captures(
+            |_this, args, win: &JsObject, context| {
+                let undefined_val = JsValue::undefined();
+                let key = args.get(1).unwrap_or(&undefined_val);
+
+                // Step 2.1: "If P is an array index property name:"
+                if is_array_index_key(key) {
+                    let prop_key = property_key_from_value_with_ctx(key, context);
+                    // Step 2.1.1: "Let desc be ! this.[[GetOwnProperty]](P)."
+                    // Step 2.1.2: "If desc is undefined, return true."
+                    // Step 2.1.3: "Return false."
+                    let has = win.has_own_property(prop_key, context)?;
+                    return Ok(JsValue::new(!has));
+                }
+
+                // Step 2.2: "Return ? OrdinaryDelete(W, P)."
+                let prop_key = property_key_from_value_with_ctx(key, context);
+                let result = win.delete_property_or_throw(prop_key, context)?;
+                Ok(JsValue::new(result))
+            },
+            window.clone(),
+        );
+        let fn_obj = FunctionObjectBuilder::new(context.realm(), trap)
+            .name(js_string!("deleteProperty"))
+            .length(2)
+            .build();
+        handler.create_data_property_or_throw(js_string!("deleteProperty"), fn_obj, context)?;
+    }
+
+    // ── [[GetPrototypeOf]] not provided ──
+    // <https://html.spec.whatwg.org/#windowproxy-getprototypeof>
+    // Same-origin: delegates to OrdinaryGetPrototypeOf(W) → Proxy default.
+    // Cross-origin: return null — not yet active.
+
+    // ── [[IsExtensible]] not provided ──
+    // <https://html.spec.whatwg.org/#windowproxy-isextensible>
+    // Proxy default delegates to target.[[IsExtensible]]().  For an
+    // extensible Window this returns true, matching the spec.  Providing
+    // a trap would risk Proxy invariant violations (if target differs).
+
+    // ── [[GetOwnProperty]] not provided ──
+    // <https://html.spec.whatwg.org/#windowproxy-getownproperty>
+    // Same-origin non-array-index: Proxy default delegates to target's
+    // [[GetOwnProperty]] which IS OrdinaryGetOwnProperty(W, P).
+    // Array-index child navigable support not yet implemented.
+
+    // ── [[Get]] not provided ──
+    // <https://html.spec.whatwg.org/#windowproxy-get>
+    // Same-origin: Proxy default calls target.[[Get]](P, Receiver) with
+    // the proxy as receiver — this IS OrdinaryGet(this, P, Receiver).
+
+    // ── [[HasProperty]] not provided ──
+    // Not listed as overridden in the WindowProxy spec.  Proxy default is correct.
+
+    // ── [[OwnPropertyKeys]] not provided ──
+    // <https://html.spec.whatwg.org/#windowproxy-ownpropertykeys>
+    // Same-origin: Proxy default returns target's own property keys.
+    // Child navigable indices not yet implemented.
+
+    // ── Create the Proxy ──
     Proxy::create(&JsValue::from(window.clone()), &handler.into(), context)
         .map(JsValue::from)
 }
@@ -112,6 +230,67 @@ pub(crate) fn resolve_window(value: &JsValue, context: &Context) -> JsObject {
         return object.clone();
     }
     context.global_object()
+}
+
+// ── Helper functions ──
+
+/// <https://webidl.spec.whatwg.org/#dfn-array-index-property-name>
+fn is_array_index_key(key: &JsValue) -> bool {
+    if let Some(s) = key.as_string() {
+        let s = s.to_std_string_escaped();
+        if s.is_empty() {
+            return false;
+        }
+        let parsed: u64 = match s.parse() {
+            Ok(v) => v,
+            Err(_) => return false,
+        };
+        if parsed >= u32::MAX as u64 {
+            return false;
+        }
+        parsed.to_string() == s
+    } else if key.is_number() {
+        if let Some(n) = key.as_number() {
+            n.fract() == 0.0 && n >= 0.0 && n < u32::MAX as f64
+        } else {
+            false
+        }
+    } else {
+        false
+    }
+}
+
+/// Convert a JsValue property key to a PropertyKey, using a Context
+/// for ToString conversion when needed.
+fn property_key_from_value_with_ctx(
+    key: &JsValue,
+    context: &mut Context,
+) -> PropertyKey {
+    if let Some(s) = key.as_string() {
+        PropertyKey::String(s.clone())
+    } else if let Some(n) = key.as_number() {
+        if n.fract() == 0.0 && n >= 0.0 && n < u32::MAX as f64 {
+            PropertyKey::from(n as u32)
+        } else {
+            PropertyKey::from(n)
+        }
+    } else if let Some(sym) = key.as_symbol() {
+        PropertyKey::Symbol(sym)
+    } else {
+        // null, undefined, boolean — convert via ToString
+        let s = key.to_string(context).unwrap_or_else(|_| js_string!(""));
+        PropertyKey::String(s)
+    }
+}
+
+/// Convert a JsValue descriptor object to a PropertyDescriptor.
+fn desc_from_obj(desc_obj: &JsValue, context: &mut Context) -> JsResult<PropertyDescriptor> {
+    match desc_obj.as_object() {
+        Some(o) => o.to_property_descriptor(context),
+        None => Err(JsNativeError::typ()
+            .with_message("Property descriptor must be an object")
+            .into()),
+    }
 }
 
 // ── Cross-origin helper operations ──
@@ -148,22 +327,16 @@ fn cross_origin_window_properties() -> Vec<CrossOriginPropertyEntry> {
 
 /// <https://html.spec.whatwg.org/#crossoriginownpropertykeys-(-o-)>
 #[allow(dead_code)]
-pub(crate) fn cross_origin_own_property_keys() -> Vec<boa_engine::property::PropertyKey> {
-    let mut keys = cross_origin_window_properties()
+pub(crate) fn cross_origin_own_property_keys() -> Vec<PropertyKey> {
+    let mut keys: Vec<PropertyKey> = cross_origin_window_properties()
         .into_iter()
-        .map(|p| boa_engine::property::PropertyKey::String(js_string!(p.property)))
-        .collect::<Vec<_>>();
+        .map(|p| PropertyKey::String(js_string!(p.property)))
+        .collect();
 
-    keys.push(boa_engine::property::PropertyKey::String(js_string!("then")));
-    keys.push(boa_engine::property::PropertyKey::Symbol(
-        boa_engine::JsSymbol::to_string_tag(),
-    ));
-    keys.push(boa_engine::property::PropertyKey::Symbol(
-        boa_engine::JsSymbol::has_instance(),
-    ));
-    keys.push(boa_engine::property::PropertyKey::Symbol(
-        boa_engine::JsSymbol::is_concat_spreadable(),
-    ));
+    keys.push(PropertyKey::String(js_string!("then")));
+    keys.push(PropertyKey::Symbol(boa_engine::JsSymbol::to_string_tag()));
+    keys.push(PropertyKey::Symbol(boa_engine::JsSymbol::has_instance()));
+    keys.push(PropertyKey::Symbol(boa_engine::JsSymbol::is_concat_spreadable()));
 
     keys
 }

--- a/content/src/html/windowproxy.rs
+++ b/content/src/html/windowproxy.rs
@@ -1,15 +1,4 @@
 //! <https://html.spec.whatwg.org/#the-windowproxy-exotic-object>
-//!
-//! The WindowProxy is an exotic object that wraps a Window ordinary object
-//! and is implemented as a JavaScript Proxy following the Web IDL observable
-//! array pattern (§3.10).  The Proxy target is the inner Window and the
-//! handler is an ordinary object whose trap functions implement the
-//! WindowProxy semantics per HTML §7.2.3.
-//!
-//! The handler carries a [[Window]] internal slot (via JsData) referencing
-//! the wrapped Window.  Each trap reads the handler's internal slot via
-//! `this`, replicating the observable array pattern where the handler
-//! stores state in internal slots ([[BackingList]], [[Type]], etc.).
 
 use boa_engine::{
     Context, JsData, JsNativeError, JsObject, JsResult, JsValue,
@@ -23,8 +12,6 @@ use boa_gc::{Finalize, Trace};
 
 use crate::webidl::is_array_index_key;
 
-// ── Handler struct with [[Window]] internal slot ──
-
 /// <https://webidl.spec.whatwg.org/#creating-an-observable-array-exotic-object>
 #[derive(Trace, Finalize)]
 struct WindowProxyHandler {
@@ -32,8 +19,6 @@ struct WindowProxyHandler {
 }
 
 impl JsData for WindowProxyHandler {}
-
-// ── Helper: extract Window from handler (via `this`) ──
 
 fn handler_window(this: &JsValue) -> JsResult<JsObject> {
     let obj = this.as_object().ok_or_else(|| {
@@ -46,8 +31,6 @@ fn handler_window(this: &JsValue) -> JsResult<JsObject> {
     })?;
     Ok(handler.window.clone())
 }
-
-// ── Trap functions ──
 
 /// <https://html.spec.whatwg.org/#windowproxy-setprototypeof>
 fn trap_set_prototype_of(
@@ -77,6 +60,7 @@ fn trap_prevent_extensions(
     _captures: &WindowProxyHandler,
     _context: &mut Context,
 ) -> JsResult<JsValue> {
+    // Step 1: "Return false."
     Ok(JsValue::new(false))
 }
 
@@ -87,6 +71,7 @@ fn trap_is_extensible(
     _captures: &WindowProxyHandler,
     _context: &mut Context,
 ) -> JsResult<JsValue> {
+    // Step 1: "Return true."
     Ok(JsValue::new(true))
 }
 
@@ -103,7 +88,7 @@ fn trap_get_own_property_descriptor(
 
     // Step 2: "If P is an array index property name:"
     if is_array_index_key(key) {
-        // Child navigable lookup not yet implemented.
+        // Note: Child navigable lookup not yet implemented.
         return Ok(JsValue::undefined());
     }
 
@@ -154,8 +139,6 @@ fn trap_get(
     let key_val = args.get(1).unwrap_or(&undefined_val);
 
     // Step 3: "Return ? OrdinaryGet(this, P, Receiver)."
-    // Delegate to the target's [[Get]] via the public API, matching the
-    // observable array pattern's "Return ? O.[[Get]](P, Receiver)".
     let prop_key = property_key_from_value_with_ctx(key_val, context);
     win.get(prop_key, context)
 }
@@ -254,7 +237,8 @@ fn trap_own_keys(
     let win = handler_window(this)?;
 
     // Step 2: "Let maxProperties be W's associated Document's document-tree
-    //          child navigables's size." → empty (not yet implemented).
+    //          child navigables's size."
+    // Note: Child navigable support not yet implemented — keys is empty.
     // Step 4: "Return the concatenation of keys and OrdinaryOwnPropertyKeys(W)."
     let window_keys = win.own_property_keys(context)?;
     let key_values: Vec<JsValue> = window_keys.into_iter().map(JsValue::from).collect();
@@ -277,15 +261,12 @@ fn trap_own_keys(
     Ok(JsValue::from(key_array))
 }
 
-// ── Public API ──
-
 /// <https://html.spec.whatwg.org/#the-windowproxy-exotic-object>
 pub(crate) fn create_window_proxy(
     window: &JsObject,
     context: &mut Context,
 ) -> JsResult<JsValue> {
-    // Step 1-2 (observable array pattern): Create handler with null proto
-    // and a [[Window]] internal slot.
+    // Note: The handler is created with a [[Window]] internal slot.
     let handler_proto: JsPrototype = None;
     let handler: JsObject = JsObject::<WindowProxyHandler>::new(
         context.root_shape(),
@@ -296,7 +277,8 @@ pub(crate) fn create_window_proxy(
     )
     .upcast();
 
-    // Steps 3+: Register all traps.
+    // Note: Each trap is registered via CreateBuiltinFunction +
+    // CreateDataPropertyOrThrow, matching the observable array pattern.
     let traps: &[(
         &str,
         usize,
@@ -317,8 +299,8 @@ pub(crate) fn create_window_proxy(
 
     for &(name_str, length, trap_fn) in traps {
         let name = js_string!(name_str);
-        // Each trap is a NativeFunction with a dummy handler capture.
-        // The real handler state is read from `this` inside each trap.
+        // Note: The captures value is a dummy; the real handler is
+        // read from `this` inside each trap function.
         let trap = NativeFunction::from_copy_closure_with_captures(
             move |this, args, _captures: &WindowProxyHandler, context| {
                 trap_fn(this, args, _captures, context)
@@ -334,8 +316,7 @@ pub(crate) fn create_window_proxy(
         handler.create_data_property_or_throw(name, fn_obj, context)?;
     }
 
-    // ── Create the Proxy ──
-    Proxy::create(&JsValue::from(window.clone()), &handler.into(), context)
+        Proxy::create(&JsValue::from(window.clone()), &handler.into(), context)
         .map(JsValue::from)
 }
 
@@ -351,8 +332,6 @@ pub(crate) fn resolve_window(value: &JsValue, context: &Context) -> JsObject {
     }
     context.global_object()
 }
-
-// ── Helpers ──
 
 fn descriptor_to_js_value(desc: &PropertyDescriptor, context: &mut Context) -> JsValue {
     if desc.is_data_descriptor() {
@@ -410,8 +389,6 @@ fn desc_from_obj(desc_obj: &JsValue, context: &mut Context) -> JsResult<Property
             .into()),
     }
 }
-
-// ── Cross-origin helpers (HTML §7.2.1.3) ──
 
 #[allow(dead_code)]
 struct CrossOriginPropertyEntry {

--- a/content/src/html/windowproxy.rs
+++ b/content/src/html/windowproxy.rs
@@ -1,394 +1,117 @@
 //! <https://html.spec.whatwg.org/#the-windowproxy-exotic-object>
 //!
-//! The WindowProxy is an exotic object that wraps a Window ordinary object,
-//! indirecting most operations through to the wrapped object.
-//! Each browsing context has an associated WindowProxy object. When the
-//! browsing context is navigated, the Window object wrapped by the
-//! browsing context's associated WindowProxy object is changed.
+//! The WindowProxy is an exotic object that wraps a Window ordinary object
+//! and is implemented as a JavaScript Proxy (see Web IDL observable array
+//! pattern in §3.10).  The Proxy target is the inner Window and the handler
+//! is an ordinary object whose trap functions implement the WindowProxy
+//! semantics per HTML §7.2.3.
 //!
-//! The WindowProxy implements custom internal methods per the HTML spec.
-//! For same-origin access most operations delegate to the inner Window
-//! object.  Cross-origin operations use a restricted property set.
+//! For same-origin access (currently always true) most operations delegate
+//! to the inner Window object via the default Proxy behavior.  Only traps
+//! that differ from the default Proxy behavior are provided:
+//! - [[SetPrototypeOf]]: SetImmutablePrototype
+//! - [[PreventExtensions]]: always false
+//!
+//! [[IsExtensible]] is left to the default (delegates to target), which
+//! satisfies the Proxy invariant (trap result must match target result)
+//! while still returning the correct value for an extensible Window.
 
 use boa_engine::{
-    Context, JsData, JsResult, JsValue,
+    Context, JsObject, JsResult, JsValue,
+    builtins::proxy::Proxy,
     js_string,
-    object::{
-        JsObject, JsPrototype,
-        internal_methods::{
-            InternalMethodPropertyContext, InternalObjectMethods,
-            ORDINARY_INTERNAL_METHODS,
-        },
-    },
-    property::{PropertyDescriptor, PropertyKey},
+    native_function::NativeFunction,
+    object::FunctionObjectBuilder,
 };
-use boa_gc::{Finalize, Trace};
-
-// ── WindowProxy struct ──
 
 /// <https://html.spec.whatwg.org/#the-windowproxy-exotic-object>
 ///
-/// Each browsing context has an associated WindowProxy object.
-/// The [[Window]] internal slot points to the current Window ordinary
-/// object for that browsing context's active document.
-#[derive(Trace, Finalize)]
-pub struct WindowProxy {
-    /// <https://html.spec.whatwg.org/#windowproxy-[[window]]>
-    window: JsObject,
-}
-
-impl WindowProxy {
-    /// Create a new WindowProxy wrapping the given Window JsObject.
-    pub(crate) fn new(window: JsObject) -> Self {
-        Self { window }
-    }
-
-    /// Returns the wrapped Window JsObject handle.
-    /// Used to extract the inner Window when bindings receive a
-    /// WindowProxy as `this`, and for navigation-time Window swapping.
-    pub(crate) fn window_handle(&self) -> &JsObject {
-        &self.window
-    }
-}
-
-// ── Exotic internal methods ──
-
-/// <https://html.spec.whatwg.org/#the-windowproxy-exotic-object>
-///
-/// The WindowProxy's internal methods vtable overrides 10 of the 14
-/// ordinary internal methods to implement the WindowProxy exotic
-/// behavior per HTML §7.2.3.
-impl JsData for WindowProxy {
-    fn internal_methods(&self) -> &'static InternalObjectMethods {
-        static METHODS: InternalObjectMethods = InternalObjectMethods {
-            __get_prototype_of__: window_proxy_get_prototype_of,
-            __set_prototype_of__: window_proxy_set_prototype_of,
-            __is_extensible__: window_proxy_is_extensible,
-            __prevent_extensions__: window_proxy_prevent_extensions,
-            __get_own_property__: window_proxy_get_own_property,
-            __define_own_property__: window_proxy_define_own_property,
-            __get__: window_proxy_get,
-            __set__: window_proxy_set,
-            __delete__: window_proxy_delete,
-            __own_property_keys__: window_proxy_own_property_keys,
-            // __has_property__, __try_get__: ordinary — works because
-            //   ordinary_has_property calls [[GetOwnProperty]] which we
-            //   override to delegate to the Window.
-            // __call__, __construct__: ordinary — WindowProxy is neither
-            //   callable nor constructable.
-            ..ORDINARY_INTERNAL_METHODS
-        };
-        &METHODS
-    }
-}
-
-/// Helper: extract the wrapped Window from the WindowProxy receiver.
-fn unwrap_window(obj: &JsObject) -> JsObject {
-    // The obj IS the WindowProxy JsObject.
-    // Step 1: "Let W be the value of the [[Window]] internal slot of this."
-    obj.downcast_ref::<WindowProxy>()
-        .map(|proxy| proxy.window.clone())
-        .expect("WindowProxy exotic method called on non-WindowProxy object")
-}
-
-// ── [[GetPrototypeOf]] ──
-//
-// <https://html.spec.whatwg.org/#windowproxy-getprototypeof>
-fn window_proxy_get_prototype_of(
-    obj: &JsObject,
-    _context: &mut Context,
-) -> JsResult<JsPrototype> {
-    // Step 1: "Let W be the value of the [[Window]] internal slot of this."
-    let window = unwrap_window(obj);
-
-    // Step 2: "If IsPlatformObjectSameOrigin(W) is true, then return !
-    //          OrdinaryGetPrototypeOf(W)."
-    // Note: Same-origin is always true (single origin per content process)
-    // until multi-origin support is added.
-    // Step 3: "Return null."
-    Ok(window.prototype())
-}
-
-// ── [[SetPrototypeOf]] ──
-//
-// <https://html.spec.whatwg.org/#windowproxy-setprototypeof>
-fn window_proxy_set_prototype_of(
-    obj: &JsObject,
-    val: JsPrototype,
+/// Create a WindowProxy exotic object wrapping the given Window, using a
+/// JavaScript Proxy with custom handler traps.
+pub(crate) fn create_window_proxy(
+    window: &JsObject,
     context: &mut Context,
-) -> JsResult<bool> {
-    // Step 1: "Return ! SetImmutablePrototype(this, V)."
-    //
-    // SetImmutablePrototype ( O, V )
-    // https://tc39.es/ecma262/#sec-set-immutable-prototype
-    // 1. Let current be ? O.[[GetPrototypeOf]]().
-    //    Must go through the vtable because the WindowProxy overrides
-    //    [[GetPrototypeOf]].
-    let current = obj.__get_prototype_of__(context)?;
-
-    // 2. If SameValue(V, current) is true, return true.
-    // 3. Return false.
-    Ok(val == current)
-}
-
-// ── [[IsExtensible]] ──
-//
-// <https://html.spec.whatwg.org/#windowproxy-isextensible>
-fn window_proxy_is_extensible(
-    _obj: &JsObject,
-    _context: &mut Context,
-) -> JsResult<bool> {
-    // Step 1: "Return true."
-    Ok(true)
-}
-
-// ── [[PreventExtensions]] ──
-//
-// <https://html.spec.whatwg.org/#windowproxy-preventextensions>
-fn window_proxy_prevent_extensions(
-    _obj: &JsObject,
-    _context: &mut Context,
-) -> JsResult<bool> {
-    // Step 1: "Return false."
-    Ok(false)
-}
-
-// ── [[GetOwnProperty]] ──
-//
-// <https://html.spec.whatwg.org/#windowproxy-getownproperty>
-fn window_proxy_get_own_property(
-    obj: &JsObject,
-    key: &PropertyKey,
-    context: &mut InternalMethodPropertyContext<'_>,
-) -> JsResult<Option<PropertyDescriptor>> {
-    // Step 1: "Let W be the value of the [[Window]] internal slot of this."
-    let window = unwrap_window(obj);
-
-    // Step 2: "If P is an array index property name:"
-    // <https://webidl.spec.whatwg.org/#dfn-array-index-property-name>
-    let is_array_index = key_to_u32(key).is_some();
-    if is_array_index {
-        // Step 2.1-2.x: child navigable lookup.
-        // Note: Child navigable support is not yet implemented
-        // (no iframe child tracking in the content process).
-        // Step 2.5.1: "If IsPlatformObjectSameOrigin(W) is true, then
-        //              return undefined."
-        return Ok(None);
-    }
-
-    // Step 3: "If IsPlatformObjectSameOrigin(W) is true, then return !
-    //          OrdinaryGetOwnProperty(W, P)."
-    //
-    // Note: Use __get_own_property__ to go through the Window's vtable
-    // (which is ordinary [[GetOwnProperty]]).  We cannot use the public
-    // `get()` method because it returns a value, not a descriptor.
-    window.__get_own_property__(key, context)
-}
-
-// ── [[DefineOwnProperty]] ──
-//
-// <https://html.spec.whatwg.org/#windowproxy-defineownproperty>
-fn window_proxy_define_own_property(
-    obj: &JsObject,
-    key: &PropertyKey,
-    desc: PropertyDescriptor,
-    context: &mut InternalMethodPropertyContext<'_>,
-) -> JsResult<bool> {
-    // Step 1: "Let W be the value of the [[Window]] internal slot of this."
-    let window = unwrap_window(obj);
-
-    // Step 2: "If IsPlatformObjectSameOrigin(W) is true:"
-    // Note: Same-origin is always true (single origin per content process).
-
-    // Step 2.1: "If P is an array index property name, return false."
-    if key_to_u32(key).is_some() {
-        return Ok(false);
-    }
-
-    // Step 2.2: "Return ? OrdinaryDefineOwnProperty(W, P, Desc)."
-    window.__define_own_property__(key, desc, context)
-}
-
-// ── [[Get]] ──
-//
-// <https://html.spec.whatwg.org/#windowproxy-get>
-fn window_proxy_get(
-    obj: &JsObject,
-    key: &PropertyKey,
-    receiver: JsValue,
-    context: &mut InternalMethodPropertyContext<'_>,
 ) -> JsResult<JsValue> {
-    // Step 1: "Let W be the value of the [[Window]] internal slot of this."
-    let _window = unwrap_window(obj);
+    // Create handler with null prototype, matching the Web IDL observable
+    // array pattern.
+    let handler = JsObject::with_null_proto();
 
-    // Step 2: "Check if an access between two browsing contexts should be
-    //          reported..."
-    // Note: Same-origin check — access reporting is not yet implemented.
+    // ── setPrototypeOf trap ──
+    // <https://html.spec.whatwg.org/#windowproxy-setprototypeof>
+    // Implements SetImmutablePrototype: only succeeds if V matches current.
+    {
+        let trap = NativeFunction::from_copy_closure_with_captures(
+            |_this, args, window: &JsObject, _context| {
+                let current = window.prototype();
+                let undefined_val = JsValue::undefined();
+                let val = args.get(1).unwrap_or(&undefined_val);
 
-    // Step 3: "If IsPlatformObjectSameOrigin(W) is true, then return ?
-    //          OrdinaryGet(this, P, Receiver)."
-    //
-    // NOTE: Cannot delegate through the vtable (obj.__get__) because that
-    // dispatches back to window_proxy_get — infinite loop.  Instead we
-    // implement OrdinaryGet manually: call [[GetOwnProperty]], walk the
-    // prototype chain if not found, then return the value or call the
-    // accessor getter.
-
-    // OrdinaryGet ( O, P, Receiver )
-    // https://tc39.es/ecma262/#sec-ordinaryget
-
-    // 1. Assert: IsPropertyKey(P) is true.
-    // 2. Let desc be ? O.[[GetOwnProperty]](P).
-    match obj.__get_own_property__(key, context)? {
-        None => {
-            // 2a. Let parent be ? O.[[GetPrototypeOf]]().
-            if let Some(parent) = obj.__get_prototype_of__(context)? {
-                // 2c. Return ? parent.[[Get]](P, Receiver).
-                parent.__get__(key, receiver, context)
-            } else {
-                // 2b. If parent is null, return undefined.
-                Ok(JsValue::undefined())
-            }
-        }
-        Some(ref desc) => {
-            // 3. If IsDataDescriptor(desc) is true, return desc.[[Value]].
-            if let Some(value) = desc.value() {
-                return Ok(value.clone());
-            }
-            // 4. Assert: IsAccessorDescriptor(desc) is true.
-            // 5. Let getter be desc.[[Get]].
-            if let Some(getter) = desc.get().and_then(|v| v.as_object()) {
-                // 7. Return ? Call(getter, Receiver).
-                return getter.call(&receiver, &[], context);
-            }
-            // 6. If getter is undefined, return undefined.
-            Ok(JsValue::undefined())
-        }
-    }
-}
-
-// ── [[Set]] ──
-//
-// <https://html.spec.whatwg.org/#windowproxy-set>
-fn window_proxy_set(
-    obj: &JsObject,
-    key: PropertyKey,
-    value: JsValue,
-    receiver: JsValue,
-    context: &mut InternalMethodPropertyContext<'_>,
-) -> JsResult<bool> {
-    // Step 1: "Let W be the value of the [[Window]] internal slot of this."
-    let window = unwrap_window(obj);
-
-    // Step 2: "Check if an access between two browsing contexts should be
-    //          reported..."
-    // Note: Same-origin check — access reporting is not yet implemented.
-
-    // Step 3: "If IsPlatformObjectSameOrigin(W) is true:"
-    // Step 3.1: "If P is an array index property name, then return false."
-    if key_to_u32(&key).is_some() {
-        return Ok(false);
+                let same = match (&current, val) {
+                    (Some(current_proto), _) => val
+                        .as_object()
+                        .map_or(false, |v| JsObject::equals(current_proto, &v)),
+                    (None, _) => val.is_null(),
+                };
+                Ok(JsValue::new(same))
+            },
+            window.clone(),
+        );
+        let set_prototype_of_fn = FunctionObjectBuilder::new(context.realm(), trap)
+            .name(js_string!("setPrototypeOf"))
+            .length(2)
+            .build();
+        handler.create_data_property_or_throw(
+            js_string!("setPrototypeOf"),
+            set_prototype_of_fn,
+            context,
+        )?;
     }
 
-    // Step 3.2: "Return ? OrdinarySet(W, P, V, Receiver)."
-    //
-    // NOTE: OrdinarySet delegates to the Window's [[Set]], which calls
-    // Window.[[GetOwnProperty]](P) and either updates an existing own
-    // property or walks the prototype chain.  When the property is found
-    // on the prototype (Window.prototype), the setter is called with
-    // `Receiver` as the `this` value.  When not found at all, the new
-    // property is created on `Receiver` — but [[DefineOwnProperty]] on
-    // the receiver (the WindowProxy) delegates to the Window, so the
-    // new property ends up on the Window as desired.
-    //
-    // We use the vtable __set__ directly to pass the original Receiver
-    // through, rather than the public `set()` which hardcodes self as
-    // the receiver.
-    window.__set__(key, value, receiver, context)
-}
-
-// ── [[Delete]] ──
-//
-// <https://html.spec.whatwg.org/#windowproxy-delete>
-fn window_proxy_delete(
-    obj: &JsObject,
-    key: &PropertyKey,
-    context: &mut InternalMethodPropertyContext<'_>,
-) -> JsResult<bool> {
-    // Step 1: "Let W be the value of the [[Window]] internal slot of this."
-    let window = unwrap_window(obj);
-
-    // Step 2: "If IsPlatformObjectSameOrigin(W) is true:"
-    // Note: Same-origin is always true (single origin per content process).
-
-    // Step 2.1: "If P is an array index property name:"
-    if key_to_u32(key).is_some() {
-        // Step 2.1.1: "Let desc be ! this.[[GetOwnProperty]](P)."
-        let desc = obj.__get_own_property__(key, context)?;
-        // Step 2.1.2: "If desc is undefined, then return true."
-        // Step 2.1.3: "Return false."
-        return Ok(desc.is_none());
+    // ── preventExtensions trap ──
+    // <https://html.spec.whatwg.org/#windowproxy-preventextensions>
+    {
+        let trap = NativeFunction::from_copy_closure_with_captures(
+            |_this, _args, _window: &JsObject, _context| Ok(JsValue::new(false)),
+            window.clone(),
+        );
+        let prevent_extensions_fn = FunctionObjectBuilder::new(context.realm(), trap)
+            .name(js_string!("preventExtensions"))
+            .length(1)
+            .build();
+        handler.create_data_property_or_throw(
+            js_string!("preventExtensions"),
+            prevent_extensions_fn,
+            context,
+        )?;
     }
 
-    // Step 2.2: "Return ? OrdinaryDelete(W, P)."
-    window.__delete__(key, context)
+    // All other traps (get, set, has, deleteProperty, defineProperty,
+    // getOwnPropertyDescriptor, ownKeys, getPrototypeOf) are NOT provided.
+    // The default Proxy behavior delegates them to the target (Window),
+    // which is correct for the same-origin case.
+
+    Proxy::create(&JsValue::from(window.clone()), &handler.into(), context)
+        .map(JsValue::from)
 }
 
-// ── [[OwnPropertyKeys]] ──
-//
-// <https://html.spec.whatwg.org/#windowproxy-ownpropertykeys>
-fn window_proxy_own_property_keys(
-    obj: &JsObject,
-    context: &mut Context,
-) -> JsResult<Vec<PropertyKey>> {
-    // Step 1: "Let W be the value of the [[Window]] internal slot of this."
-    let window = unwrap_window(obj);
-
-    // Step 2: "Let maxProperties be W's associated Document's
-    //          document-tree child navigables's size."
-    // Note: Child navigable support is not yet implemented.
-    // Step 3: "Let keys be the range 0 to maxProperties, exclusive."
-    // → empty for now.
-    let mut keys: Vec<PropertyKey> = Vec::new();
-
-    // Step 4: "If IsPlatformObjectSameOrigin(W) is true, then return the
-    //          concatenation of keys and OrdinaryOwnPropertyKeys(W)."
-    let window_keys = window.__own_property_keys__(context)?;
-    keys.extend(window_keys);
-
-    Ok(keys)
-}
-
-// ── Helpers ──
-
-/// Check whether a PropertyKey is an array index property name.
+/// <https://html.spec.whatwg.org/#the-windowproxy-exotic-object>
 ///
-/// <https://webidl.spec.whatwg.org/#dfn-array-index-property-name>
-fn key_to_u32(key: &PropertyKey) -> Option<u32> {
-    match key {
-        PropertyKey::Index(index) => Some(index.get()),
-        PropertyKey::String(string) => {
-            // A string property name P is an array index if:
-            // - P is not the empty string
-            // - ToUint32(P) is not 2^32-1
-            // - SameValue(ToString(ToUint32(P)), P) is true
-            let s = string.to_std_string_escaped();
-            if s.is_empty() {
-                return None;
-            }
-            let parsed: u64 = s.parse().ok()?;
-            if parsed >= u32::MAX as u64 {
-                return None;
-            }
-            // Verify round-trip: must be the canonical decimal representation.
-            if parsed.to_string() == s {
-                Some(parsed as u32)
-            } else {
-                None
+/// Resolve the inner Window from a value that may be a WindowProxy
+/// (Proxy exotic object wrapping a Window).  When accessors on
+/// Window.prototype are invoked via a WindowProxy (e.g.
+/// `proxy.onload = ...`), the receiver (`this`) is the Proxy object.
+/// This function extracts the Proxy's target (the inner Window) so
+/// that downcasts succeed.
+pub(crate) fn resolve_window(value: &JsValue, context: &Context) -> JsObject {
+    if let Some(object) = value.as_object() {
+        if let Some(proxy) = object.downcast_ref::<Proxy>() {
+            if let Ok((target, _)) = proxy.try_data() {
+                return target;
             }
         }
-        PropertyKey::Symbol(_) => None,
+        return object.clone();
     }
+    context.global_object()
 }
 
 // ── Cross-origin helper operations ──
@@ -425,16 +148,20 @@ fn cross_origin_window_properties() -> Vec<CrossOriginPropertyEntry> {
 
 /// <https://html.spec.whatwg.org/#crossoriginownpropertykeys-(-o-)>
 #[allow(dead_code)]
-pub(crate) fn cross_origin_own_property_keys() -> Vec<PropertyKey> {
-    let mut keys: Vec<PropertyKey> = cross_origin_window_properties()
+pub(crate) fn cross_origin_own_property_keys() -> Vec<boa_engine::property::PropertyKey> {
+    let mut keys = cross_origin_window_properties()
         .into_iter()
-        .map(|p| PropertyKey::String(js_string!(p.property)))
-        .collect();
+        .map(|p| boa_engine::property::PropertyKey::String(js_string!(p.property)))
+        .collect::<Vec<_>>();
 
-    keys.push(PropertyKey::String(js_string!("then")));
-    keys.push(PropertyKey::Symbol(boa_engine::JsSymbol::to_string_tag()));
-    keys.push(PropertyKey::Symbol(boa_engine::JsSymbol::has_instance()));
-    keys.push(PropertyKey::Symbol(
+    keys.push(boa_engine::property::PropertyKey::String(js_string!("then")));
+    keys.push(boa_engine::property::PropertyKey::Symbol(
+        boa_engine::JsSymbol::to_string_tag(),
+    ));
+    keys.push(boa_engine::property::PropertyKey::Symbol(
+        boa_engine::JsSymbol::has_instance(),
+    ));
+    keys.push(boa_engine::property::PropertyKey::Symbol(
         boa_engine::JsSymbol::is_concat_spreadable(),
     ));
 
@@ -447,20 +174,4 @@ pub(crate) fn is_cross_origin_property(name: &str) -> bool {
     cross_origin_window_properties()
         .iter()
         .any(|p| p.property == name)
-}
-
-/// <https://html.spec.whatwg.org/#isplatformobjectsameorigin-(-o-)>
-///
-/// Currently hardcoded to `true` because the content process only runs a
-/// single origin.  When multi-origin support is added, this must check
-/// whether the active document of the given Window's browsing context is
-/// same-origin with the active document of the entry settings object's
-/// browsing context.
-///
-/// Hardcoding to `true` means that if cross-origin windows are ever
-/// returned from `window_open_steps`, all their properties will be
-/// silently leaked through the WindowProxy.
-#[allow(dead_code)]
-pub(crate) fn is_platform_object_same_origin(_window: &JsObject, _context: &JsObject) -> bool {
-    true
 }

--- a/content/src/html/windowproxy.rs
+++ b/content/src/html/windowproxy.rs
@@ -6,206 +6,333 @@
 //! handler is an ordinary object whose trap functions implement the
 //! WindowProxy semantics per HTML §7.2.3.
 //!
-//! Each trap matches a WindowProxy internal method.  Traps that differ from
-//! the default Proxy behavior (which delegates to the target) are explicitly
-//! implemented.  Traps whose default behavior matches the WindowProxy spec
-//! for the same-origin case are omitted — the Proxy spec's default
-//! [[GetOwnProperty]] / [[Get]] / [[Set]] / [[Delete]] / [[DefineOwnProperty]]
-//! / [[HasProperty]] / [[OwnPropertyKeys]] all delegate to the target's
-//! ordinary operations, which IS the WindowProxy same-origin algorithm.
+//! The handler carries a [[Window]] internal slot (via JsData) referencing
+//! the wrapped Window.  Each trap reads the handler's internal slot via
+//! `this`, replicating the observable array pattern where the handler
+//! stores state in internal slots ([[BackingList]], [[Type]], etc.).
 
 use boa_engine::{
-    Context, JsNativeError, JsObject, JsResult, JsValue,
+    Context, JsData, JsNativeError, JsObject, JsResult, JsValue,
     builtins::proxy::Proxy,
     js_string,
     native_function::NativeFunction,
-    object::FunctionObjectBuilder,
+    object::{FunctionObjectBuilder, JsPrototype, ObjectInitializer},
     property::{PropertyDescriptor, PropertyKey},
 };
+use boa_gc::{Finalize, Trace};
+
+use crate::webidl::is_array_index_key;
+
+// ── Handler struct with [[Window]] internal slot ──
+
+/// <https://webidl.spec.whatwg.org/#creating-an-observable-array-exotic-object>
+#[derive(Trace, Finalize)]
+struct WindowProxyHandler {
+    window: JsObject,
+}
+
+impl JsData for WindowProxyHandler {}
+
+// ── Helper: extract Window from handler (via `this`) ──
+
+fn handler_window(this: &JsValue) -> JsResult<JsObject> {
+    let obj = this.as_object().ok_or_else(|| {
+        JsNativeError::typ()
+            .with_message("WindowProxy trap called with non-object this")
+    })?;
+    let handler = obj.downcast_ref::<WindowProxyHandler>().ok_or_else(|| {
+        JsNativeError::typ()
+            .with_message("WindowProxy trap called on non-WindowProxy handler")
+    })?;
+    Ok(handler.window.clone())
+}
+
+// ── Trap functions ──
+
+/// <https://html.spec.whatwg.org/#windowproxy-setprototypeof>
+fn trap_set_prototype_of(
+    this: &JsValue,
+    args: &[JsValue],
+    _captures: &WindowProxyHandler,
+    _context: &mut Context,
+) -> JsResult<JsValue> {
+    let win = handler_window(this)?;
+    // Step 1: "Return ! SetImmutablePrototype(this, V)."
+    let current = win.prototype();
+    let undefined_val = JsValue::undefined();
+    let val = args.get(1).unwrap_or(&undefined_val);
+    let same = match (&current, val) {
+        (Some(current_proto), _) => val
+            .as_object()
+            .map_or(false, |v| JsObject::equals(current_proto, &v)),
+        (None, _) => val.is_null(),
+    };
+    Ok(JsValue::new(same))
+}
+
+/// <https://html.spec.whatwg.org/#windowproxy-preventextensions>
+fn trap_prevent_extensions(
+    _this: &JsValue,
+    _args: &[JsValue],
+    _captures: &WindowProxyHandler,
+    _context: &mut Context,
+) -> JsResult<JsValue> {
+    Ok(JsValue::new(false))
+}
+
+/// <https://html.spec.whatwg.org/#windowproxy-isextensible>
+fn trap_is_extensible(
+    _this: &JsValue,
+    _args: &[JsValue],
+    _captures: &WindowProxyHandler,
+    _context: &mut Context,
+) -> JsResult<JsValue> {
+    Ok(JsValue::new(true))
+}
+
+/// <https://html.spec.whatwg.org/#windowproxy-getownproperty>
+fn trap_get_own_property_descriptor(
+    this: &JsValue,
+    args: &[JsValue],
+    _captures: &WindowProxyHandler,
+    context: &mut Context,
+) -> JsResult<JsValue> {
+    let win = handler_window(this)?;
+    let undefined_val = JsValue::undefined();
+    let key = args.get(1).unwrap_or(&undefined_val);
+
+    // Step 2: "If P is an array index property name:"
+    if is_array_index_key(key) {
+        // Child navigable lookup not yet implemented.
+        return Ok(JsValue::undefined());
+    }
+
+    // Step 3: "Return ! OrdinaryGetOwnProperty(W, P)."
+    let prop_key = property_key_from_value_with_ctx(key, context);
+    let desc = win.borrow().properties().get(&prop_key);
+    match desc {
+        None => Ok(JsValue::undefined()),
+        Some(desc) => Ok(descriptor_to_js_value(&desc, context)),
+    }
+}
+
+/// <https://html.spec.whatwg.org/#windowproxy-defineownproperty>
+fn trap_define_property(
+    this: &JsValue,
+    args: &[JsValue],
+    _captures: &WindowProxyHandler,
+    context: &mut Context,
+) -> JsResult<JsValue> {
+    let win = handler_window(this)?;
+    let undefined_val = JsValue::undefined();
+    let key = args.get(1).unwrap_or(&undefined_val);
+    let desc_obj = args.get(2).unwrap_or(&undefined_val);
+
+    // Step 2.1: "If P is an array index property name, return false."
+    if is_array_index_key(key) {
+        return Ok(JsValue::new(false));
+    }
+
+    // Step 2.2: "Return ? OrdinaryDefineOwnProperty(W, P, Desc)."
+    let desc = desc_from_obj(desc_obj, context)?;
+    let prop_key = property_key_from_value_with_ctx(key, context);
+    match win.define_property_or_throw(prop_key, desc, context) {
+        Ok(_) => Ok(JsValue::new(true)),
+        Err(_) => Ok(JsValue::new(false)),
+    }
+}
+
+/// <https://html.spec.whatwg.org/#windowproxy-get>
+fn trap_get(
+    this: &JsValue,
+    args: &[JsValue],
+    _captures: &WindowProxyHandler,
+    context: &mut Context,
+) -> JsResult<JsValue> {
+    let win = handler_window(this)?;
+    let undefined_val = JsValue::undefined();
+    let key_val = args.get(1).unwrap_or(&undefined_val);
+
+    // Step 3: "Return ? OrdinaryGet(this, P, Receiver)."
+    // Delegate to the target's [[Get]] via the public API, matching the
+    // observable array pattern's "Return ? O.[[Get]](P, Receiver)".
+    let prop_key = property_key_from_value_with_ctx(key_val, context);
+    win.get(prop_key, context)
+}
+
+/// <https://html.spec.whatwg.org/#windowproxy-set>
+fn trap_set(
+    this: &JsValue,
+    args: &[JsValue],
+    _captures: &WindowProxyHandler,
+    context: &mut Context,
+) -> JsResult<JsValue> {
+    let win = handler_window(this)?;
+    let undefined_val = JsValue::undefined();
+    let key = args.get(1).unwrap_or(&undefined_val);
+
+    // Step 3.1: "If P is an array index property name, return false."
+    if is_array_index_key(key) {
+        return Ok(JsValue::new(false));
+    }
+
+    // Step 3.2: "Return ? OrdinarySet(W, P, V, Receiver)."
+    let value = args.get(2).cloned().unwrap_or(JsValue::undefined());
+    let prop_key = property_key_from_value_with_ctx(key, context);
+    let result = win.set(prop_key, value, false, context)?;
+    Ok(JsValue::new(result))
+}
+
+/// <https://html.spec.whatwg.org/#windowproxy-delete>
+fn trap_delete_property(
+    this: &JsValue,
+    args: &[JsValue],
+    _captures: &WindowProxyHandler,
+    context: &mut Context,
+) -> JsResult<JsValue> {
+    let win = handler_window(this)?;
+    let undefined_val = JsValue::undefined();
+    let key = args.get(1).unwrap_or(&undefined_val);
+
+    // Step 2.1: "If P is an array index property name:"
+    if is_array_index_key(key) {
+        let prop_key = property_key_from_value_with_ctx(key, context);
+        let has = win.has_own_property(prop_key, context)?;
+        return Ok(JsValue::new(!has));
+    }
+
+    // Step 2.2: "Return ? OrdinaryDelete(W, P)."
+    let prop_key = property_key_from_value_with_ctx(key, context);
+    let result = win.delete_property_or_throw(prop_key, context)?;
+    Ok(JsValue::new(result))
+}
+
+/// <https://html.spec.whatwg.org/#windowproxy-has>
+fn trap_has(
+    this: &JsValue,
+    args: &[JsValue],
+    _captures: &WindowProxyHandler,
+    context: &mut Context,
+) -> JsResult<JsValue> {
+    let win = handler_window(this)?;
+    let undefined_val = JsValue::undefined();
+    let key = args.get(1).unwrap_or(&undefined_val);
+
+    if let Some(s) = key.as_string() {
+        if s == "length" {
+            return Ok(JsValue::new(true));
+        }
+    }
+
+    let prop_key = property_key_from_value_with_ctx(key, context);
+    let result = win.has_property(prop_key, context)?;
+    Ok(JsValue::new(result))
+}
+
+/// <https://html.spec.whatwg.org/#windowproxy-getprototypeof>
+fn trap_get_prototype_of(
+    this: &JsValue,
+    _args: &[JsValue],
+    _captures: &WindowProxyHandler,
+    _context: &mut Context,
+) -> JsResult<JsValue> {
+    let win = handler_window(this)?;
+    let proto = win.prototype();
+    match proto {
+        Some(p) => Ok(JsValue::from(p)),
+        None => Ok(JsValue::null()),
+    }
+}
+
+/// <https://html.spec.whatwg.org/#windowproxy-ownpropertykeys>
+fn trap_own_keys(
+    this: &JsValue,
+    _args: &[JsValue],
+    _captures: &WindowProxyHandler,
+    context: &mut Context,
+) -> JsResult<JsValue> {
+    let win = handler_window(this)?;
+
+    // Step 2: "Let maxProperties be W's associated Document's document-tree
+    //          child navigables's size." → empty (not yet implemented).
+    // Step 4: "Return the concatenation of keys and OrdinaryOwnPropertyKeys(W)."
+    let window_keys = win.own_property_keys(context)?;
+    let key_values: Vec<JsValue> = window_keys.into_iter().map(JsValue::from).collect();
+
+    let key_array = JsObject::with_object_proto(context.intrinsics());
+    for (i, val) in key_values.iter().enumerate() {
+        key_array
+            .create_data_property_or_throw(i as u32, val.clone(), context)
+            .expect("CreateArrayFromList: creating array properties");
+    }
+    key_array.set_prototype(None);
+    key_array
+        .create_data_property_or_throw(
+            js_string!("length"),
+            JsValue::new(key_values.len()),
+            context,
+        )
+        .expect("CreateArrayFromList: setting length");
+
+    Ok(JsValue::from(key_array))
+}
+
+// ── Public API ──
 
 /// <https://html.spec.whatwg.org/#the-windowproxy-exotic-object>
 pub(crate) fn create_window_proxy(
     window: &JsObject,
     context: &mut Context,
 ) -> JsResult<JsValue> {
-    // Create handler with null prototype (Web IDL observable array pattern).
-    let handler = JsObject::with_null_proto();
+    // Step 1-2 (observable array pattern): Create handler with null proto
+    // and a [[Window]] internal slot.
+    let handler_proto: JsPrototype = None;
+    let handler: JsObject = JsObject::<WindowProxyHandler>::new(
+        context.root_shape(),
+        handler_proto,
+        WindowProxyHandler {
+            window: window.clone(),
+        },
+    )
+    .upcast();
 
-    // ── [[SetPrototypeOf]] trap ──
-    // <https://html.spec.whatwg.org/#windowproxy-setprototypeof>
-    // Step 1: "Return ! SetImmutablePrototype(this, V)."
-    {
+    // Steps 3+: Register all traps.
+    let traps: &[(
+        &str,
+        usize,
+        fn(&JsValue, &[JsValue], &WindowProxyHandler, &mut Context) -> JsResult<JsValue>,
+    )] = &[
+        ("getPrototypeOf", 1, trap_get_prototype_of as _),
+        ("setPrototypeOf", 2, trap_set_prototype_of as _),
+        ("isExtensible", 1, trap_is_extensible as _),
+        ("preventExtensions", 1, trap_prevent_extensions as _),
+        ("getOwnPropertyDescriptor", 2, trap_get_own_property_descriptor as _),
+        ("defineProperty", 3, trap_define_property as _),
+        ("get", 3, trap_get as _),
+        ("set", 4, trap_set as _),
+        ("deleteProperty", 2, trap_delete_property as _),
+        ("has", 2, trap_has as _),
+        ("ownKeys", 1, trap_own_keys as _),
+    ];
+
+    for &(name_str, length, trap_fn) in traps {
+        let name = js_string!(name_str);
+        // Each trap is a NativeFunction with a dummy handler capture.
+        // The real handler state is read from `this` inside each trap.
         let trap = NativeFunction::from_copy_closure_with_captures(
-            |_this, args, win: &JsObject, _context| {
-                let current = win.prototype();
-                let undefined_val = JsValue::undefined();
-                let val = args.get(1).unwrap_or(&undefined_val);
-
-                let same = match (&current, val) {
-                    (Some(current_proto), _) => val
-                        .as_object()
-                        .map_or(false, |v| JsObject::equals(current_proto, &v)),
-                    (None, _) => val.is_null(),
-                };
-                Ok(JsValue::new(same))
+            move |this, args, _captures: &WindowProxyHandler, context| {
+                trap_fn(this, args, _captures, context)
             },
-            window.clone(),
-        );
-        let fn_obj = FunctionObjectBuilder::new(context.realm(), trap)
-            .name(js_string!("setPrototypeOf"))
-            .length(2)
-            .build();
-        handler.create_data_property_or_throw(js_string!("setPrototypeOf"), fn_obj, context)?;
-    }
-
-    // ── [[PreventExtensions]] trap ──
-    // <https://html.spec.whatwg.org/#windowproxy-preventextensions>
-    // Step 1: "Return false."
-    {
-        let trap = NativeFunction::from_copy_closure_with_captures(
-            |_this, _args, _win: &JsObject, _context| Ok(JsValue::new(false)),
-            window.clone(),
-        );
-        let fn_obj = FunctionObjectBuilder::new(context.realm(), trap)
-            .name(js_string!("preventExtensions"))
-            .length(1)
-            .build();
-        handler.create_data_property_or_throw(
-            js_string!("preventExtensions"),
-            fn_obj,
-            context,
-        )?;
-    }
-
-    // ── [[DefineOwnProperty]] trap ──
-    // <https://html.spec.whatwg.org/#windowproxy-defineownproperty>
-    // Array index: return false (spec step 2.1).
-    // Non-array-index: Return ? OrdinaryDefineOwnProperty(W, P, Desc).
-    {
-        let trap = NativeFunction::from_copy_closure_with_captures(
-            |_this, args, win: &JsObject, context| {
-                let undefined_val = JsValue::undefined();
-                let key = args.get(1).unwrap_or(&undefined_val);
-                let desc_obj = args.get(2).unwrap_or(&undefined_val);
-
-                // Step 2.1: "If P is an array index property name, return false."
-                if is_array_index_key(key) {
-                    return Ok(JsValue::new(false));
-                }
-
-                // Step 2.2: "Return ? OrdinaryDefineOwnProperty(W, P, Desc)."
-                let desc = desc_from_obj(desc_obj, context)?;
-                let prop_key = property_key_from_value_with_ctx(key, context);
-                match win.define_property_or_throw(prop_key, desc, context) {
-                    Ok(_) => Ok(JsValue::new(true)),
-                    Err(_) => Ok(JsValue::new(false)),
-                }
+            WindowProxyHandler {
+                window: window.clone(),
             },
-            window.clone(),
         );
         let fn_obj = FunctionObjectBuilder::new(context.realm(), trap)
-            .name(js_string!("defineProperty"))
-            .length(3)
+            .name(name.clone())
+            .length(length)
             .build();
-        handler.create_data_property_or_throw(js_string!("defineProperty"), fn_obj, context)?;
+        handler.create_data_property_or_throw(name, fn_obj, context)?;
     }
-
-    // ── [[Set]] trap ──
-    // <https://html.spec.whatwg.org/#windowproxy-set>
-    // Array index: return false (spec step 3.1).
-    // Non-array-index: Return ? OrdinarySet(W, P, V, Receiver).
-    {
-        let trap = NativeFunction::from_copy_closure_with_captures(
-            |_this, args, win: &JsObject, context| {
-                let undefined_val = JsValue::undefined();
-                let key = args.get(1).unwrap_or(&undefined_val);
-
-                // Step 3.1: "If P is an array index property name, return false."
-                if is_array_index_key(key) {
-                    return Ok(JsValue::new(false));
-                }
-
-                // Step 3.2: "Return ? OrdinarySet(W, P, V, Receiver)."
-                let value = args.get(2).cloned().unwrap_or(JsValue::undefined());
-                let prop_key = property_key_from_value_with_ctx(key, context);
-                // target.set() uses self as receiver, which is correct here
-                // because OrdinarySet(W, P, V, Receiver) starts property
-                // lookup on W (the Window), not on the proxy.
-                let result = win.set(prop_key, value, false, context)?;
-                Ok(JsValue::new(result))
-            },
-            window.clone(),
-        );
-        let fn_obj = FunctionObjectBuilder::new(context.realm(), trap)
-            .name(js_string!("set"))
-            .length(4)
-            .build();
-        handler.create_data_property_or_throw(js_string!("set"), fn_obj, context)?;
-    }
-
-    // ── [[Delete]] trap ──
-    // <https://html.spec.whatwg.org/#windowproxy-delete>
-    // Array index: check own property (spec step 2.1).
-    // Non-array-index: Return ? OrdinaryDelete(W, P).
-    {
-        let trap = NativeFunction::from_copy_closure_with_captures(
-            |_this, args, win: &JsObject, context| {
-                let undefined_val = JsValue::undefined();
-                let key = args.get(1).unwrap_or(&undefined_val);
-
-                // Step 2.1: "If P is an array index property name:"
-                if is_array_index_key(key) {
-                    let prop_key = property_key_from_value_with_ctx(key, context);
-                    // Step 2.1.1: "Let desc be ! this.[[GetOwnProperty]](P)."
-                    // Step 2.1.2: "If desc is undefined, return true."
-                    // Step 2.1.3: "Return false."
-                    let has = win.has_own_property(prop_key, context)?;
-                    return Ok(JsValue::new(!has));
-                }
-
-                // Step 2.2: "Return ? OrdinaryDelete(W, P)."
-                let prop_key = property_key_from_value_with_ctx(key, context);
-                let result = win.delete_property_or_throw(prop_key, context)?;
-                Ok(JsValue::new(result))
-            },
-            window.clone(),
-        );
-        let fn_obj = FunctionObjectBuilder::new(context.realm(), trap)
-            .name(js_string!("deleteProperty"))
-            .length(2)
-            .build();
-        handler.create_data_property_or_throw(js_string!("deleteProperty"), fn_obj, context)?;
-    }
-
-    // ── [[GetPrototypeOf]] not provided ──
-    // <https://html.spec.whatwg.org/#windowproxy-getprototypeof>
-    // Same-origin: delegates to OrdinaryGetPrototypeOf(W) → Proxy default.
-    // Cross-origin: return null — not yet active.
-
-    // ── [[IsExtensible]] not provided ──
-    // <https://html.spec.whatwg.org/#windowproxy-isextensible>
-    // Proxy default delegates to target.[[IsExtensible]]().  For an
-    // extensible Window this returns true, matching the spec.  Providing
-    // a trap would risk Proxy invariant violations (if target differs).
-
-    // ── [[GetOwnProperty]] not provided ──
-    // <https://html.spec.whatwg.org/#windowproxy-getownproperty>
-    // Same-origin non-array-index: Proxy default delegates to target's
-    // [[GetOwnProperty]] which IS OrdinaryGetOwnProperty(W, P).
-    // Array-index child navigable support not yet implemented.
-
-    // ── [[Get]] not provided ──
-    // <https://html.spec.whatwg.org/#windowproxy-get>
-    // Same-origin: Proxy default calls target.[[Get]](P, Receiver) with
-    // the proxy as receiver — this IS OrdinaryGet(this, P, Receiver).
-
-    // ── [[HasProperty]] not provided ──
-    // Not listed as overridden in the WindowProxy spec.  Proxy default is correct.
-
-    // ── [[OwnPropertyKeys]] not provided ──
-    // <https://html.spec.whatwg.org/#windowproxy-ownpropertykeys>
-    // Same-origin: Proxy default returns target's own property keys.
-    // Child navigable indices not yet implemented.
 
     // ── Create the Proxy ──
     Proxy::create(&JsValue::from(window.clone()), &handler.into(), context)
@@ -213,13 +340,6 @@ pub(crate) fn create_window_proxy(
 }
 
 /// <https://html.spec.whatwg.org/#the-windowproxy-exotic-object>
-///
-/// Resolve the inner Window from a value that may be a WindowProxy
-/// (Proxy exotic object wrapping a Window).  When accessors on
-/// Window.prototype are invoked via a WindowProxy (e.g.
-/// `proxy.onload = ...`), the receiver (`this`) is the Proxy object.
-/// This function extracts the Proxy's target (the inner Window) so
-/// that downcasts succeed.
 pub(crate) fn resolve_window(value: &JsValue, context: &Context) -> JsObject {
     if let Some(object) = value.as_object() {
         if let Some(proxy) = object.downcast_ref::<Proxy>() {
@@ -232,40 +352,40 @@ pub(crate) fn resolve_window(value: &JsValue, context: &Context) -> JsObject {
     context.global_object()
 }
 
-// ── Helper functions ──
+// ── Helpers ──
 
-/// <https://webidl.spec.whatwg.org/#dfn-array-index-property-name>
-fn is_array_index_key(key: &JsValue) -> bool {
-    if let Some(s) = key.as_string() {
-        let s = s.to_std_string_escaped();
-        if s.is_empty() {
-            return false;
+fn descriptor_to_js_value(desc: &PropertyDescriptor, context: &mut Context) -> JsValue {
+    if desc.is_data_descriptor() {
+        let mut obj = ObjectInitializer::new(context);
+        obj.property(js_string!("value"), desc.expect_value().clone(), Default::default());
+        obj.property(js_string!("writable"), desc.expect_writable(), Default::default());
+        obj.property(js_string!("enumerable"), desc.expect_enumerable(), Default::default());
+        obj.property(js_string!("configurable"), desc.expect_configurable(), Default::default());
+        obj.build().into()
+    } else if desc.is_accessor_descriptor() {
+        let mut obj = ObjectInitializer::new(context);
+        if let Some(get) = desc.get() {
+            if !get.is_undefined() {
+                obj.property(js_string!("get"), get.clone(), Default::default());
+            }
         }
-        let parsed: u64 = match s.parse() {
-            Ok(v) => v,
-            Err(_) => return false,
-        };
-        if parsed >= u32::MAX as u64 {
-            return false;
+        if let Some(set) = desc.set() {
+            if !set.is_undefined() {
+                obj.property(js_string!("set"), set.clone(), Default::default());
+            }
         }
-        parsed.to_string() == s
-    } else if key.is_number() {
-        if let Some(n) = key.as_number() {
-            n.fract() == 0.0 && n >= 0.0 && n < u32::MAX as f64
-        } else {
-            false
-        }
+        obj.property(js_string!("enumerable"), desc.expect_enumerable(), Default::default());
+        obj.property(js_string!("configurable"), desc.expect_configurable(), Default::default());
+        obj.build().into()
     } else {
-        false
+        let mut obj = ObjectInitializer::new(context);
+        obj.property(js_string!("enumerable"), desc.expect_enumerable(), Default::default());
+        obj.property(js_string!("configurable"), desc.expect_configurable(), Default::default());
+        obj.build().into()
     }
 }
 
-/// Convert a JsValue property key to a PropertyKey, using a Context
-/// for ToString conversion when needed.
-fn property_key_from_value_with_ctx(
-    key: &JsValue,
-    context: &mut Context,
-) -> PropertyKey {
+fn property_key_from_value_with_ctx(key: &JsValue, context: &mut Context) -> PropertyKey {
     if let Some(s) = key.as_string() {
         PropertyKey::String(s.clone())
     } else if let Some(n) = key.as_number() {
@@ -277,13 +397,11 @@ fn property_key_from_value_with_ctx(
     } else if let Some(sym) = key.as_symbol() {
         PropertyKey::Symbol(sym)
     } else {
-        // null, undefined, boolean — convert via ToString
         let s = key.to_string(context).unwrap_or_else(|_| js_string!(""));
         PropertyKey::String(s)
     }
 }
 
-/// Convert a JsValue descriptor object to a PropertyDescriptor.
 fn desc_from_obj(desc_obj: &JsValue, context: &mut Context) -> JsResult<PropertyDescriptor> {
     match desc_obj.as_object() {
         Some(o) => o.to_property_descriptor(context),
@@ -293,11 +411,8 @@ fn desc_from_obj(desc_obj: &JsValue, context: &mut Context) -> JsResult<Property
     }
 }
 
-// ── Cross-origin helper operations ──
-// These implement the abstract operations from HTML spec § 7.2.1.3.
-// They are ready for cross-origin support.
+// ── Cross-origin helpers (HTML §7.2.1.3) ──
 
-/// <https://html.spec.whatwg.org/#crossoriginproperties-(-o-)>
 #[allow(dead_code)]
 struct CrossOriginPropertyEntry {
     property: &'static str,
@@ -305,7 +420,6 @@ struct CrossOriginPropertyEntry {
     needs_set: bool,
 }
 
-/// <https://html.spec.whatwg.org/#crossoriginproperties-(-o-)>
 #[allow(dead_code)]
 fn cross_origin_window_properties() -> Vec<CrossOriginPropertyEntry> {
     vec![
@@ -325,26 +439,20 @@ fn cross_origin_window_properties() -> Vec<CrossOriginPropertyEntry> {
     ]
 }
 
-/// <https://html.spec.whatwg.org/#crossoriginownpropertykeys-(-o-)>
 #[allow(dead_code)]
 pub(crate) fn cross_origin_own_property_keys() -> Vec<PropertyKey> {
     let mut keys: Vec<PropertyKey> = cross_origin_window_properties()
         .into_iter()
         .map(|p| PropertyKey::String(js_string!(p.property)))
         .collect();
-
     keys.push(PropertyKey::String(js_string!("then")));
     keys.push(PropertyKey::Symbol(boa_engine::JsSymbol::to_string_tag()));
     keys.push(PropertyKey::Symbol(boa_engine::JsSymbol::has_instance()));
     keys.push(PropertyKey::Symbol(boa_engine::JsSymbol::is_concat_spreadable()));
-
     keys
 }
 
-/// <https://html.spec.whatwg.org/#crossoriginownpropertykeys-(-o-)>
 #[allow(dead_code)]
 pub(crate) fn is_cross_origin_property(name: &str) -> bool {
-    cross_origin_window_properties()
-        .iter()
-        .any(|p| p.property == name)
+    cross_origin_window_properties().iter().any(|p| p.property == name)
 }

--- a/content/src/js/bindings/html/mod.rs
+++ b/content/src/js/bindings/html/mod.rs
@@ -11,4 +11,4 @@ mod window;
 
 pub(crate) use host_hooks::build_boa_context;
 pub(crate) use html_element::style_declaration_object;
-pub(crate) use window::create_window_proxy;
+

--- a/content/src/js/bindings/html/window.rs
+++ b/content/src/js/bindings/html/window.rs
@@ -8,7 +8,7 @@ use crate::js::platform_objects::{
 };
 use crate::js::with_event_target_mut;
 use crate::html::{
-    Location, Window, WindowOrWorkerGlobalScope, WindowProxy,
+    Location, Window, WindowOrWorkerGlobalScope, resolve_window,
     safe_passing_of_structured_data::StructuredCloneOptions,
     window_computed_style_properties_for_element,
 };
@@ -362,20 +362,7 @@ fn get_computed_style_method(
 
 /// <https://html.spec.whatwg.org/#the-windowproxy-exotic-object>
 ///
-/// Create a WindowProxy exotic object wrapping the given Window.
-/// The returned JsObject carries a `WindowProxy` data struct whose
-/// `internal_methods()` override supplies the 10 overridden internal
-/// methods specified by HTML §7.2.3.
-///
-/// The prototype is set to `Window.prototype` so that accessors and
-/// methods on the Window WebIDL interface are reachable through the
-/// proxy's prototype chain.
-pub(crate) fn create_window_proxy(window: JsObject) -> JsValue {
-    let prototype = window.prototype();
-    let proxy = WindowProxy::new(window);
-    let proxy_object = JsObject::from_proto_and_data(prototype, proxy);
-    JsValue::from(proxy_object)
-}
+
 
 fn location_object(context: &mut Context) -> JsResult<JsObject> {
     if let Some(object) = cached_location_object(context)? {
@@ -392,24 +379,9 @@ fn location_object(context: &mut Context) -> JsResult<JsObject> {
 /// <https://html.spec.whatwg.org/#the-windowproxy-exotic-object>
 ///
 /// Resolve the Window from a receiver that may be a Window or a WindowProxy.
-/// When accessors on Window.prototype are invoked via a WindowProxy (e.g.
-/// `proxy.onload = ...`), the receiver (`this`) is the WindowProxy JsObject.
-/// This function unwraps WindowProxy to its inner Window so that downcasts
-/// succeed.
+/// Delegates to the domain layer's `resolve_window`.
 fn current_window_object(this: &JsValue, context: &Context) -> JsObject {
-    if let Some(object) = this.as_object() {
-        // If the receiver is a WindowProxy, extract the inner Window.
-        // This handles [[Get]] and [[Set]] delegation: the spec says
-        // OrdinaryGet(W, P, Receiver) / OrdinarySet(W, P, V, Receiver)
-        // where operations happen on W (the Window) even though the
-        // Receiver is the WindowProxy.
-        if let Some(proxy) = object.downcast_ref::<WindowProxy>() {
-            return proxy.window_handle().clone();
-        }
-        return object.clone();
-    }
-
-    context.global_object()
+    resolve_window(this, context)
 }
 
 fn downcast_window(object: &JsObject) -> JsResult<boa_gc::GcRef<'_, Window>> {

--- a/content/src/webidl/array_index.rs
+++ b/content/src/webidl/array_index.rs
@@ -2,28 +2,47 @@
 
 use boa_engine::JsValue;
 
-/// <https://webidl.spec.whatwg.org/#dfn-array-index-property-name>
+/// <https://webidl.spec.whatwg.org/#legacy-platform-object-abstract-ops>
 pub(crate) fn is_array_index_key(key: &JsValue) -> bool {
-    if let Some(s) = key.as_string() {
-        let s = s.to_std_string_escaped();
-        if s.is_empty() {
-            return false;
+    // Step 1: "If P is not a String, then return false."
+    let s = match key.as_string() {
+        Some(s) => s.to_std_string_escaped(),
+        None => {
+            // Also accept numeric JsValues — they coerce to string keys.
+            let n = match key.as_number() {
+                Some(n) => n,
+                None => return false,
+            };
+            // For numbers, check the integer range directly.
+            // Step 5: "If index is −0, then return false."
+            // Step 6: "If index < 0, then return false."
+            // Step 7: "If index ≥ 2^32 − 1, then return false."
+            if n.fract() != 0.0 || n == -0.0_f64 || n < 0.0 || n >= (1u64 << 32) as f64 - 1.0 {
+                return false;
+            }
+            return true;
         }
-        let parsed: u64 = match s.parse() {
-            Ok(v) => v,
-            Err(_) => return false,
-        };
-        if parsed >= u32::MAX as u64 {
-            return false;
-        }
-        parsed.to_string() == s
-    } else if key.is_number() {
-        if let Some(n) = key.as_number() {
-            n.fract() == 0.0 && n >= 0.0 && n < u32::MAX as f64
-        } else {
-            false
-        }
-    } else {
-        false
+    };
+
+    // Step 2: "Let index be CanonicalNumericIndexString(P)."
+    // CanonicalNumericIndexString returns undefined for non-numeric strings.
+    // Parse as integer and verify round-trip via ToString.
+    // Step 3: "If index is undefined, then return false."
+    let parsed: u64 = match s.parse() {
+        Ok(v) => v,
+        Err(_) => return false,
+    };
+
+    // Step 6: "If index < 0, then return false." — u64 is always >= 0.
+    // Step 7: "If index ≥ 2^32 − 1, then return false."
+    if parsed >= (1u64 << 32) - 1 {
+        return false;
     }
+
+    // Verify round-trip: CanonicalNumericIndexString requires the string
+    // to be the canonical numeric representation (no leading zeros, etc.).
+    // Step 4: "If IsInteger(index) is false, then return false."
+    // Step 5: "If index is −0, then return false." — u64 excludes −0.
+    // Step 8: "Return true."
+    parsed.to_string() == s
 }

--- a/content/src/webidl/array_index.rs
+++ b/content/src/webidl/array_index.rs
@@ -1,18 +1,8 @@
 //! <https://webidl.spec.whatwg.org/#dfn-array-index-property-name>
-//!
-//! Helpers for the Web IDL "array index property name" definition.
 
 use boa_engine::JsValue;
 
 /// <https://webidl.spec.whatwg.org/#dfn-array-index-property-name>
-///
-/// A string property name P is an array index if:
-/// - P is not the empty string
-/// - ToUint32(P) is not 2^32-1
-/// - SameValue(ToString(ToUint32(P)), P) is true
-///
-/// This also checks numeric JsValue variants as they would be coerced
-/// to string for property access.
 pub(crate) fn is_array_index_key(key: &JsValue) -> bool {
     if let Some(s) = key.as_string() {
         let s = s.to_std_string_escaped();

--- a/content/src/webidl/array_index.rs
+++ b/content/src/webidl/array_index.rs
@@ -1,0 +1,39 @@
+//! <https://webidl.spec.whatwg.org/#dfn-array-index-property-name>
+//!
+//! Helpers for the Web IDL "array index property name" definition.
+
+use boa_engine::JsValue;
+
+/// <https://webidl.spec.whatwg.org/#dfn-array-index-property-name>
+///
+/// A string property name P is an array index if:
+/// - P is not the empty string
+/// - ToUint32(P) is not 2^32-1
+/// - SameValue(ToString(ToUint32(P)), P) is true
+///
+/// This also checks numeric JsValue variants as they would be coerced
+/// to string for property access.
+pub(crate) fn is_array_index_key(key: &JsValue) -> bool {
+    if let Some(s) = key.as_string() {
+        let s = s.to_std_string_escaped();
+        if s.is_empty() {
+            return false;
+        }
+        let parsed: u64 = match s.parse() {
+            Ok(v) => v,
+            Err(_) => return false,
+        };
+        if parsed >= u32::MAX as u64 {
+            return false;
+        }
+        parsed.to_string() == s
+    } else if key.is_number() {
+        if let Some(n) = key.as_number() {
+            n.fract() == 0.0 && n >= 0.0 && n < u32::MAX as f64
+        } else {
+            false
+        }
+    } else {
+        false
+    }
+}

--- a/content/src/webidl/mod.rs
+++ b/content/src/webidl/mod.rs
@@ -1,9 +1,11 @@
 pub(crate) mod bindings;
+mod array_index;
 mod async_iterable;
 mod buffer_source;
 mod callback;
 mod promise;
 
+pub(crate) use array_index::is_array_index_key;
 pub(crate) use async_iterable::{AsyncValueIterable, create_value_async_iterator};
 pub(crate) use buffer_source::{get_a_copy_of_the_buffer_source, is_buffer_source};
 pub(crate) use callback::{

--- a/vendor/boa/core/engine/src/builtins/proxy/mod.rs
+++ b/vendor/boa/core/engine/src/builtins/proxy/mod.rs
@@ -134,16 +134,16 @@ impl BuiltInConstructor for Proxy {
 }
 
 impl Proxy {
-    pub(crate) fn new(target: JsObject, handler: JsObject) -> Self {
+    pub fn new(target: JsObject, handler: JsObject) -> Self {
         Self {
             data: Some((target, handler)),
         }
     }
 
-    /// This is an internal method only built for usage in the proxy internal methods.
+    /// Returns the (target, handler) of the proxy.
     ///
-    /// It returns the (target, handler) of the proxy.
-    pub(crate) fn try_data(&self) -> JsResult<(JsObject, JsObject)> {
+    /// This is an internal method only built for usage in the proxy internal methods.
+    pub fn try_data(&self) -> JsResult<(JsObject, JsObject)> {
         self.data.clone().ok_or_else(|| {
             JsNativeError::typ()
                 .with_message("Proxy object has empty handler and target")
@@ -157,7 +157,7 @@ impl Proxy {
     //  - [ECMAScript reference][spec]
     //
     // [spec]: https://tc39.es/ecma262/#sec-proxycreate
-    pub(crate) fn create(
+    pub fn create(
         target: &JsValue,
         handler: &JsValue,
         context: &mut Context,

--- a/vendor/boa/core/engine/src/object/internal_methods/mod.rs
+++ b/vendor/boa/core/engine/src/object/internal_methods/mod.rs
@@ -25,7 +25,7 @@ pub(crate) mod string;
 
 /// A lightweight wrapper around [`Context`] used in [`InternalObjectMethods`].
 #[derive(Debug)]
-pub struct InternalMethodPropertyContext<'ctx> {
+pub(crate) struct InternalMethodPropertyContext<'ctx> {
     context: &'ctx mut Context,
     slot: Slot,
 }
@@ -71,7 +71,7 @@ impl<'context> From<&'context mut Context> for InternalMethodPropertyContext<'co
 
 /// A lightweight wrapper around [`Context`] used in internal call methods.
 #[derive(Debug)]
-pub struct InternalMethodCallContext<'ctx> {
+pub(crate) struct InternalMethodCallContext<'ctx> {
     context: &'ctx mut Context,
     native_source_info: NativeSourceInfo,
 }
@@ -143,7 +143,7 @@ impl JsObject {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-getprototypeof
     #[track_caller]
-    pub fn __get_prototype_of__(&self, context: &mut Context) -> JsResult<JsPrototype> {
+    pub(crate) fn __get_prototype_of__(&self, context: &mut Context) -> JsResult<JsPrototype> {
         (self.vtable().__get_prototype_of__)(self, context)
     }
 
@@ -155,7 +155,7 @@ impl JsObject {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-setprototypeof-v
-    pub fn __set_prototype_of__(
+    pub(crate) fn __set_prototype_of__(
         &self,
         val: JsPrototype,
         context: &mut Context,
@@ -171,7 +171,7 @@ impl JsObject {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-isextensible
-    pub fn __is_extensible__(&self, context: &mut Context) -> JsResult<bool> {
+    pub(crate) fn __is_extensible__(&self, context: &mut Context) -> JsResult<bool> {
         (self.vtable().__is_extensible__)(self, context)
     }
 
@@ -183,7 +183,7 @@ impl JsObject {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-preventextensions
-    pub fn __prevent_extensions__(&self, context: &mut Context) -> JsResult<bool> {
+    pub(crate) fn __prevent_extensions__(&self, context: &mut Context) -> JsResult<bool> {
         (self.vtable().__prevent_extensions__)(self, context)
     }
 
@@ -195,7 +195,7 @@ impl JsObject {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-getownproperty-p
-    pub fn __get_own_property__(
+    pub(crate) fn __get_own_property__(
         &self,
         key: &PropertyKey,
         context: &mut InternalMethodPropertyContext<'_>,
@@ -211,7 +211,7 @@ impl JsObject {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-defineownproperty-p-desc
-    pub fn __define_own_property__(
+    pub(crate) fn __define_own_property__(
         &self,
         key: &PropertyKey,
         desc: PropertyDescriptor,
@@ -228,7 +228,7 @@ impl JsObject {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-hasproperty-p
-    pub fn __has_property__(
+    pub(crate) fn __has_property__(
         &self,
         key: &PropertyKey,
         context: &mut InternalMethodPropertyContext<'_>,
@@ -246,7 +246,7 @@ impl JsObject {
     ///
     /// [spec0]: https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-hasproperty-p
     /// [spec1]: https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-get-p-receiver
-    pub fn __try_get__(
+    pub(crate) fn __try_get__(
         &self,
         key: &PropertyKey,
         receiver: JsValue,
@@ -263,7 +263,7 @@ impl JsObject {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-get-p-receiver
-    pub fn __get__(
+    pub(crate) fn __get__(
         &self,
         key: &PropertyKey,
         receiver: JsValue,
@@ -280,7 +280,7 @@ impl JsObject {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-set-p-v-receiver
-    pub fn __set__(
+    pub(crate) fn __set__(
         &self,
         key: PropertyKey,
         value: JsValue,
@@ -298,7 +298,7 @@ impl JsObject {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-delete-p
-    pub fn __delete__(
+    pub(crate) fn __delete__(
         &self,
         key: &PropertyKey,
         context: &mut InternalMethodPropertyContext<'_>,
@@ -315,7 +315,7 @@ impl JsObject {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-ownpropertykeys
     #[track_caller]
-    pub fn __own_property_keys__(
+    pub(crate) fn __own_property_keys__(
         &self,
         context: &mut Context,
     ) -> JsResult<Vec<PropertyKey>> {
@@ -333,7 +333,7 @@ impl JsObject {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-ecmascript-function-objects-call-thisargument-argumentslist
     #[track_caller]
-    pub fn __call__(&self, argument_count: usize) -> CallValue {
+    pub(crate) fn __call__(&self, argument_count: usize) -> CallValue {
         CallValue::Pending {
             func: self.vtable().__call__,
             object: self.clone(),
@@ -353,7 +353,7 @@ impl JsObject {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-ecmascript-function-objects-construct-argumentslist-newtarget
     #[track_caller]
-    pub fn __construct__(&self, argument_count: usize) -> CallValue {
+    pub(crate) fn __construct__(&self, argument_count: usize) -> CallValue {
         CallValue::Pending {
             func: self.vtable().__construct__,
             object: self.clone(),
@@ -374,7 +374,7 @@ impl JsObject {
 /// Then, reference this static in the creation phase of an `ObjectData`.
 ///
 /// E.g. `ObjectData::string`
-pub const ORDINARY_INTERNAL_METHODS: InternalObjectMethods = InternalObjectMethods {
+pub(crate) const ORDINARY_INTERNAL_METHODS: InternalObjectMethods = InternalObjectMethods {
     __get_prototype_of__: ordinary_get_prototype_of,
     __set_prototype_of__: ordinary_set_prototype_of,
     __is_extensible__: ordinary_is_extensible,
@@ -400,53 +400,53 @@ pub const ORDINARY_INTERNAL_METHODS: InternalObjectMethods = InternalObjectMetho
 /// For a guide on how to implement exotic internal methods, see `ORDINARY_INTERNAL_METHODS`.
 #[derive(Debug, Clone, Copy)]
 #[allow(clippy::type_complexity, clippy::struct_field_names)]
-pub struct InternalObjectMethods {
-    pub __get_prototype_of__: fn(&JsObject, &mut Context) -> JsResult<JsPrototype>,
-    pub __set_prototype_of__: fn(&JsObject, JsPrototype, &mut Context) -> JsResult<bool>,
-    pub __is_extensible__: fn(&JsObject, &mut Context) -> JsResult<bool>,
-    pub __prevent_extensions__: fn(&JsObject, &mut Context) -> JsResult<bool>,
-    pub __get_own_property__: fn(
+pub(crate) struct InternalObjectMethods {
+    pub(crate) __get_prototype_of__: fn(&JsObject, &mut Context) -> JsResult<JsPrototype>,
+    pub(crate) __set_prototype_of__: fn(&JsObject, JsPrototype, &mut Context) -> JsResult<bool>,
+    pub(crate) __is_extensible__: fn(&JsObject, &mut Context) -> JsResult<bool>,
+    pub(crate) __prevent_extensions__: fn(&JsObject, &mut Context) -> JsResult<bool>,
+    pub(crate) __get_own_property__: fn(
         &JsObject,
         &PropertyKey,
         &mut InternalMethodPropertyContext<'_>,
     ) -> JsResult<Option<PropertyDescriptor>>,
-    pub __define_own_property__: fn(
+    pub(crate) __define_own_property__: fn(
         &JsObject,
         &PropertyKey,
         PropertyDescriptor,
         &mut InternalMethodPropertyContext<'_>,
     ) -> JsResult<bool>,
-    pub __has_property__:
+    pub(crate) __has_property__:
         fn(&JsObject, &PropertyKey, &mut InternalMethodPropertyContext<'_>) -> JsResult<bool>,
-    pub __get__: fn(
+    pub(crate) __get__: fn(
         &JsObject,
         &PropertyKey,
         JsValue,
         &mut InternalMethodPropertyContext<'_>,
     ) -> JsResult<JsValue>,
-    pub __try_get__: fn(
+    pub(crate) __try_get__: fn(
         &JsObject,
         &PropertyKey,
         JsValue,
         &mut InternalMethodPropertyContext<'_>,
     ) -> JsResult<Option<JsValue>>,
-    pub __set__: fn(
+    pub(crate) __set__: fn(
         &JsObject,
         PropertyKey,
         JsValue,
         JsValue,
         &mut InternalMethodPropertyContext<'_>,
     ) -> JsResult<bool>,
-    pub __delete__:
+    pub(crate) __delete__:
         fn(&JsObject, &PropertyKey, &mut InternalMethodPropertyContext<'_>) -> JsResult<bool>,
-    pub __own_property_keys__:
+    pub(crate) __own_property_keys__:
         fn(&JsObject, context: &mut Context) -> JsResult<Vec<PropertyKey>>,
-    pub __call__: fn(
+    pub(crate) __call__: fn(
         &JsObject,
         argument_count: usize,
         context: &mut InternalMethodCallContext<'_>,
     ) -> JsResult<CallValue>,
-    pub __construct__: fn(
+    pub(crate) __construct__: fn(
         &JsObject,
         argument_count: usize,
         context: &mut InternalMethodCallContext<'_>,
@@ -457,7 +457,7 @@ pub struct InternalObjectMethods {
 ///
 /// This is done to avoid recursion.
 #[allow(variant_size_differences)]
-pub enum CallValue {
+pub(crate) enum CallValue {
     /// Calling is ready, the frames have been setup.
     ///
     /// Requires calling [`Context::run()`].

--- a/vendor/boa/core/engine/src/object/mod.rs
+++ b/vendor/boa/core/engine/src/object/mod.rs
@@ -29,7 +29,7 @@ use std::{
 #[cfg(test)]
 mod tests;
 
-pub mod internal_methods;
+pub(crate) mod internal_methods;
 
 pub mod builtins;
 mod datatypes;


### PR DESCRIPTION
   Replace the custom JsData exotic-object WindowProxy (which required
   exposing Boa's internal methods as public API) with a real JavaScript
   Proxy created via ProxyCreate.  This follows the Web IDL observable
   array pattern (§3.10 of the Web IDL spec).

   The handler provides only two traps that differ from default Proxy
   behavior:
   - setPrototypeOf: implements SetImmutablePrototype
   - preventExtensions: always returns false

   All other internal methods ([[Get]], [[Set]], [[Has]], [[Delete]],
   [[DefineOwnProperty]], [[GetOwnProperty]], [[OwnPropertyKeys]],
   [[GetPrototypeOf]]) use the default Proxy behavior which correctly
   delegates to the target Window.

   Boa changes:
   - Made Proxy::create, Proxy::new, Proxy::try_data public
   - Reverted all internal-methods visibility changes (back to pub(crate))