### PR TITLE
Run the embedder in-process instead of spawning a child process

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,7 +103,7 @@ review checklist.
 
 # Project Structure
 
-The formal-web project implements a web browser from scratch from separate processes coordinated by the user agent. The main `formal-web` binary launches dedicated `formal-web-content` and `formal-web-net` processes from the `content` and `net` packages. The embedder delegates to these processes through the `webview` and `user_agent` layers, keeps paint payloads on shared-memory transport, and uses typed IPC messages for metadata and handles. Navigation completion uses explicit content-to-embedder commit signaling.
+The formal-web project implements a web browser from scratch from separate processes coordinated by the user agent. The main `formal-web` binary runs the embedder directly in-process and launches dedicated `formal-web-content` and `formal-web-net` helper processes from the `content` and `net` packages. It delegates to these processes through the `webview` and `user_agent` layers, keeps paint payloads on shared-memory transport, and uses typed IPC messages for metadata and handles. Navigation completion uses explicit content-to-embedder commit signaling.
 
 TLA+ models under `verification/` verify critical algorithms (e.g. navigation). The TLA+ Toolbox jar is at `/Applications/TLA+ Toolbox.app/Contents/Eclipse/tla2tools.jar`. Verification artifacts go in temporary directories.
 
@@ -121,8 +121,8 @@ shared dependency resolution and incremental compilation.
 
 ### Components
 
-- **Root binary** (`formal-web`): thin launcher that delegates to the embedder.
-- **Embedder** (`formal-web-embedder`): the actual application process.
+- **Root binary** (`formal-web`): runs the embedder directly in-process, creating the window and event loop.
+- **Embedder crate** (`embedder`): a library used by the root binary that owns the winit event loop, window, chrome, and automation plumbing. A standalone `formal-web-embedder` binary is also produced for direct use.
 - **Helper processes** (`formal-web-content`, `formal-web-net`, `formal-web-media`): spawned by the embedder.
 
 ### Three verbs
@@ -278,8 +278,8 @@ The project uses the standard `log` crate with `env_logger` for structured loggi
 
 At the end of each task, run the following steps **in order**:
 
-1. **Tear down browser/CDP infra** — Kill any formal-web embedder processes
-   (`pkill -f "formal-web-embedder")`, CDP servers, or other processes that
+1. **Tear down browser/CDP infra** — Kill any formal-web processes
+   (`pkill -f "formal-web"`)`, CDP servers, or other processes that
    were started during the session. Leftover processes can block ports and
    interfere with subsequent tasks.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1774,6 +1774,7 @@ version = "0.1.0"
 dependencies = [
  "automation",
  "clap",
+ "embedder",
  "env_logger",
  "log",
  "verification",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ media = []
 [dependencies]
 automation = { path = "automation" }
 clap = { version = "4.5", features = ["derive"] }
+embedder = { path = "embedder" }
 wpt_runner = { path = "tests/wpt_runner" }
 verification = { path = "verification" }
 log = "0.4"

--- a/README.md
+++ b/README.md
@@ -27,6 +27,18 @@ rustup run 1.94.0 cargo build --release --no-default-features
 rustup run 1.94.0 cargo run --release -- --no-default-features
 ```
 
+## Project architecture
+
+A multiprocess approach is chosen by default, because the goal is to match [Apple's guidelines for an independent browser engine](https://developer.apple.com/documentation/
+BrowserEngineKit/designing-your-browser-architecture). 
+
+The following procesess are used:
+
+- Main: running the `embedder`, `webview`, and `user_agent` crates. The process is started in `src/main.rs`.
+- Content: running the `content` crate, and started in `user_agent/src/event_loop.rs`, because each process is running what is essentially a window event loop. In the future it will also run dedicated worker event loops. Service workers will likely run in their own process, and for shared worker the issue hasn't been decided yet (it seems there is a move towards isolating them per top-level sites). There is one process per [similar origin window agent](https://html.spec.whatwg.org/#similar-origin-window-agent); this is the only type of process of which there can be more than one.
+- Net: running the `net` crate. That process is owned by the fetch worker in `user_agent/src/fetch.rs`, and the code in the process will essentially be the part of the fetch standard that starts at https://fetch.spec.whatwg.org/#http-network-or-cache-fetch.
+- Media: running the `media` crate, which runs gstreamer, which is started and owned by the media worker in `user_agent/src/media.rs`. This is an optional feature as expalined above under Quick Start.
+
 ## Project structure
 
 | Directory | Description |

--- a/embedder/Cargo.toml
+++ b/embedder/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.1.0"
 edition = "2024"
 publish = false
 
+[lib]
+name = "embedder"
+path = "src/lib.rs"
+
 [[bin]]
 name = "formal-web-embedder"
 path = "src/main.rs"

--- a/embedder/src/lib.rs
+++ b/embedder/src/lib.rs
@@ -1,0 +1,147 @@
+mod event_loop;
+
+use verification::{TraceSender, VerificationRun};
+
+pub use event_loop::{
+    EventLoopOptions, FormalWebUserEvent, NavigationCompleted, NavigationCompletion,
+    clear_event_loop_options, event_loop_is_ready, run_headed_event_loop, run_headless_event_loop,
+    send_user_event, set_event_loop_options, window_viewport_snapshot,
+};
+
+#[derive(Clone, Default)]
+pub struct AppRunOptions {
+    pub headless: bool,
+    pub startup_url: Option<String>,
+    pub window_title: Option<String>,
+    pub trace_sender: Option<TraceSender>,
+}
+
+pub fn run_default(verify: bool, headless: bool) -> Result<(), String> {
+    let verification_run = if verify {
+        Some(
+            VerificationRun::start()
+                .map_err(|error| format!("failed to start verification: {error}"))?,
+        )
+    } else {
+        None
+    };
+    let trace_sender = verification_run.as_ref().map(VerificationRun::sender_clone);
+
+    let result = run_app_with_options(AppRunOptions {
+        headless,
+        trace_sender,
+        ..AppRunOptions::default()
+    });
+
+    let verification_result = verification_run
+        .map(VerificationRun::finish)
+        .unwrap_or(Ok(()));
+    combine_results(result, verification_result)
+}
+
+pub fn run_app_with_options(options: AppRunOptions) -> Result<(), String> {
+    set_event_loop_options(EventLoopOptions {
+        startup_url: options.startup_url,
+        window_title: options.window_title,
+    });
+
+    let event_loop_result = if options.headless {
+        run_headless_event_loop(options.trace_sender.clone())
+    } else {
+        run_headed_event_loop(options.trace_sender.clone())
+    };
+    clear_event_loop_options();
+
+    event_loop_result
+}
+
+pub fn run_webdriver(
+    args: automation::WebDriverArgs,
+    verify: bool,
+    headless: bool,
+) -> Result<(), String> {
+    let verification_run = if verify {
+        Some(
+            VerificationRun::start()
+                .map_err(|error| format!("failed to start verification: {error}"))?,
+        )
+    } else {
+        None
+    };
+    let trace_sender = verification_run.as_ref().map(VerificationRun::sender_clone);
+
+    let runtime = automation::automation_bridge(
+        |command| send_user_event(FormalWebUserEvent::Automation(command)),
+        || send_user_event(FormalWebUserEvent::Exit),
+        event_loop_is_ready,
+    );
+    let webdriver_server = automation::WebDriverServer::start(
+        args.port,
+        args.exit_on_session_delete,
+        runtime.clone(),
+    )?;
+    let cdp_server = args
+        .cdp_port
+        .map(|port| automation::CdpServerHandle::start(port, runtime))
+        .transpose()?;
+    let result = run_app_with_options(AppRunOptions {
+        headless: args.headless || headless,
+        startup_url: args
+            .startup_url
+            .or_else(|| Some(String::from("about:blank"))),
+        window_title: Some(format!("formal-web WebDriver :{}", args.port)),
+        trace_sender,
+    });
+    drop(cdp_server);
+    drop(webdriver_server);
+
+    let verification_result = verification_run
+        .map(VerificationRun::finish)
+        .unwrap_or(Ok(()));
+    combine_results(result, verification_result)
+}
+
+pub fn run_cdp(args: automation::CdpArgs, verify: bool, headless: bool) -> Result<(), String> {
+    let verification_run = if verify {
+        Some(
+            VerificationRun::start()
+                .map_err(|error| format!("failed to start verification: {error}"))?,
+        )
+    } else {
+        None
+    };
+    let trace_sender = verification_run.as_ref().map(VerificationRun::sender_clone);
+
+    let runtime = automation::automation_bridge(
+        |command| send_user_event(FormalWebUserEvent::Automation(command)),
+        || send_user_event(FormalWebUserEvent::Exit),
+        event_loop_is_ready,
+    );
+    let server = automation::CdpServerHandle::start(args.port, runtime)?;
+    let result = run_app_with_options(AppRunOptions {
+        headless: args.headless || headless,
+        startup_url: args
+            .startup_url
+            .or_else(|| Some(String::from("about:blank"))),
+        window_title: Some(format!("formal-web CDP :{}", args.port)),
+        trace_sender,
+    });
+    drop(server);
+
+    let verification_result = verification_run
+        .map(VerificationRun::finish)
+        .unwrap_or(Ok(()));
+    combine_results(result, verification_result)
+}
+
+fn combine_results(
+    primary: Result<(), String>,
+    final_step: Result<(), String>,
+) -> Result<(), String> {
+    match (primary, final_step) {
+        (Ok(()), Ok(())) => Ok(()),
+        (Err(error), Ok(())) => Err(error),
+        (Ok(()), Err(error)) => Err(error),
+        (Err(error), Err(final_error)) => Err(format!("{error}; {final_error}")),
+    }
+}

--- a/embedder/src/main.rs
+++ b/embedder/src/main.rs
@@ -1,10 +1,8 @@
-mod event_loop;
-
 use clap::{Parser, Subcommand};
 use log::error;
 use std::ffi::OsString;
 use std::process::ExitCode;
-use verification::{TraceSender, VerificationRun, run_validation_from_iter};
+use verification::run_validation_from_iter;
 
 #[derive(Parser, Debug)]
 #[command(name = "formal-web-embedder")]
@@ -27,92 +25,6 @@ enum CommandKind {
 
     #[command(name = "cdp")]
     Cdp(automation::CdpArgs),
-}
-
-#[derive(Clone, Default)]
-struct AppRunOptions {
-    headless: bool,
-    startup_url: Option<String>,
-    window_title: Option<String>,
-    trace_sender: Option<TraceSender>,
-}
-
-fn run_app_with_options(options: AppRunOptions) -> Result<(), String> {
-    event_loop::set_event_loop_options(event_loop::EventLoopOptions {
-        startup_url: options.startup_url,
-        window_title: options.window_title,
-    });
-
-    let event_loop_result = if options.headless {
-        event_loop::run_headless_event_loop(options.trace_sender.clone())
-    } else {
-        event_loop::run_headed_event_loop(options.trace_sender.clone())
-    };
-    event_loop::clear_event_loop_options();
-
-    event_loop_result
-}
-
-fn run_webdriver(
-    args: automation::WebDriverArgs,
-    trace_sender: Option<TraceSender>,
-) -> Result<(), String> {
-    let runtime = automation::automation_bridge(
-        |command| event_loop::send_user_event(event_loop::FormalWebUserEvent::Automation(command)),
-        || event_loop::send_user_event(event_loop::FormalWebUserEvent::Exit),
-        event_loop::event_loop_is_ready,
-    );
-    let webdriver_server = automation::WebDriverServer::start(
-        args.port,
-        args.exit_on_session_delete,
-        runtime.clone(),
-    )?;
-    let cdp_server = args
-        .cdp_port
-        .map(|port| automation::CdpServerHandle::start(port, runtime.clone()))
-        .transpose()?;
-    let result = run_app_with_options(AppRunOptions {
-        headless: args.headless,
-        startup_url: args
-            .startup_url
-            .or_else(|| Some(String::from("about:blank"))),
-        window_title: Some(format!("formal-web WebDriver :{}", args.port)),
-        trace_sender,
-    });
-    drop(cdp_server);
-    drop(webdriver_server);
-    result
-}
-
-fn run_cdp(args: automation::CdpArgs, trace_sender: Option<TraceSender>) -> Result<(), String> {
-    let runtime = automation::automation_bridge(
-        |command| event_loop::send_user_event(event_loop::FormalWebUserEvent::Automation(command)),
-        || event_loop::send_user_event(event_loop::FormalWebUserEvent::Exit),
-        event_loop::event_loop_is_ready,
-    );
-    let server = automation::CdpServerHandle::start(args.port, runtime)?;
-    let result = run_app_with_options(AppRunOptions {
-        headless: args.headless,
-        startup_url: args
-            .startup_url
-            .or_else(|| Some(String::from("about:blank"))),
-        window_title: Some(format!("formal-web CDP :{}", args.port)),
-        trace_sender,
-    });
-    drop(server);
-    result
-}
-
-fn combine_results(
-    primary: Result<(), String>,
-    final_step: Result<(), String>,
-) -> Result<(), String> {
-    match (primary, final_step) {
-        (Ok(()), Ok(())) => Ok(()),
-        (Err(error), Ok(())) => Err(error),
-        (Ok(()), Err(error)) => Err(error),
-        (Err(error), Err(final_error)) => Err(format!("{error}; {final_error}")),
-    }
 }
 
 fn delegated_tla_validate_command() -> Option<ExitCode> {
@@ -140,35 +52,13 @@ fn main() -> ExitCode {
     }
 
     let cli = Cli::parse();
-
-    let verification_run = if cli.verify {
-        match VerificationRun::start() {
-            Ok(run) => Some(run),
-            Err(error) => {
-                error!("formal-web-embedder: {error}");
-                return ExitCode::from(1);
-            }
-        }
-    } else {
-        None
-    };
-
-    let trace_sender = verification_run.as_ref().map(VerificationRun::sender_clone);
     let result = match cli.command {
-        None => run_app_with_options(AppRunOptions {
-            headless: cli.headless,
-            trace_sender: trace_sender.clone(),
-            ..AppRunOptions::default()
-        }),
-        Some(CommandKind::WebDriver(args)) => run_webdriver(args, trace_sender.clone()),
-        Some(CommandKind::Cdp(args)) => run_cdp(args, trace_sender.clone()),
+        None => embedder::run_default(cli.verify, cli.headless),
+        Some(CommandKind::WebDriver(args)) => {
+            embedder::run_webdriver(args, cli.verify, cli.headless)
+        }
+        Some(CommandKind::Cdp(args)) => embedder::run_cdp(args, cli.verify, cli.headless),
     };
-    drop(trace_sender);
-
-    let verification_result = verification_run
-        .map(VerificationRun::finish)
-        .unwrap_or(Ok(()));
-    let result = combine_results(result, verification_result);
 
     if let Err(error) = result {
         error!("formal-web-embedder: {error}");

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 use clap::{Parser, Subcommand};
 use log::error;
 use std::ffi::OsString;
-use std::process::{Command as ProcessCommand, ExitCode, Stdio};
+use std::process::ExitCode;
 use verification::run_validation_from_iter;
 
 #[derive(Parser, Debug)]
@@ -51,105 +51,6 @@ fn delegated_tla_validate_command() -> Option<ExitCode> {
     })
 }
 
-fn run_embedder_process(embedder_args: Vec<OsString>) -> Result<(), String> {
-    // The embedder is a workspace member, so cargo build --release already
-    // produces target/{profile}/formal-web-embedder alongside the root
-    // binary.  Find it and run it directly rather than spawning a nested
-    // cargo invocation (which would deadlock on the workspace target dir).
-    let current_exe = std::env::current_exe()
-        .map_err(|error| format!("failed to resolve current executable: {error}"))?;
-    let embedder_path = current_exe
-        .parent()
-        .ok_or_else(|| String::from("failed to resolve executable directory"))?
-        .join("formal-web-embedder");
-
-    if !embedder_path.is_file() {
-        return Err(format!(
-            "embedder binary not found at {}; run `cargo build --release -p embedder --bin formal-web-embedder` first",
-            embedder_path.display()
-        ));
-    }
-
-    let status = ProcessCommand::new(&embedder_path)
-        .args(&embedder_args)
-        .stdin(Stdio::inherit())
-        .stdout(Stdio::inherit())
-        .stderr(Stdio::inherit())
-        .status()
-        .map_err(|error| {
-            format!(
-                "failed to execute embedder at {}: {error}",
-                embedder_path.display()
-            )
-        })?;
-
-    if status.success() {
-        Ok(())
-    } else {
-        Err(format!(
-            "embedder process exited with status {}",
-            status
-                .code()
-                .map(|code| code.to_string())
-                .unwrap_or_else(|| String::from("unknown"))
-        ))
-    }
-}
-
-fn run_embedder_default(verify: bool, headless: bool) -> Result<(), String> {
-    let mut args = Vec::<OsString>::new();
-    if verify {
-        args.push(OsString::from("--verify"));
-    }
-    if headless {
-        args.push(OsString::from("--headless"));
-    }
-    run_embedder_process(args)
-}
-
-fn run_embedder_webdriver(verify: bool, args: automation::WebDriverArgs) -> Result<(), String> {
-    let mut embedder_args = Vec::<OsString>::new();
-    if verify {
-        embedder_args.push(OsString::from("--verify"));
-    }
-    embedder_args.push(OsString::from("webdriver"));
-    embedder_args.push(OsString::from("--port"));
-    embedder_args.push(OsString::from(args.port.to_string()));
-    if let Some(cdp_port) = args.cdp_port {
-        embedder_args.push(OsString::from("--cdp-port"));
-        embedder_args.push(OsString::from(cdp_port.to_string()));
-    }
-    if args.headless {
-        embedder_args.push(OsString::from("--headless"));
-    }
-    if let Some(startup_url) = args.startup_url {
-        embedder_args.push(OsString::from("--startup-url"));
-        embedder_args.push(OsString::from(startup_url));
-    }
-    if args.exit_on_session_delete {
-        embedder_args.push(OsString::from("--exit-on-session-delete"));
-    }
-    run_embedder_process(embedder_args)
-}
-
-fn run_embedder_cdp(verify: bool, args: automation::CdpArgs) -> Result<(), String> {
-    let mut embedder_args = Vec::<OsString>::new();
-    if verify {
-        embedder_args.push(OsString::from("--verify"));
-    }
-    embedder_args.push(OsString::from("cdp"));
-    embedder_args.push(OsString::from("--port"));
-    embedder_args.push(OsString::from(args.port.to_string()));
-    if args.headless {
-        embedder_args.push(OsString::from("--headless"));
-    }
-    if let Some(startup_url) = args.startup_url {
-        embedder_args.push(OsString::from("--startup-url"));
-        embedder_args.push(OsString::from(startup_url));
-    }
-    run_embedder_process(embedder_args)
-}
-
 fn main() -> ExitCode {
     env_logger::init();
     if let Some(exit_code) = delegated_tla_validate_command() {
@@ -173,9 +74,11 @@ fn main() -> ExitCode {
     }
 
     let result = match command {
-        None => run_embedder_default(cli.verify, cli.headless),
-        Some(CommandKind::WebDriver(args)) => run_embedder_webdriver(cli.verify, args),
-        Some(CommandKind::Cdp(args)) => run_embedder_cdp(cli.verify, args),
+        None => embedder::run_default(cli.verify, cli.headless),
+        Some(CommandKind::WebDriver(args)) => {
+            embedder::run_webdriver(args, cli.verify, cli.headless)
+        }
+        Some(CommandKind::Cdp(args)) => embedder::run_cdp(args, cli.verify, cli.headless),
         Some(CommandKind::Wpt { .. }) => Ok(()),
     };
 


### PR DESCRIPTION
   Previously the root `formal-web` binary spawned `formal-web-embedder` as a
   separate process, forwarding CLI arguments via command-line serialization.
   This commit eliminates that indirection by making the embedder crate a
   library (`embedder`) that the root binary depends on directly.

   Changes:
   - Created `embedder/src/lib.rs` with the runtime logic (`run_app_with_options`, `run_default`, `run_webdriver`, `run_cdp`) and re-exports from the `event_loop` module.
   - Added `[lib]` section to `embedder/Cargo.toml` so the crate produces both a library and a standalone binary.
   - Thinned `embedder/src/main.rs` to a CLI parser that delegates to the library.
   - Removed `run_embedder_process` and all process-spawning helpers from `src/main.rs` (~100 lines removed). Now calls `embedder::run_default()`, `embedder::run_webdriver()`, etc. directly.
   - Added `embedder` dependency to root `Cargo.toml`.
   - Updated `AGENTS.md` to reflect the new architecture.
   - Added process architecture section to readme