### PR TITLE
ipc: update ARCHITECTURE.md and clean up XPC backend dispatch

### DIFF
--- a/content/src/main.rs
+++ b/content/src/main.rs
@@ -1367,9 +1367,9 @@ impl ContentProcess {
                     0,
                 );
                 let mut next_shmem_key = 0usize;
-                let scene = self
-                    .font_sender
-                    .prepare_scene(self.font_namespace, scene, &mut next_shmem_key);
+                let scene =
+                    self.font_sender
+                        .prepare_scene(self.font_namespace, scene, &mut next_shmem_key);
                 log_render_state_debug(format!(
                     "emit paint traversable={} document={} size=({}, {})",
                     traversable_id, document_id, width, height,

--- a/ipc/ARCHITECTURE.md
+++ b/ipc/ARCHITECTURE.md
@@ -2,12 +2,12 @@
 
 ## Overview
 
-The IPC (Inter-Process Communication) system connects the main `formal-web` process
-with its three helper processes:
+The IPC (Inter-Process Communication) system connects the browser main process
+(embedder / user agent) with its three helper processes:
 
 | Process | Role | Binary |
 |---|---|---|
-| `formal-web` | Browser main process (embedder, window, chrome) | `src/main.rs` |
+| `formal-web-embedder` | Browser main process (window, chrome, routing) | `embedder/src/main.rs` |
 | `formal-web-content` | One per webview — HTML rendering, JS, DOM | `content/src/bin/content_process.rs` |
 | `formal-web-net` | Singleton — HTTP networking | `net/src/bin/net_process.rs` |
 | `formal-web-media` | Singleton — GStreamer media playback | `media/src/bin/media_process.rs` |
@@ -15,11 +15,30 @@ with its three helper processes:
 ## Two Backend Architecture
 
 The crate `ipc/` provides an abstract IPC layer with two selectable backends.
-On macOS, **native XPC is the default**. The ipc-channel backend remains
-available via the `ipc-channel-backend` Cargo feature (used by WPT and
-verification tooling on all platforms).
+**`ipc-channel` is the default** (`default = ["ipc-channel-backend"]` in
+`ipc/Cargo.toml`). The native XPC backend remains available on macOS when the
+feature is disabled.
 
-### 1. Native XPC backend (macOS default)
+### 1. `ipc-channel` backend (default, works everywhere)
+
+Uses Servo's [`ipc-channel`](https://crates.io/crates/ipc-channel) crate for:
+
+- **Bootstrap**: `IpcOneShotServer<T>` — parent creates a named Mach port (macOS)
+  or Unix domain socket (Linux), passes the name to the child via
+  `--<name>-token <uuid>` argv, child connects back.
+- **Transport**: Typed channels (`IpcSender<T>` / `IpcReceiver<T>`) with serde
+  serialization. Mach port rights (macOS) and file descriptors (Linux) are
+  transferred natively by ipc-channel.
+- **Shared memory**: `IpcSharedMemory` regions carried as `HashMap<usize, IpcSharedMemory>`
+  alongside each message, enabling zero-copy bulk data transport for paint scenes
+  and video frames.
+- **Routing**: `RouterProxy` / `ROUTER` to bridge ipc-channel receivers to crossbeam
+  channels on both parent and child sides.
+
+**Selection**: Enabled by `default = ["ipc-channel-backend"]` in `ipc/Cargo.toml`.
+All extensions (content, net, media) use ipc-channel by default.
+
+### 2. Native XPC backend (macOS-only, experimental)
 
 Uses Apple's XPC framework directly for:
 
@@ -30,28 +49,19 @@ Uses Apple's XPC framework directly for:
 - **Shared memory**: `xpc_shmem_create` / `xpc_shmem_map` (stub — not yet wired to
   the message pipeline).
 
-**Selection**: Default on `target_vendor = "apple"` when `ipc-channel-backend`
-feature is not enabled.
+**Selection**: Enabled on `target_vendor = "apple"` when the `ipc-channel-backend`
+feature is disabled (`--no-default-features`).
 
-### 2. `ipc-channel` backend (testing, verification)
-
-Uses Servo's [`ipc-channel`](https://crates.io/crates/ipc-channel) crate for:
-
-- **Bootstrap**: `IpcOneShotServer<T>` — parent creates a named Mach port, passes the
-  name to the child via `--<name>-token <uuid>` argv, child connects back.
-- **Transport**: Typed channels (`IpcSender<T>` / `IpcReceiver<T>`) with serde+postcard
-  serialization. Shared memory via `IpcSharedMemory`.
-- **Routing**: `RouterProxy` / `ROUTER` to bridge ipc-channel receivers to crossbeam
-  channels on both parent and child sides.
-
-**Selection**: `ipc-channel-backend` Cargo feature on individual crates.
-`cargo build --release -p content --features ipc-channel-backend` etc.
+**Mixed-mode fallback**: When the feature is disabled, only `net` and `media`
+use XPC. The `content` process always uses ipc-channel (Unix domain sockets)
+because macOS AMFI rejects ad-hoc-signed embedded XPC services — a paid Apple
+Developer certificate would be required.
 
 ## Crate Structure
 
 ```
 ipc/                          # Abstract IPC API
-├── Cargo.toml                # Feature: ipc-channel-backend
+├── Cargo.toml                # default = ["ipc-channel-backend"]
 ├── src/
 │   ├── lib.rs                # Re-exports
 │   ├── types.rs              # IpcSender, IpcIncoming, IpcSharedRegion,
@@ -61,7 +71,7 @@ ipc/                          # Abstract IPC API
 │   ├── backend.rs            # Feature-gated backend selection
 │   └── backend/
 │       ├── ipc_channel.rs    # ipc-channel backend: IpcOneShotServer bootstrap
-│       └── native.rs         # XPC backend: unique bootstrap listener + postcard
+│       └── xpc.rs            # XPC backend: launchd listener + postcard
 
 xpc-sys/                      # Minimal XPC FFI bindings (Apple only)
 ├── Cargo.toml
@@ -72,12 +82,12 @@ xpc-sys/                      # Minimal XPC FFI bindings (Apple only)
 │   │                         # XpcSharedMemory, callback wrappers
 │   └── xpc_wrapper.c         # C shim: block-based XPC → callback-based FFI
 
-xpc-services/                 # Launchd XPC service configuration
-├── formal-web.net.plist      # Singleton XPC service for net helper
-├── formal-web.media.plist    # Singleton XPC service for media helper
-├── formal-web.content.plist  # MultipleInstances XPC service for content helper
-├── install.sh                # Installs plists with correct binary paths
-└── README.md                 # XPC setup instructions
+xpc-services/                 # Launchd XPC service configuration (XPC backend only)
+├── formal-web.net.plist
+├── formal-web.media.plist
+├── formal-web.content.plist
+├── install.sh
+└── README.md
 ```
 
 ## Public API
@@ -98,25 +108,26 @@ server.tx.send(NetResponse { ... })?;              // send to parent
 
 ## Feature Selection
 
+The `ipc-channel-backend` feature is defined in `ipc/Cargo.toml` and inherited
+transitively by all crates that depend on `ipc`.
+
 ```bash
-# Default (XPC on macOS, requires launchd plists):
+# Default (ipc-channel everywhere — works on all platforms):
 cargo build --release
+cargo run --release
+
+# Mixed: XPC for net/media, ipc-channel for content (macOS only):
+cargo build --release --no-default-features --features media
+# Requires XPC service setup first:
 ./ipc/xpc-services/install.sh $(pwd)/target/release
 launchctl load ~/Library/LaunchAgents/formal-web.net.plist
 launchctl load ~/Library/LaunchAgents/formal-web.media.plist
-launchctl load ~/Library/LaunchAgents/formal-web.content.plist
-cargo run --release
-
-# ipc-channel backend (testing, WPT, verification):
-cargo build --release -p content --features ipc-channel-backend
-cargo build --release -p net --features ipc-channel-backend
-cargo build --release -p media --features ipc-channel-backend
-cargo run --release --features ipc-channel-backend
+cargo run --release --no-default-features --features media
 ```
 
-| Crate | How backend is selected |
-|---|---|
-| All | The `ipc-channel-backend` feature on each crate enables `ipc/ipc-channel-backend`. By default this feature is disabled → native XPC (macOS). Enable it for the ipc-channel transport.|
+| Crate | Default backend | Alternative |
+|---|---|---|
+| All (content, net, media) | ipc-channel (`ipc-channel-backend` feature enabled) | XPC (macOS only, `--no-default-features`)| 
 
 ## Message Types
 
@@ -126,82 +137,83 @@ IPC message types live in `ipc_messages/src/`:
 - `network.rs` — `Request` and `Response` for net-process HTTP fetching
 - `media.rs` — `MediaCommand` and `MediaEvent` for media-process playback
 
-Message serialization uses `serde` + `postcard` on both backends. All shared memory
-was migrated from `IpcSharedMemory` to `Vec<u8>` in message types for cross-backend
-compatibility.
+Serialization uses `serde` + `postcard` on both backends.
+
+## Shared Memory Transport
+
+Bulk data (paint scenes, video frames) is transferred through shared memory regions
+carried alongside each message. On the ipc-channel backend, `HashMap<usize, IpcSharedMemory>`
+is serialized alongside the payload — ipc-channel transfers each `IpcSharedMemory` as a
+Mach port (macOS) or fd (Linux) with zero-copy semantics.
+
+### Font deduplication
+
+`FontTransportSender`/`FontTransportReceiver` avoid re-sending font binary data that
+was already shipped in a previous paint frame. Each font is identified by a unique
+`FontIdentifier`; the sender tracks which fonts have been sent and omits duplicates.
+The receiver caches font data by identifier.
 
 ## XPC Backend — Status
 
-The native XPC backend is now the default on macOS. All three helper processes
-(content, net, media) work correctly with exit code 0.
+The XPC backend is experimental and requires additional setup (launchd plists,
+ad-hoc code signing). It is disabled by default.
 
-### Requirements
+### Requirements (XPC mode only)
 
-1. Build all helper binaries: `cargo build --release`
-2. Install XPC service plists: `./ipc/xpc-services/install.sh $(pwd)/target/release`
-3. Load services: `launchctl load ~/Library/LaunchAgents/formal-web.*.plist`
-4. Run: `cargo run --release` (or `cargo run --release cdp --port 9222` for CDP)
+1. Disable the default feature: `--no-default-features --features media`
+2. Build all helper binaries: `cargo build --release --no-default-features --features media`
+3. Install XPC service plists: `./ipc/xpc-services/install.sh $(pwd)/target/release`
+4. Load services: `launchctl load ~/Library/LaunchAgents/formal-web.net.plist`
+                               `~/Library/LaunchAgents/formal-web.media.plist`
+5. Run: `cargo run --release --no-default-features --features media`
 
 Check `launchctl list | grep formal-web` for exit codes:
 - `0` = clean exit ✅
 - Non-zero = investigate `log show --predicate 'process == "formal-web-*"'`
 
-### Previous issues resolved
+### Known limitations
 
-| Issue | Fix |
-|---|---|
-| Content process crash (SIGTRAP) — hardcoded `features = ["ipc-channel-backend"]` in Cargo.toml | Made `ipc-channel-backend` an opt-in feature; default is XPC |
-| C-side memory leaks in `xpc_wrapper.c` (`malloc` / never freed) | Replaced manual `malloc` with Clang block capture by value |
-| Error events swallowed for client/peer connections (deadlock) | Forward all XPC events (errors + dictionaries) to Rust callbacks |
-| Fat pointer segfault (thin→fat pointer cast) | Double-indirection: `Box<Box<dyn Fn(...)>>` |
-| Double `munmap` on XPC shared memory | `needs_munmap` flag to track ownership |
-| Listener dropped immediately in `run_extension` | Store `_listener` in `ExtensionServer` |
-| Peer not configured before listener callback returns (XPC contract violation) | Configure + resume peer inside listener callback, per Apple docs |
-| Closure context leaked when no invalidation fires | Shared `Arc<Mutex<Option<ContextEntry>>>` between callback and `Drop` |
-| Missing `fw_xpc_cancel` in `XpcConnection::drop` | Call `cancel` before `release` |
-| `Clone` for `XpcConnection` missing `context` field | Clone `Arc`, skip cleanup on clones |
+- Content process cannot use XPC (macOS AMFI rejects ad-hoc-signed embedded
+  XPC services). Content always uses ipc-channel even in mixed mode.
+- Shared memory via `xpc_shmem_create` / `xpc_shmem_map` is not yet wired to
+  the message pipeline.
+- The anonymous XPC endpoint approach (`xpc_connection_create(NULL, queue)` +
+  `xpc_endpoint_create`) was explored for content multi-instance mode but
+  abandoned for the same AMFI reason. The `start_multi_instance`/`run_multi_instance`
+  code was removed in favour of always using ipc-channel for content.
 
-## Broken: Verification & WPT
+### macOS 26 XPC quirks
 
-The verification tracer (`verification::tracer`) and WPT runner (`wpt_runner`) are
-broken after the IPC switch. Both use `TraceSender = IpcSender<LogEntry>` embedded
-in `Command::SetTraceSender`, which fails with:
+Developers debugging the native XPC backend should be aware of these platform
+behaviours observed on macOS 26:
 
-```
-Error in IO: Bogus destination port
-```
+- **Listener events are `XPC_TYPE_CONNECTION` directly**, not dictionaries.
+  The peer connection is the event object itself — use `fw_xpc_peer_from_event()`
+  and never call `xpc_dictionary_get_string` on a connection object (that
+  triggers `_xpc_api_misuse` → SIGTRAP).
+- **Mach cancel events deliver garbage pointers** (e.g., `0x10d8`, `0x1a0c`)
+  after the connection is closed. Rust callbacks must check pointer validity
+  before dereferencing. An `alive` flag in `SharedContext` prevents
+  use-after-free.
+- **`xpc_main` requires the main thread** — it calls `dispatch_main()`
+  internally and never returns. A C wrapper (`fw_xpc_run_service`) exists
+  but is currently unused; the XPC backend uses `listen()` + `resume()`
+  directly on a dedicated dispatch queue instead.
+- **Error events must never be swallowed.** XPC delivers `XPC_TYPE_ERROR`
+  events on connection invalidation. If these are not forwarded to Rust,
+  the parent process deadlocks waiting for a response from a dead helper.
+  The C wrapper and Rust callbacks both forward all event types.
 
-The `IpcSender<LogEntry>` Mach port is invalidated during the bootstrap handshake.
-Likely cause: the ipc-channel `IpcOneShotServer::accept()` transfers Mach port
-rights that the embedded `TraceSender` depends on, and the rights are consumed
-or invalidated during the new `start_extension`/`run_extension` flow.
+## Verification Trace Support
 
-### Symptoms
+The verification tracer (`verification::tracer`) sends `LogEntry` records to a
+`TraceMonitor` via `TraceSender = ipc_channel::ipc::IpcSender<LogEntry>`. The sender
+is embedded in `Command::SetTraceSender(Option<TraceSender>)` and forwarded to the
+content and net processes on startup.
 
-- WPT tests hang or exit with code 1 (runner starts wptserve + WebDriver but
-  tests never complete)
-- `verify-navigation.sh` reports `formal-web exited with a failure status`
-  with many `verification trace send failed` errors
-- `bogus destination port` errors from the content process
-
-### Possible fix
-
-The `TraceSender` in `Command::SetTraceSender(Option<TraceSender>)` is
-serialized through `ipc_channel::ipc::IpcSender<Command>`, which should handle
-`IpcSender<LogEntry>` port transfer natively. The issue might be in how
-`send_command_inner` clones the Command before sending, or the Mach port
-namespace of the child process differs from the parent's.
-
-### To restore
-
-1. Run a simple verification test to reproduce:
-   ```bash
-   target/release/formal-web --verify --headless
-   ```
-2. Check for `bogus destination port` errors in the output
-3. Debug the Mach port transfer in `Command::SetTraceSender` — verify that
-   the `IpcSender<LogEntry>` survives the round-trip through `BootstrapMessage`
-   and into the child's `TLATracer`
+With the ipc-channel backend (default), Mach port rights for the embedded
+`IpcSender<LogEntry>` are transferred natively by ipc-channel's serde
+serialization — no special handling is needed.
 
 See `verification/src/tracer.rs` and `verification/src/monitor.rs` for the
 trace sender/receiver setup.

--- a/ipc/src/backend.rs
+++ b/ipc/src/backend.rs
@@ -6,37 +6,22 @@
 //! use ipc-channel (Unix domain sockets + Mach ports). This works on all
 //! platforms.
 //!
-//! When the feature is disabled, a mixed backend is used:
-//!
-//! | Extension | Endpoint      | Backend      | Transport          |
-//! |-----------|---------------|--------------|--------------------|
-//! | net       | Singleton     | XPC          | launchd Mach service |
-//! | media     | Singleton     | XPC          | launchd Mach service |
-//! | content   | MultiInstance | ipc-channel  | Unix domain socket   |
-//!
-//! Content cannot use embedded XPC services because macOS AMFI rejects
-//! ad-hoc-signed binaries in XPCServices/ (error -423: "The file is adhoc
-//! signed or signed by an unknown certificate chain"). A paid Apple
-//! Developer certificate would be required.
-//!
-//! The ipc-channel module is always compiled so it is available for content
-//! in mixed mode.
+//! When the feature is disabled, only the native XPC backend is available
+//! (macOS only). Only Singleton launchd services (net, media) are supported.
+//! MultiInstance extensions (content) cannot use XPC because macOS AMFI
+//! rejects ad-hoc-signed embedded XPC services (error -423).
 
 use serde::{Serialize, de::DeserializeOwned};
 
 use crate::IpcError;
 use crate::types::{ExtensionClient, ExtensionManifest, ExtensionServer};
 
-// Always compiled — used by content in mixed mode, and all extensions in
-// ipc-channel-backend mode.
+#[cfg(feature = "ipc-channel-backend")]
 mod ipc_channel;
 
 // Only on Apple when NOT using ipc-channel-backend.
 #[cfg(all(not(feature = "ipc-channel-backend"), target_vendor = "apple"))]
 mod xpc;
-
-#[cfg(all(not(feature = "ipc-channel-backend"), target_vendor = "apple"))]
-use crate::types::ExtensionEndpoint;
 
 // No backend available on non-Apple without ipc-channel-backend.
 #[cfg(all(not(feature = "ipc-channel-backend"), not(target_vendor = "apple")))]
@@ -59,9 +44,17 @@ where
     }
     #[cfg(not(feature = "ipc-channel-backend"))]
     {
+        // XPC backend only supports Singleton launchd services (net, media).
+        // Content (MultiInstance) would require embedded XPC, which macOS
+        // AMFI rejects for ad-hoc-signed binaries.
         match manifest.endpoint() {
-            ExtensionEndpoint::Singleton { .. } => xpc::start_extension(manifest),
-            ExtensionEndpoint::MultiInstance { .. } => ipc_channel::start_extension(manifest),
+            crate::types::ExtensionEndpoint::Singleton { .. } => xpc::start_extension(manifest),
+            crate::types::ExtensionEndpoint::MultiInstance { .. } => {
+                unimplemented!(
+                    "XPC backend does not support MultiInstance (content) \
+                     extensions; use --features ipc-channel-backend"
+                )
+            }
         }
     }
 }
@@ -85,11 +78,14 @@ where
     #[cfg(not(feature = "ipc-channel-backend"))]
     {
         match manifest.endpoint() {
-            ExtensionEndpoint::Singleton { .. } => {
+            crate::types::ExtensionEndpoint::Singleton { .. } => {
                 xpc::run_extension(manifest, token, service_name)
             }
-            ExtensionEndpoint::MultiInstance { .. } => {
-                ipc_channel::run_extension(manifest, token, service_name)
+            crate::types::ExtensionEndpoint::MultiInstance { .. } => {
+                unimplemented!(
+                    "XPC backend does not support MultiInstance (content) \
+                     extensions; use --features ipc-channel-backend"
+                )
             }
         }
     }

--- a/ipc/src/backend/ipc_channel.rs
+++ b/ipc/src/backend/ipc_channel.rs
@@ -7,8 +7,7 @@ use std::collections::HashMap;
 
 use crossbeam_channel::unbounded;
 use ipc_channel::ipc::{
-    self as ipc_ipc, IpcOneShotServer, IpcReceiver, IpcSender as IpcChannelSender,
-    IpcSharedMemory,
+    self as ipc_ipc, IpcOneShotServer, IpcReceiver, IpcSender as IpcChannelSender, IpcSharedMemory,
 };
 use ipc_channel::router::ROUTER;
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
@@ -112,15 +111,13 @@ where
     let (parent_to_child_tx, parent_to_child_rx): (
         IpcChannelSender<ChannelMessage<Out>>,
         IpcReceiver<ChannelMessage<Out>>,
-    ) = ipc_ipc::channel().map_err(|error| {
-        IpcError::Transport(format!("failed to create IPC channel: {error}"))
-    })?;
+    ) = ipc_ipc::channel()
+        .map_err(|error| IpcError::Transport(format!("failed to create IPC channel: {error}")))?;
     let (child_to_parent_tx, child_to_parent_rx): (
         IpcChannelSender<ChannelMessage<In>>,
         IpcReceiver<ChannelMessage<In>>,
-    ) = ipc_ipc::channel().map_err(|error| {
-        IpcError::Transport(format!("failed to create IPC channel: {error}"))
-    })?;
+    ) = ipc_ipc::channel()
+        .map_err(|error| IpcError::Transport(format!("failed to create IPC channel: {error}")))?;
 
     log::info!(
         "ipc-channel backend: child connecting to bootstrap token='{}'",

--- a/ipc/src/backend/xpc.rs
+++ b/ipc/src/backend/xpc.rs
@@ -1,29 +1,27 @@
 //! Native XPC backend for the abstract IPC API.
 //!
-//! On the native XPC backend, the helper processes are registered as launchd
-//! XPC services (see `xpc-services/`). The parent connects to the service,
-//! launchd starts the helper process, and the helper creates a listener that
-//! receives the parent's connection.
+//! Only Singleton launchd services (net, media) are supported. Content
+//! (MultiInstance) cannot use XPC because macOS AMFI rejects ad-hoc-signed
+//! embedded XPC services.
 //!
-//! ## Usage
+//! See `xpc-services/README.md` for setup instructions.
 //!
-//! 1. Build & install helper binaries + plists:
-//!    ```
-//!    ./xpc-services/install.sh ./target/release
-//!    launchctl load ~/Library/LaunchAgents/formal-web.net.plist
-//!    launchctl load ~/Library/LaunchAgents/formal-web.media.plist
-//!    launchctl load ~/Library/LaunchAgents/formal-web.content.plist
-//!    ```
-//! 2. Run:
-//!    ```
-//!    cargo run --release
-//!    ```
+//! ## Architecture
+//!
+//! Parent: connects to the launchd-registered XPC service name. launchd
+//! starts the helper process on first connection and delivers the peer.
+//!
+//! Child: creates a listener on the XPC service name. launchd delivers
+//! the parent's connection to the listener callback.
 
 use crossbeam_channel::unbounded;
 use serde::{Serialize, de::DeserializeOwned};
 
 use crate::types::IpcTransport;
 use crate::types::{ExtensionClient, ExtensionEndpoint, ExtensionManifest, ExtensionServer};
+
+// ExtensionEndpoint::MultiInstance is unreachable from the backend dispatch;
+// only Singleton launchd services (net, media) reach this module.
 use crate::{IpcError, IpcIncoming, IpcSender};
 
 use xpc_sys::{XpcConnection, XpcListenerEvent, XpcMessageEvent};
@@ -36,12 +34,10 @@ where
     Out: Serialize + DeserializeOwned + Send + 'static,
     In: Serialize + DeserializeOwned + Send + 'static,
 {
-    let service_name = match manifest.endpoint() {
-        ExtensionEndpoint::Singleton { service_name } => service_name,
-        ExtensionEndpoint::MultiInstance { service_name } => service_name,
+    // Only Singleton (launchd-registered) services reach this module.
+    let ExtensionEndpoint::Singleton { service_name } = manifest.endpoint() else {
+        unreachable!("MultiInstance should be handled before reaching xpc::start_extension")
     };
-
-    let is_multi_instance = matches!(manifest.endpoint(), ExtensionEndpoint::MultiInstance { .. });
 
     let (crossbeam_in_tx, crossbeam_in_rx) = unbounded();
     let handler = move |event| match event {
@@ -69,15 +65,8 @@ where
         }
     };
 
-    let connection = if is_multi_instance {
-        // Embedded XPC service in app bundle's XPCServices/.
-        // Uses xpc_connection_create to bypass launchd and its watchdog.
-        XpcConnection::connect_embedded(service_name, handler)
-    } else {
-        // Global launchd-registered Mach service.
-        XpcConnection::connect(service_name, handler)
-    };
-
+    // Global launchd-registered Mach service.
+    let connection = XpcConnection::connect(service_name, handler);
     connection.resume();
 
     let tx = IpcSender {
@@ -95,12 +84,9 @@ where
 }
 
 // ── run_extension (child side) ──────────────────────────────────────────────
-//
-// Dispatches to `listen()`-based approach for Singleton (launchd) services,
-// and to `xpc_main`-based approach for MultiInstance (embedded XPC) services.
 
 pub fn run_extension<M, Out, In>(
-    _manifest: &M,
+    manifest: &M,
     _token: &str,
     service_name: &str,
 ) -> Result<ExtensionServer<In, Out>, IpcError>
@@ -109,6 +95,11 @@ where
     Out: Serialize + DeserializeOwned + Send + 'static,
     In: Serialize + DeserializeOwned + Send + 'static,
 {
+    // Only Singleton (launchd-registered) services reach this module.
+    let ExtensionEndpoint::Singleton { .. } = manifest.endpoint() else {
+        unreachable!("MultiInstance should be handled before reaching xpc::run_extension")
+    };
+
     run_listen_extension::<Out, In>(service_name)
 }
 

--- a/ipc/src/types.rs
+++ b/ipc/src/types.rs
@@ -70,6 +70,7 @@ pub(crate) type IpcChannelMessage<T> = (T, HashMap<usize, IpcSharedMemory>);
 
 #[derive(Clone)]
 pub(crate) enum IpcTransport<T: Serialize + DeserializeOwned> {
+    #[cfg_attr(not(feature = "ipc-channel-backend"), allow(dead_code))]
     IpcChannel(ipc_channel::ipc::IpcSender<IpcChannelMessage<T>>),
     #[cfg(all(not(feature = "ipc-channel-backend"), target_vendor = "apple"))]
     Xpc {
@@ -187,6 +188,7 @@ impl IpcSharedRegion {
     }
 
     /// Wrap an `IpcSharedMemory` received from the ipc-channel backend.
+    #[cfg_attr(not(feature = "ipc-channel-backend"), allow(dead_code))]
     pub(crate) fn from_ipc_shmem(shmem: ipc_channel::ipc::IpcSharedMemory) -> Self {
         IpcSharedRegion(shmem)
     }

--- a/ipc/xpc-services/README.md
+++ b/ipc/xpc-services/README.md
@@ -3,45 +3,80 @@
 The `ipc/` crate provides an abstract IPC layer with two backends:
 
 - **`ipc-channel-backend`** (default, works reliably on all platforms)
-- **Native XPC** (macOS only, requires additional setup)
+- **Native XPC** (macOS only, experimental, requires additional setup)
+
+The native XPC backend is **disabled by default** — enable it with
+`--no-default-features --features media`.
 
 ## Prerequisites for Native XPC
 
 The native XPC backend requires each helper process to be registered as a launchd
-XPC service. This is currently experimental — the content process has a known
-lifecycle issue (crashes during initialization when launched as an XPC service).
+XPC service. The content process always uses ipc-channel even in XPC mode because
+macOS AMFI rejects ad-hoc-signed embedded XPC services.
 
 ## Setup (for native XPC development)
 
 ```bash
 # 1. Build all binaries
-cargo build --release -p net --bin formal-web-net
-cargo build --release -p media --bin formal-web-media
-cargo build --release -p content --bin formal-web-content
+cargo build --release --no-default-features --features media
 
 # 2. Install XPC service plists with correct binary paths
 ./xpc-services/install.sh $(pwd)/target/release
 
-# 3. Load services into launchd
+# 3. Load services into launchd (content plist is unused — content uses ipc-channel)
 launchctl load ~/Library/LaunchAgents/formal-web.net.plist
 launchctl load ~/Library/LaunchAgents/formal-web.media.plist
-launchctl load ~/Library/LaunchAgents/formal-web.content.plist
 
 # 4. Run with native XPC backend
 cargo run --release --no-default-features --features media
 ```
 
+## Why Content Can't Use XPC
+
+macOS **AMFI (Apple Mobile File Integrity)** rejects ad-hoc-signed binaries in
+embedded XPC services with error:
+
+```
+amfid: not valid: Error Code=-423
+"The file is adhoc signed or signed by an unknown certificate chain"
+```
+
+This happens even with Developer Mode enabled (`developerMode: 1`). Embedded
+XPC services (inside an `.app` bundle's `XPCServices/` directory) require a
+**paid Apple Developer certificate** for code signing — ad-hoc signing is
+insufficient.
+
+### Diagnostic journey
+
+1. **Identifier mismatch**: `launchd: failed lookup: name = com.formal-web.content,
+   error = 3: No such process` — the XPC service bundle identifier was not
+   prefixed with the app's identifier. Fixed by renaming from
+   `com.formal-web.content` to `com.formal-web.app.content`.
+
+2. **SIGTRAP from API misuse**: Child crashed with `_xpc_api_misuse` → SIGTRAP
+   in `xpc_listener_callback` — macOS 26 calls `xpc_dictionary_get_string` on
+   non-dictionary objects (connections). Fixed by adding `xpc_get_type()` checks
+   in both the C wrapper blocks and Rust callbacks.
+
+3. **Garbage pointers from Mach cancel events**: Cancel events delivered with
+   invalid/freed object pointers after connection close. Fixed by:
+   (a) early pointer-range check in Rust callbacks,
+   (b) `alive` flag in `SharedContext`,
+   (c) leaking `SharedContext` to prevent use-after-free.
+
+4. **Final blocker**: AMFI rejection of ad-hoc signed binary. Cannot be
+   worked around without a paid Apple Developer certificate.
+
 ## Known Issues
 
-- Content process crashes with SIGTRAP during XPC service initialization.
-  The ipc-channel backend works reliably.
-- Service plists must be updated whenever binary paths change (e.g., after
-  switching between debug/release builds).
+- Content process cannot use XPC (macOS AMFI rejects ad-hoc-signed embedded
+  XPC services). Content always uses ipc-channel even in mixed mode.
+- Service plists must be updated whenever binary paths change.
 
-## Architecture
+## Architecture (XPC mode)
 
-| Service Name | Type | Binary |
-|---|---|---|
-| `formal-web.net` | Singleton (Application) | `formal-web-net` |
-| `formal-web.media` | Singleton (Application) | `formal-web-media` |
-| `formal-web.content` | MultipleInstances | `formal-web-content` |
+| Service Name | Type | Binary | Backend |
+|---|---|---|---|
+| `formal-web.net` | Singleton (Application) | `formal-web-net` | XPC |
+| `formal-web.media` | Singleton (Application) | `formal-web-media` | XPC |
+| `formal-web.content` | MultipleInstances | `formal-web-content` | ipc-channel (always) |

--- a/ipc_messages/src/content.rs
+++ b/ipc_messages/src/content.rs
@@ -363,10 +363,13 @@ pub struct RegisteredFont {
 
 impl RegisteredFont {
     fn from_font_data(id: FontIdentifier, font_data: &FontData, key: usize) -> (Self, Vec<u8>) {
-        (Self {
-            id,
-            data_shmem_key: key,
-        }, font_data.data.data().to_vec())
+        (
+            Self {
+                id,
+                data_shmem_key: key,
+            },
+            font_data.data.data().to_vec(),
+        )
     }
 
     fn into_font_data_from_bytes(self, data: Vec<u8>) -> FontData {

--- a/media/src/main.rs
+++ b/media/src/main.rs
@@ -226,6 +226,11 @@ pub fn run_media_process_from_args() -> Result<(), String> {
     let ipc_event_tx = server.tx;
     let (crossbeam_event_tx, crossbeam_event_rx) = crossbeam_channel::unbounded::<MediaEvent>();
 
-    run_media_process(server.rx, crossbeam_event_tx, crossbeam_event_rx, ipc_event_tx);
+    run_media_process(
+        server.rx,
+        crossbeam_event_tx,
+        crossbeam_event_rx,
+        ipc_event_tx,
+    );
     Ok(())
 }

--- a/user_agent/src/event_loop.rs
+++ b/user_agent/src/event_loop.rs
@@ -547,12 +547,12 @@ impl EventLoopWorker {
                     frame.viewport_width,
                     frame.viewport_height,
                 ));
-                if let Err(error) = self
-                    .webview_provider_sender
-                    .send(WebviewProviderMessage::PaintFrame {
-                        frame,
-                        shmem_regions: incoming_shmem.clone(),
-                    })
+                if let Err(error) =
+                    self.webview_provider_sender
+                        .send(WebviewProviderMessage::PaintFrame {
+                            frame,
+                            shmem_regions: incoming_shmem.clone(),
+                        })
                 {
                     error!("failed to enqueue webview-provider paint frame: {error}");
                 } else {

--- a/webview/src/lib.rs
+++ b/webview/src/lib.rs
@@ -368,8 +368,7 @@ impl WebviewProvider {
                 composition.embed_sites.len()
             );
         }
-        let recorded_scene =
-            frame.into_recorded_scene(&mut self.font_receiver, shmem_regions)?;
+        let recorded_scene = frame.into_recorded_scene(&mut self.font_receiver, shmem_regions)?;
 
         let state = self.webviews.entry(traversable_id).or_default();
         state.compositor.store_frame(


### PR DESCRIPTION
   ARCHITECTURE.md:
   - Reposition ipc-channel as the default backend (ipc-channel-backend feature is now a default), XPC as experimental/macOS-only fallback
   - Replace stale "Broken: Verification & WPT" section with updated Verification Trace Support (ported rights transfer via ipc-channel)
   - Add Shared Memory Transport section with font deduplication notes
   - Add macOS 26 XPC quirks section (SIGTRAP on type mismatch, garbage pointers from cancel events, xpc_main requirements, error forwarding)
   - Note abandoned anonymous endpoint approach for content multi-instance

   xpc-services/README.md:
   - Add AMFI diagnostic journey (error -423, 4-step debugging history)

   backend.rs:
   - Make `mod ipc_channel` conditional on `ipc-channel-backend` feature
   - Replace mixed-mode dispatch (Singleton→XPC, MultiInstance→ipc_channel) with explicit `unimplemented!()` for MultiInstance in XPC mode

   xpc.rs:
   - Remove unreachable `connect_embedded` and `is_multi_instance` paths
   - Assert Singleton-only entry with `unreachable!()` guards

   types.rs:
   - Suppress dead_code warnings on IpcTransport::IpcChannel and from_ipc_shmem when ipc-channel-backend feature is disabled