### PR TITLE
Modular media

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1366,6 +1366,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
  "bitflags 2.13.0",
+ "block2 0.6.2",
  "objc2 0.6.4",
 ]
 
@@ -3093,6 +3094,11 @@ dependencies = [
  "ipc",
  "ipc_messages",
  "log",
+ "objc2 0.6.4",
+ "objc2-av-foundation",
+ "objc2-core-media",
+ "objc2-core-video",
+ "objc2-foundation 0.3.2",
  "serde",
  "url",
 ]
@@ -3383,7 +3389,7 @@ dependencies = [
  "libc",
  "objc2 0.5.2",
  "objc2-core-data",
- "objc2-core-image",
+ "objc2-core-image 0.2.2",
  "objc2-foundation 0.2.2",
  "objc2-quartz-core 0.2.2",
 ]
@@ -3397,6 +3403,39 @@ dependencies = [
  "bitflags 2.13.0",
  "objc2 0.6.4",
  "objc2-core-graphics",
+ "objc2-foundation 0.3.2",
+]
+
+[[package]]
+name = "objc2-av-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "478ae33fcac9df0a18db8302387c666b8ef08a3e2d62b510ca4fc278a384b6c0"
+dependencies = [
+ "bitflags 2.13.0",
+ "block2 0.6.2",
+ "dispatch2",
+ "objc2 0.6.4",
+ "objc2-avf-audio",
+ "objc2-core-audio-types",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-core-image 0.3.2",
+ "objc2-core-media",
+ "objc2-core-video",
+ "objc2-foundation 0.3.2",
+ "objc2-image-io",
+ "objc2-media-toolbox",
+ "objc2-quartz-core 0.3.2",
+]
+
+[[package]]
+name = "objc2-avf-audio"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13a380031deed8e99db00065c45937da434ca987c034e13b87e4441f9e4090be"
+dependencies = [
+ "objc2 0.6.4",
  "objc2-foundation 0.3.2",
 ]
 
@@ -3422,6 +3461,28 @@ dependencies = [
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-core-audio"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1eebcea8b0dbff5f7c8504f3107c68fc061a3eb44932051c8cf8a68d969c3b2"
+dependencies = [
+ "dispatch2",
+ "objc2 0.6.4",
+ "objc2-core-audio-types",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-core-audio-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a89f2ec274a0cf4a32642b2991e8b351a404d290da87bb6a9a9d8632490bd1c"
+dependencies = [
+ "bitflags 2.13.0",
+ "objc2 0.6.4",
 ]
 
 [[package]]
@@ -3473,6 +3534,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-core-image"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5d563b38d2b97209f8e861173de434bd0214cf020e3423a52624cd1d989f006"
+dependencies = [
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
+]
+
+[[package]]
 name = "objc2-core-location"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3485,6 +3556,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-core-media"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05ec576860167a15dd9fce7fbee7512beb4e31f532159d3482d1f9c6caedf31d"
+dependencies = [
+ "bitflags 2.13.0",
+ "block2 0.6.2",
+ "dispatch2",
+ "objc2 0.6.4",
+ "objc2-core-audio",
+ "objc2-core-audio-types",
+ "objc2-core-foundation",
+ "objc2-core-video",
+]
+
+[[package]]
 name = "objc2-core-text"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3492,6 +3579,21 @@ checksum = "0cde0dfb48d25d2b4862161a4d5fcc0e3c24367869ad306b0c9ec0073bfed92d"
 dependencies = [
  "bitflags 2.13.0",
  "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-core-video"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d425caf1df73233f29fd8a5c3e5edbc30d2d4307870f802d18f00d83dc5141a6"
+dependencies = [
+ "bitflags 2.13.0",
+ "block2 0.6.2",
+ "objc2 0.6.4",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-io-surface",
+ "objc2-metal 0.3.2",
 ]
 
 [[package]]
@@ -3520,8 +3622,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.13.0",
+ "block2 0.6.2",
+ "libc",
  "objc2 0.6.4",
  "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-image-io"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32b0446e98cf4a784cc7a0177715ff317eeaa8463841c616cfc78aa4f953c4ea"
+dependencies = [
+ "objc2 0.6.4",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
 ]
 
 [[package]]
@@ -3545,6 +3660,18 @@ dependencies = [
  "objc2 0.5.2",
  "objc2-app-kit 0.2.2",
  "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-media-toolbox"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd9fdde720df3da7046bb9097811000c1e7ab5cd579fa89d96b27d56781fb30"
+dependencies = [
+ "objc2 0.6.4",
+ "objc2-core-audio-types",
+ "objc2-core-foundation",
+ "objc2-core-media",
 ]
 
 [[package]]
@@ -3618,7 +3745,7 @@ dependencies = [
  "objc2 0.5.2",
  "objc2-cloud-kit",
  "objc2-core-data",
- "objc2-core-image",
+ "objc2-core-image 0.2.2",
  "objc2-core-location",
  "objc2-foundation 0.2.2",
  "objc2-link-presentation",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,12 @@ path = "src/main.rs"
 default = ["media"]
 media = []
 
+# Select the AVFoundation media backend (macOS, no GStreamer required).
+# You must also build the media binary separately:
+#   cargo build --release -p media --bin formal-web-media \
+#       --no-default-features --features backend-avfoundation
+backend-avfoundation = ["media"]
+
 [dependencies]
 automation = { path = "automation" }
 clap = { version = "4.5", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -5,9 +5,16 @@ formal-web is a Rust web-engine prototype in alpha status, with an embedding API
 ## Prerequisites
 
 - **Rust toolchain**: `rustup toolchain install 1.94.0`
-- **GStreamer** (for media): see [gstreamer docs](https://docs.rs/gstreamer/latest/gstreamer/) for platform-specific installation
+- **GStreamer** (for the GStreamer media backend — default):
+  see [gstreamer docs](https://docs.rs/gstreamer/latest/gstreamer/) for
+  platform-specific installation.  On macOS:
+  ```bash
+  brew install gstreamer gst-plugins-base gst-plugins-good gst-plugins-bad gst-plugins-ugly
+  ```
 
 ## Commands
+
+### Default (GStreamer media backend)
 
 ```bash
 # Check all    (type-check every package without producing binaries)
@@ -20,11 +27,36 @@ rustup run 1.94.0 cargo build --release
 rustup run 1.94.0 cargo run --release
 ```
 
-Without media:
+### AVFoundation media backend (macOS, no GStreamer required)
+
+```bash
+# 1. Build the media binary with AVFoundation
+rustup run 1.94.0 cargo build --release -p media --bin formal-web-media \
+  --no-default-features --features backend-avfoundation
+
+# 2. Build the root binary (media features aren't linked into root)
+rustup run 1.94.0 cargo build --release
+
+# 3. Run — the embedder spawns the AVFoundation-based media process
+rustup run 1.94.0 cargo run --release
+```
+
+> `cargo run --release` does **not** rebuild the media binary.  Always run
+> step 1 (`cargo build -p media --bin formal-web-media …`) before step 3.
+
+### Without media (no video playback)
 
 ```bash
 rustup run 1.94.0 cargo build --release --no-default-features
-rustup run 1.94.0 cargo run --release -- --no-default-features
+rustup run 1.94.0 cargo run --release
+```
+
+### Verify which backend is active
+
+```bash
+RUST_LOG=info cargo run --release 2>&1 | grep "creating pipeline"
+# GStreamer:   "[media] creating pipeline id=…"
+# AVFoundation: same prefix, but the media process log also shows "[avf] …"
 ```
 
 ## Project architecture
@@ -36,7 +68,10 @@ The following procesess are used:
 - Main: running the `embedder`, `webview`, and `user_agent` crates. The process is started in `src/main.rs`.
 - Content: running the `content` crate, and started in `user_agent/src/event_loop.rs`, because each process is running what is essentially a window event loop. In the future it will also run dedicated worker event loops. Service workers will likely run in their own process, and for shared worker the issue hasn't been decided yet (it seems there is a move towards isolating them per top-level sites). There is one process per [similar origin window agent](https://html.spec.whatwg.org/#similar-origin-window-agent); this is the only type of process of which there can be more than one.
 - Net: running the `net` crate. That process is owned by the fetch worker in `user_agent/src/fetch.rs`, and the code in the process will essentially be the part of the fetch standard that starts at https://fetch.spec.whatwg.org/#http-network-or-cache-fetch.
-- Media: running the `media` crate, which runs gstreamer, which is started and owned by the media worker in `user_agent/src/media.rs`. This is an optional feature as expalined above under Quick Start.
+- Media: running the `media` crate, started and owned by the media worker in `user_agent/src/media.rs`. The media binary uses one of two backends, selected at compile time via Cargo features:
+  - `backend-gstreamer` (default) — GStreamer pipeline (uridecodebin → videoconvert → appsink). Requires GStreamer libraries at build time.
+  - `backend-avfoundation` — AVFoundation (AVPlayer + AVPlayerItemVideoOutput). macOS only, no external dependencies.
+  See [`media/README.md`](./media/README.md) for backend-specific details.
 
 ## Project structure
 
@@ -45,7 +80,7 @@ The following procesess are used:
 | [`embedder/`](./embedder/README.md) | Application lifecycle, window management, browser chrome, redraw loop |
 | [`user_agent/`](./user_agent/README.md) | Navigables, session history, event loops, timers, fetch workers |
 | [`content/`](./content/README.md) | DOM, HTML algorithms, Boa JS integration, Web IDL bridges |
-| [`media/`](./media/README.md) | GStreamer video decoding pipeline |
+| [`media/`](./media/README.md) | Media pipeline: GStreamer or AVFoundation backend, frame extraction, IPC |
 | [`net/`](./net/README.md) | HTTP and file fetch |
 | [`webview/`](./webview/README.md) | Embedder-facing compositor and redraw API |
 | [`automation/`](./automation/README.md) | WebDriver and CDP wire-protocol servers |

--- a/README.md
+++ b/README.md
@@ -30,19 +30,25 @@ rustup run 1.94.0 cargo run --release
 ### AVFoundation media backend (macOS, no GStreamer required)
 
 ```bash
-# 1. Build the media binary with AVFoundation
+# 1. Build the media binary (separate step — `cargo run` won't do this)
 rustup run 1.94.0 cargo build --release -p media --bin formal-web-media \
   --no-default-features --features backend-avfoundation
 
-# 2. Build the root binary (media features aren't linked into root)
-rustup run 1.94.0 cargo build --release
-
-# 3. Run — the embedder spawns the AVFoundation-based media process
+# 2. Run — the embedder spawns the AVFoundation-based media process
 rustup run 1.94.0 cargo run --release
 ```
 
-> `cargo run --release` does **not** rebuild the media binary.  Always run
-> step 1 (`cargo build -p media --bin formal-web-media …`) before step 3.
+> `cargo run --release` builds only the root `formal-web` binary — it does
+> **not** rebuild the `formal-web-media` binary.  Always run step 1 before
+> step 2.  The root crate's `backend-avfoundation` feature (which implies
+> `media`) is provided for symmetry but is not strictly required since
+> `media` is enabled by default anyway.
+
+To switch back to GStreamer, just rebuild the media binary:
+```bash
+cargo build --release -p media --bin formal-web-media
+# then `cargo run --release` as usual
+```
 
 ### Without media (no video playback)
 

--- a/artifacts/media-test.html
+++ b/artifacts/media-test.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Media Backend Test</title>
+<style>
+  body { background: #1a1a2e; color: #e0e0e0; font-family: system-ui; margin: 2rem; }
+  h1 { color: #00d4ff; }
+  #status { margin: 1rem 0; padding: 0.5rem; background: #16213e; border-radius: 0.4rem; }
+  video { display: block; width: 100%; max-width: 640px; margin: 1rem 0; }
+  .log { margin: 0.2rem 0; padding: 0.2rem 0.4rem; font-family: monospace; font-size: 0.85rem; }
+  .error { color: #ff6b6b; }
+  .info { color: #69db7c; }
+</style>
+</head>
+<body>
+<h1>Media Backend Test</h1>
+<div id="status">Loading...</div>
+<video id="test-video" controls autoplay muted playsinline></video>
+<div id="log"></div>
+
+<script>
+  const status = document.getElementById('status');
+  const video = document.getElementById('test-video');
+  const logDiv = document.getElementById('log');
+
+  function log(msg, type = 'info') {
+    const el = document.createElement('div');
+    el.className = `log ${type}`;
+    el.textContent = `[${new Date().toISOString().split('T')[1].split('.')[0]}] ${msg}`;
+    logDiv.appendChild(el);
+  }
+
+  // Try loading the demo video
+  // document.baseURI may be null in some contexts, so derive from location
+  const baseUrl = document.baseURI || window.location.href;
+  const videoUrl = baseUrl.replace(/\/[^/]*$/, '/IMG_7716.mov');
+  video.src = videoUrl;
+
+  video.onerror = function() {
+    const errorMsg = video.error ? video.error.message : 'Unknown error';
+    status.textContent = 'Video error';
+    status.style.color = '#ff6b6b';
+    log('Video error: ' + errorMsg, 'error');
+  };
+
+  video.oncanplay = function() {
+    status.textContent = 'Video can play (pipeline ready)';
+    status.style.color = '#69db7c';
+    log('Video can play - pipeline created and loaded');
+    log('Video dimensions: ' + video.videoWidth + 'x' + video.videoHeight);
+    log('Duration: ' + video.duration + 's');
+  };
+
+  video.onplaying = function() {
+    status.textContent = '▶ Playing';
+    status.style.color = '#69db7c';
+    log('Video is now playing');
+    log('Current time: ' + video.currentTime + 's');
+  };
+
+  video.onwaiting = function() {
+    log('Video waiting for data...', 'info');
+  };
+
+  video.onended = function() {
+    status.textContent = '✓ Ended';
+    status.style.color = '#ffd43b';
+    log('Video playback ended (EOS received)', 'info');
+  };
+
+  video.onloadedmetadata = function() {
+    log('Metadata loaded - duration: ' + video.duration + 's');
+    log('Resolution: ' + video.videoWidth + 'x' + video.videoHeight);
+  };
+
+  log('Requested video URL: ' + videoUrl);
+  log('Testing GStreamer backend (default feature)', 'info');
+</script>
+</body>
+</html>

--- a/media/Cargo.toml
+++ b/media/Cargo.toml
@@ -6,19 +6,25 @@ publish = false
 autobins = false
 
 [features]
-default = []
+default = ["backend-gstreamer"]
+backend-gstreamer = ["dep:gstreamer", "dep:gstreamer-app"]
+backend-avfoundation = [
+    "dep:objc2",
+    "dep:objc2-foundation",
+    "dep:objc2-av-foundation",
+    "dep:objc2-core-media",
+    "dep:objc2-core-video",
+]
 ipc-channel-backend = ["ipc/ipc-channel-backend"]
 
 [lib]
-path = "src/main.rs"
+path = "src/lib.rs"
 
 [[bin]]
 name = "formal-web-media"
 path = "src/bin/media_process.rs"
 
 [dependencies]
-gstreamer = { version = "0.23", features = ["v1_22"] }
-gstreamer-app = "0.23"
 ipc = { path = "../ipc" }
 ipc_messages = { path = "../ipc_messages" }
 serde = { version = "1", features = ["derive"] }
@@ -26,3 +32,10 @@ log = "0.4"
 env_logger = "0.11"
 url = "2"
 crossbeam-channel = "0.5"
+gstreamer = { version = "0.23", features = ["v1_22"], optional = true }
+gstreamer-app = { version = "0.23", optional = true }
+objc2 = { version = "0.6.4", optional = true }
+objc2-foundation = { version = "0.3.2", optional = true }
+objc2-av-foundation = { version = "0.3.2", optional = true, features = ["objc2-core-media"] }
+objc2-core-media = { version = "0.3.2", optional = true }
+objc2-core-video = { version = "0.3.2", optional = true }

--- a/media/README.md
+++ b/media/README.md
@@ -1,79 +1,259 @@
 # Media crate
 
-Owns the `formal-web-media` process and all GStreamer pipeline state. The process is
+Owns the `formal-web-media` process and all media pipeline state. The process is
 spawned lazily by the user agent on the first media request.
+
+The media process is built around a **backend-agnostic** core: the generic
+`run_media_process` function works with any `MediaBackend` implementation,
+selected at compile time via Cargo features.
 
 ## Architecture
 
 ```
-user agent (MediaHandler)  ──IPC──▶  media process (run_media_process)
+user agent (MediaHandler)  ──IPC──▶  media process (run_media_process<B: MediaBackend>)
                                            │
-                                           ├─ uridecodebin
-                                           │   └─ videoconvert
-                                           │       └─ appsink ◀── IpcSender<MediaEvent>
+                                           ├─ B::Pipeline produces VideoFrame
+                                           │   └─ crossbeam channel ──▶ frame forwarding
                                            │
                                            └─ VideoFrame (IpcSharedMemory) ──▶ compositor
 ```
 
-- `src/main.rs` — media process main loop: drain IPC commands, poll GStreamer bus, yield.
-- `src/managed_pipeline.rs` — single-pipeline wrapper: uridecodebin → videoconvert → appsink.
-- `src/bin/media_process.rs` — binary entrypoint, calls `media::run_media_process_from_args()`.
+## Quick Start
 
-## GStreamer Rust API lessons (v0.23)
+### GStreamer backend (default)
 
-The `gstreamer` 0.23 API (GStreamer 1.28.x) uses extension traits extensively.
-Methods are not available directly on structs — they come from prelude traits.
+```bash
+# Build everything
+cargo build --release
 
-### Required imports
+# Run in windowed mode
+cargo run --release
+```
+
+### AVFoundation backend (macOS)
+
+```bash
+# Build the media binary with AVFoundation
+cargo build --release -p media --bin formal-web-media \
+  --no-default-features --features backend-avfoundation
+
+# Run (uses the AVFoundation media binary)
+cargo run --release
+```
+
+> **Note:** `cargo run --release` does NOT rebuild the media binary. Build it
+> separately with `--features backend-avfoundation` first.
+
+### Verify which backend is active
+
+```bash
+RUST_LOG=info cargo run --release 2>&1 | grep "creating pipeline"
+# GStreamer: no "[avf]" prefix
+# AVFoundation: "[avf] p0: ready"
+```
+
+## Module layout
+
+```
+media/
+├── Cargo.toml
+├── src/
+│   ├── lib.rs                       # run_media_process<B>, run_media_process_from_args
+│   ├── backend/
+│   │   ├── mod.rs                   # MediaBackend + PipelineHandle traits, BackendEvent enum
+│   │   ├── gstreamer/
+│   │   │   ├── mod.rs               # GStreamerBackend impl
+│   │   │   └── pipeline.rs          # GstPipeline (uridecodebin → videoconvert → appsink)
+│   │   └── avfoundation/
+│   │       ├── mod.rs               # AvfBackend impl
+│   │       └── pipeline.rs          # AvfPipeline (AVPlayer + AVPlayerItemVideoOutput)
+│   └── bin/
+│       └── media_process.rs         # binary entrypoint
+```
+
+## Backend traits
+
+### `BackendEvent`
+
+A backend-agnostic event type produced by the backend's notification mechanism
+(GStreamer bus, AVFoundation KVO/notifications) and consumed by the generic
+dispatch loop.
+
+```rust
+pub enum BackendEvent {
+    Eos { pipeline_id: MediaPipelineId },
+    Error { pipeline_id: MediaPipelineId, message: String },
+    DurationChanged { pipeline_id: MediaPipelineId, duration_secs: f64 },
+}
+```
+
+### `PipelineHandle`
+
+Represents one running media pipeline. Each backend provides its own concrete type.
+
+```rust
+pub trait PipelineHandle: Send + 'static {
+    fn play(&self) -> Result<(), String>;
+    fn pause(&self) -> Result<(), String>;
+    fn seek(&self, position_secs: f64) -> Result<(), String>;
+    fn destroy(self) -> Result<(), String>;
+}
+```
+
+### `MediaBackend`
+
+Factory and event source.
+
+```rust
+pub trait MediaBackend: Send + 'static {
+    type Pipeline: PipelineHandle;
+    fn init() -> Result<Self, String>;
+    fn create_pipeline(&mut self, id: MediaPipelineId, url: String,
+                       frame_tx: Sender<MediaEvent>) -> Result<Self::Pipeline, String>;
+    fn event_receiver(&self) -> Receiver<BackendEvent>;
+}
+```
+
+## Cargo Features
+
+```toml
+[features]
+default = ["backend-gstreamer"]
+backend-gstreamer    = ["dep:gstreamer", "dep:gstreamer-app"]
+backend-avfoundation = [
+    "dep:objc2",
+    "dep:objc2-foundation",
+    "dep:objc2-av-foundation",
+    "dep:objc2-core-media",
+    "dep:objc2-core-video",
+]
+```
+
+A compile-time guard in `backend/mod.rs` ensures exactly one backend is active.
+
+## GStreamer backend
+
+### Pipeline topology
+
+```
+uridecodebin ──▶ videoconvert ──▶ appsink (format=RGBA)
+```
+
+- `uridecodebin` dynamically creates a video pad when it detects a video stream.
+- `videoconvert` converts to a format compatible with the appsink caps.
+- `appsink` is configured with caps `video/x-raw,format=RGBA` and a
+  `new_sample` callback that fires on the GStreamer streaming thread.
+- Bus messages (EOS, error, duration-changed) are converted to `BackendEvent`
+  inside a sync handler and forwarded on a crossbeam channel.
+
+### Frame extraction (push model)
+
+The `new_sample` callback fires for every decoded frame. This is a push model —
+GStreamer calls us when a frame is ready. Compare with AVFoundation (poll model).
+
+### Required imports (GStreamer 0.23 / 1.28)
 
 ```rust
 use gstreamer as gst;
-use gstreamer::prelude::*;           // ElementExt, GstBinExtManual, ElementExtManual
+use gstreamer::prelude::*;
 use gstreamer_app as gst_app;
-use gstreamer_app::prelude::*;       // AppSinkCallbacks, etc.
+use gstreamer_app::prelude::*;
 ```
 
-### Key API changes from earlier versions
+### Key API patterns
 
 | Concept | v0.23 API |
 |---|---|
-| `ElementFactory::make(name)` | Returns `ElementBuilder`, call `.build()` to get `Result<Element, BoolError>` |
-| Object properties | `element.set_property_from_str("name", "value")` or the typed `element.set_property("name", &value)` |
-| `set_state(state)` | On `ElementExt` trait, returns `Result<StateChangeSuccess, BoolError>` |
-| `query_duration::<ClockTime>()` | On `ElementExtManual` trait, returns `Option<ClockTime>` |
-| `add_many(&[elements])` | On `GstBinExtManual` trait (Bin, Pipeline), returns `Result<(), BoolError>` |
-| `dynamic_cast::<T>()` | On `Cast` trait, returns `Result<T, Upcast>` |
+| `ElementFactory::make(name)` | Returns `ElementBuilder`, call `.build()` |
+| Object properties | `element.set_property_from_str("name", "value")` |
+| `set_state(state)` | Returns `Result<StateChangeSuccess, BoolError>` |
+| `query_duration::<ClockTime>()` | On `ElementExtManual` trait |
+| `add_many(&[elements])` | On `GstBinExtManual` trait |
+| `dynamic_cast::<T>()` | On `Cast` trait |
 | `connect_pad_added()` | On `ElementExt` trait |
-| `pipeline.bus()` | On `ElementExt` trait, returns `Option<Bus>` |
 
-### `set_property` vs `set_property_from_str`
+## AVFoundation backend
 
-For string properties like URIs, use `set_property_from_str`. For typed properties
-(e.g. caps), use `set_property` with the typed value.
+### Pipeline topology
 
-### `seek_simple`
-
-Available on `ElementExt` trait. Signature:
-```rust
-fn seek_simple(&self, flags: SeekFlags, seek_pos: impl Into<Option<ClockTime>>) -> Result<(), BoolError>
+```
+AVPlayer ──▶ AVPlayerItem ──▶ AVPlayerItemVideoOutput ──▶ poll loop
 ```
 
-### Error types
+- `AVPlayer` created via `playerWithURL:` (implicitly creates an `AVPlayerItem`).
+- `AVPlayerItemVideoOutput` is added to the item to extract raw pixel buffers.
+- `suppressesPlayerRendering` is set to `true` — we handle display ourselves.
+- A polling loop runs at ~33 ms intervals using `try_recv` + `NSRunLoop` drain.
+- Frame data is converted from `CVPixelBuffer` to packed `Vec<u8>` (row-padding
+  stripped) and sent as `MediaEvent::Frame(VideoFrame)`.
 
-GStreamer operations use `glib::BoolError` (aliased as `gst::BoolError`). The standard
-pattern is `.map_err(|error| format!("...: {error}"))?`.
+### Threading model
 
-### Module structure
+All AVFoundation objects are `MainThreadOnly` (enforced by `objc2`'s
+`MainThreadMarker`). The pipeline runs on a dedicated background thread
+("formal-web-avf-worker") with an unsafely-obtained marker. This is safe
+because all AVPlayer/AVPlayerItem access is serialized on this single thread
+via the command queue.
 
-- All types accessed as `gst::Pipeline`, `gst::Element`, etc.
-- Bus messages use `gst::MessageView` variants.
-- AppSink callbacks use `gst_app::AppSinkCallbacks::builder().new_sample(...).build()`.
-- `IpcSharedMemory::from_bytes(slice)` copies the frame data for IPC transport.
+### Frame extraction (poll model)
+
+Unlike GStreamer's push model, `AVPlayerItemVideoOutput` requires polling:
+
+```
+loop {
+    // 1. Convert Mach host time to item timeline
+    let host_ticks = CVGetCurrentHostTime();
+    let freq = CVGetHostClockFrequency();
+    let host_secs = host_ticks as f64 / freq;
+    let item_time = video_output.itemTimeForHostTime(host_secs);
+
+    // 2. Check for new pixel buffer at that time
+    if video_output.hasNewPixelBufferForItemTime(item_time) {
+        let pixel_buf = video_output.copyPixelBufferForItemTime(…);
+        // 3. Convert CVPixelBuffer → VideoFrame
+    }
+
+    // 4. Drain the run loop so AVFoundation's internal timing advances
+    NSRunLoop::currentRunLoop().runUntilDate(…);
+
+    // 5. Process any pending commands (non-blocking)
+    match cmd_rx.try_recv() { … }
+}
+```
+
+### Common pitfalls
+
+| Pitfall | Symptom | Fix |
+|---|---|---|
+| Using `currentTime()` instead of `itemTimeForHostTime` | Only first frame ever delivered; repeated calls with same timestamp | Use `CVGetCurrentHostTime()` → `itemTimeForHostTime` |
+| No run loop drain | `hasNewPixelBufferForItemTime` always returns `false` | `NSRunLoop::currentRunLoop().runUntilDate()` each iteration |
+| Using unix wall clock for host time | Item time doesn't match video timeline | Use `CVGetCurrentHostTime()` divided by `CVGetHostClockFrequency()` |
+| Reading duration before asset loads | `kCMTimeIndefinite`, `seconds()` returns `NaN` | Poll `item.status() == ReadyToPlay` first |
+| Creating AVPlayer off main thread without marker | Compile error (missing `MainThreadMarker`) | Use `unsafe { MainThreadMarker::new_unchecked() }` on the dedicated thread |
+
+### Future improvements
+
+- Replace the polling loop with `CVDisplayLink` for vsync-aligned callbacks
+  (lower CPU usage, better frame timing).
+- Add `AVPlayerItemDidPlayToEndTimeNotification` observer for EOS events.
+- Add `AVPlayerItemFailedToPlayToEndTimeNotification` observer for error events.
+- Add KVO on `AVPlayerItem.status` → `ReadyToPlay` for duration reporting.
+- Request `kCVPixelFormatType_32BGRA` via pixel-buffer-attributes dictionary
+  to guarantee the compositor's preferred pixel format.
+
+## What does NOT change
+
+- `MediaCommand` / `MediaEvent` / `MediaPipelineId` / `VideoFrame` in `ipc_messages::media`.
+- The frame forwarding loop (crossbeam → shmem mapping → IPC send).
+- The crossbeam `select!` loop structure in `run_media_process`.
+- The IPC bootstrap in `run_media_process_from_args`.
 
 ## Non-goals (initial cut)
 
-- **Audio output** — GStreamer decodes audio but it's not yet exposed to the system.
+- **Audio output** — Both backends decode audio but it's not yet exposed to the system.
 - **Zero-copy GPU path** — Future IOSurface/DMA-BUF work.
-- **Seek optimization** — Initial `seek_simple` is fine.
+- **Seek optimization** — Initial single-keyframe seek is fine.
 - **Live streams** — Not tested.
 - **Text tracks** — Not implemented.
+- **AVFoundation notifications** — EOS, error, and duration-changed back-events
+  are not yet wired. Frame delivery and play/pause/seek/destroy work in full.

--- a/media/README.md
+++ b/media/README.md
@@ -30,26 +30,23 @@ cargo build --release
 cargo run --release
 ```
 
-### AVFoundation backend (macOS)
+### AVFoundation backend (macOS only, NOT WORKING)
 
 ```bash
-# Build the media binary with AVFoundation
+# Build the media binary
 cargo build --release -p media --bin formal-web-media \
   --no-default-features --features backend-avfoundation
 
-# Run (uses the AVFoundation media binary)
+# Run
 cargo run --release
 ```
+Currently does not deliver frames (always returns `AVPlayerItemStatusUnknown`).
 
-> **Note:** `cargo run --release` does NOT rebuild the media binary. Build it
-> separately with `--features backend-avfoundation` first.
-
-### Verify which backend is active
+### Without media (no video playback)
 
 ```bash
-RUST_LOG=info cargo run --release 2>&1 | grep "creating pipeline"
-# GStreamer: no "[avf]" prefix
-# AVFoundation: "[avf] p0: ready"
+cargo build --release --no-default-features
+cargo run --release
 ```
 
 ## Module layout
@@ -66,7 +63,15 @@ media/
 │   │   │   └── pipeline.rs          # GstPipeline (uridecodebin → videoconvert → appsink)
 │   │   └── avfoundation/
 │   │       ├── mod.rs               # AvfBackend impl
-│   │       └── pipeline.rs          # AvfPipeline (AVPlayer + AVPlayerItemVideoOutput)
+│   │       ├── pipeline.rs          # AvfPipeline (AVPlayer + AVPlayerItemVideoOutput)
+│   │       └── av_sys/              # Safe wrappers around AVFoundation FFI
+│   │           ├── mod.rs
+│   │           ├── player.rs        # AvPlayer (wraps AVPlayer)
+│   │           ├── item.rs          # AvPlayerItem (wraps AVPlayerItem)
+│   │           ├── video_output.rs  # AvVideoOutput (wraps AVPlayerItemVideoOutput)
+│   │           ├── pixel_buffer.rs  # PixelBufferLock, pixel_buffer_to_frame
+│   │           ├── time.rs          # host_time_seconds()
+│   │           └── url.rs           # url_from_string()
 │   └── bin/
 │       └── media_process.rs         # binary entrypoint
 ```
@@ -149,7 +154,8 @@ uridecodebin ──▶ videoconvert ──▶ appsink (format=RGBA)
 ### Frame extraction (push model)
 
 The `new_sample` callback fires for every decoded frame. This is a push model —
-GStreamer calls us when a frame is ready. Compare with AVFoundation (poll model).
+GStreamer calls us when a frame is ready. No polling, run loop, or timing
+infrastructure required.
 
 ### Required imports (GStreamer 0.23 / 1.28)
 
@@ -160,19 +166,7 @@ use gstreamer_app as gst_app;
 use gstreamer_app::prelude::*;
 ```
 
-### Key API patterns
-
-| Concept | v0.23 API |
-|---|---|
-| `ElementFactory::make(name)` | Returns `ElementBuilder`, call `.build()` |
-| Object properties | `element.set_property_from_str("name", "value")` |
-| `set_state(state)` | Returns `Result<StateChangeSuccess, BoolError>` |
-| `query_duration::<ClockTime>()` | On `ElementExtManual` trait |
-| `add_many(&[elements])` | On `GstBinExtManual` trait |
-| `dynamic_cast::<T>()` | On `Cast` trait |
-| `connect_pad_added()` | On `ElementExt` trait |
-
-## AVFoundation backend
+## AVFoundation backend — current state
 
 ### Pipeline topology
 
@@ -180,68 +174,96 @@ use gstreamer_app::prelude::*;
 AVPlayer ──▶ AVPlayerItem ──▶ AVPlayerItemVideoOutput ──▶ poll loop
 ```
 
-- `AVPlayer` created via `playerWithURL:` (implicitly creates an `AVPlayerItem`).
-- `AVPlayerItemVideoOutput` is added to the item to extract raw pixel buffers.
-- `suppressesPlayerRendering` is set to `true` — we handle display ourselves.
-- A polling loop runs at ~33 ms intervals using `try_recv` + `NSRunLoop` drain.
-- Frame data is converted from `CVPixelBuffer` to packed `Vec<u8>` (row-padding
-  stripped) and sent as `MediaEvent::Frame(VideoFrame)`.
-
-### Threading model
-
-All AVFoundation objects are `MainThreadOnly` (enforced by `objc2`'s
-`MainThreadMarker`). The pipeline runs on a dedicated background thread
-("formal-web-avf-worker") with an unsafely-obtained marker. This is safe
-because all AVPlayer/AVPlayerItem access is serialized on this single thread
-via the command queue.
-
 ### Frame extraction (poll model)
-
-Unlike GStreamer's push model, `AVPlayerItemVideoOutput` requires polling:
 
 ```
 loop {
-    // 1. Convert Mach host time to item timeline
-    let host_ticks = CVGetCurrentHostTime();
-    let freq = CVGetHostClockFrequency();
-    let host_secs = host_ticks as f64 / freq;
-    let item_time = video_output.itemTimeForHostTime(host_secs);
-
-    // 2. Check for new pixel buffer at that time
-    if video_output.hasNewPixelBufferForItemTime(item_time) {
-        let pixel_buf = video_output.copyPixelBufferForItemTime(…);
-        // 3. Convert CVPixelBuffer → VideoFrame
-    }
-
-    // 4. Drain the run loop so AVFoundation's internal timing advances
-    NSRunLoop::currentRunLoop().runUntilDate(…);
-
-    // 5. Process any pending commands (non-blocking)
-    match cmd_rx.try_recv() { … }
+    NSRunLoop::currentRunLoop().runUntilDate(…33ms…);
+    drain commands via try_recv;
+    check item status;
+    poll video_output.hasNewPixelBufferForItemTime(…);
+    drain more commands;
 }
 ```
 
-### Common pitfalls
+### Status: NOT WORKING — always `AVPlayerItemStatusUnknown`
+
+The AVFoundation backend creates the pipeline and play() is called, but
+`AVPlayerItem.status` is always `Unknown` (0) and never transitions to
+`ReadyToPlay` (1). No frames are ever extracted.
+
+#### Symptoms
+
+```
+[avf] p0: status=0     ← repeated forever, never becomes 1
+```
+
+#### Root cause analysis
+
+`NSRunLoop::runUntilDate()` on a bare background thread with no input
+sources returns **immediately** instead of blocking. AVFoundation's URL
+loading machinery relies on the run loop being serviced — when it isn't,
+the `AVPlayerItem` never loads its media, so it never becomes
+`ReadyToPlay`.
+
+The original fix (adding a `recv_timeout`-based sleep) is the pacing
+mechanism, but the first 33 ms loop iterations happen before any run
+loop time is given to AVFoundation. By the time `runUntilDate` runs,
+the item has been given <1 ms of cumulative run loop time from the very
+first drain call, which is insufficient to even begin URL loading.
+
+#### Attempted fixes (all failed)
+
+| Attempt | What changed | Result |
+|---|---|---|
+| 1. `recv_timeout` only, no run loop drain | Removed `runUntilDate` entirely | Status always 0, no change |
+| 2. `try_recv` + `runUntilDate(8ms)` | Run loop 8ms then try_recv | 100% CPU (run loop returned instantly) |
+| 3. `recv_timeout(33ms)` first, then `runUntilDate(8ms)` | Two sequential sleeps totalling 41ms | Status always 0, AVFoundation starved |
+| 4. `runUntilDate(33ms)` + `try_recv` (current) | Run loop owns full cadence | Status always 0 — run loop still returns instantly |
+| 5. Create `AVPlayer` on main thread before `spawn` | Pipeline.init() uses `MainThreadMarker` | `AvPlayer` is `!Send`, can't move into closure |
+
+#### Why NSRunLoop returns immediately on background threads
+
+`NSRunLoop` has two modes:
+- **With sources/timers**: blocks until the next timer fire or input source
+  event, up to the specified timeout.
+- **Without sources/timers**: returns immediately, regardless of the timeout.
+
+A freshly-created background thread has no automatic run loop sources.
+`AVFoundation` does NOT automatically register its URL loading with a
+background thread's run loop — it registers with the **main thread's**
+run loop (or a thread that the `AVPlayer`/`AVPlayerItem` was created on).
+
+Hypothesis: `AVPlayer::playerWithURL:` registers URL loading callbacks
+on the creating thread's run loop. If that thread never has its run loop
+serviced, the callbacks never fire.
+
+#### What would be needed to fix
+
+1. **Run the AVFoundation worker on the main thread** — swap the generic
+   select loop to a background thread and keep the main thread for
+   `NSRunLoop` + AVFoundation operations. This requires restructuring
+   `run_media_process` or having the backend own its own threading.
+
+2. **Or: create a `CFRunLoopTimer` or `dispatch_source` on the worker
+   thread** so `runUntilDate` actually has something to wait on. This
+   would keep run loop occupied and let AVFoundation callbacks fire.
+
+3. **Or: use `dispatch_async` to the main queue** for all AVFoundation
+   operations, keeping the worker thread purely as a command router.
+
+Option 1 is the most architecturally sound but requires non-trivial
+refactoring of the generic run loop.
+
+### Common pitfalls (when it does work)
 
 | Pitfall | Symptom | Fix |
 |---|---|---|
-| Using `currentTime()` instead of `itemTimeForHostTime` | Only first frame ever delivered; repeated calls with same timestamp | Use `CVGetCurrentHostTime()` → `itemTimeForHostTime` |
-| No run loop drain | `hasNewPixelBufferForItemTime` always returns `false` | `NSRunLoop::currentRunLoop().runUntilDate()` each iteration |
-| Using unix wall clock for host time | Item time doesn't match video timeline | Use `CVGetCurrentHostTime()` divided by `CVGetHostClockFrequency()` |
+| Using `currentTime()` instead of `itemTimeForHostTime` | Only first frame ever delivered | Use `CVGetCurrentHostTime()` → `itemTimeForHostTime` |
+| Using unix wall clock for host time | Item time doesn't match video timeline | Use `CVGetCurrentHostTime()` / `CVGetHostClockFrequency()` |
 | Reading duration before asset loads | `kCMTimeIndefinite`, `seconds()` returns `NaN` | Poll `item.status() == ReadyToPlay` first |
-| Creating AVPlayer off main thread without marker | Compile error (missing `MainThreadMarker`) | Use `unsafe { MainThreadMarker::new_unchecked() }` on the dedicated thread |
 
-### Future improvements
-
-- Replace the polling loop with `CVDisplayLink` for vsync-aligned callbacks
-  (lower CPU usage, better frame timing).
-- Add `AVPlayerItemDidPlayToEndTimeNotification` observer for EOS events.
-- Add `AVPlayerItemFailedToPlayToEndTimeNotification` observer for error events.
-- Add KVO on `AVPlayerItem.status` → `ReadyToPlay` for duration reporting.
-- Request `kCVPixelFormatType_32BGRA` via pixel-buffer-attributes dictionary
-  to guarantee the compositor's preferred pixel format.
-
-## What does NOT change
+### What does NOT change
 
 - `MediaCommand` / `MediaEvent` / `MediaPipelineId` / `VideoFrame` in `ipc_messages::media`.
 - The frame forwarding loop (crossbeam → shmem mapping → IPC send).
@@ -255,5 +277,3 @@ loop {
 - **Seek optimization** — Initial single-keyframe seek is fine.
 - **Live streams** — Not tested.
 - **Text tracks** — Not implemented.
-- **AVFoundation notifications** — EOS, error, and duration-changed back-events
-  are not yet wired. Frame delivery and play/pause/seek/destroy work in full.

--- a/media/README.md
+++ b/media/README.md
@@ -30,7 +30,7 @@ cargo build --release
 cargo run --release
 ```
 
-### AVFoundation backend (macOS only, NOT WORKING)
+### AVFoundation backend (macOS only)
 
 ```bash
 # Build the media binary
@@ -40,7 +40,9 @@ cargo build --release -p media --bin formal-web-media \
 # Run
 cargo run --release
 ```
-Currently does not deliver frames (always returns `AVPlayerItemStatusUnknown`).
+
+> `cargo run --release` does **not** rebuild the media binary.  Always build
+> the media binary explicitly with `--features backend-avfoundation` first.
 
 ### Without media (no video playback)
 
@@ -166,102 +168,82 @@ use gstreamer_app as gst_app;
 use gstreamer_app::prelude::*;
 ```
 
-## AVFoundation backend — current state
+## AVFoundation backend
 
 ### Pipeline topology
 
 ```
-AVPlayer ──▶ AVPlayerItem ──▶ AVPlayerItemVideoOutput ──▶ poll loop
+AVPlayer ──▶ AVPlayerItem ──▶ AVPlayerItemVideoOutput ──▶ sample() poll loop
 ```
 
-### Frame extraction (poll model)
+The pipeline runs **on the select-loop thread** (the main thread of the
+media process).  No background thread is used.
 
-```
+### Frame extraction
+
+Frame polling happens inside `PipelineHandle::sample()`, which is called
+at ≈120 Hz via a `crossbeam_channel::tick(8ms)` timer arm in the generic
+`select!` loop:
+
+```rust
+// lib.rs: the select loop drives sampling independently of message traffic
+let sample_tick = crossbeam_channel::tick(Duration::from_millis(8));
+
 loop {
-    NSRunLoop::currentRunLoop().runUntilDate(…33ms…);
-    drain commands via try_recv;
-    check item status;
-    poll video_output.hasNewPixelBufferForItemTime(…);
-    drain more commands;
+    crossbeam_channel::select! {
+        recv(cmd_rx) -> cmd => { ... },
+        recv(backend_event_rx) -> event => { ... },
+        recv(sample_tick) -> _ => {
+            for pipeline in pipelines.values() {
+                pipeline.sample();
+            }
+        },
+    }
 }
 ```
 
-### Status: NOT WORKING — always `AVPlayerItemStatusUnknown`
+`sample()` does:
+1. **Drain the run loop** via `NSRunLoop::currentRunLoop().runUntilDate(8ms)`
+   — this lets AVFoundation service URL loading, KVO, and video output
+   timing.
+2. **Check item status** (once) — wait for `AVPlayerItemStatus::ReadyToPlay`
+   before reporting duration.
+3. **Poll for frames** via `AVPlayerItemVideoOutput`:
+   - Convert `CVGetCurrentHostTime()` to item time via `itemTimeForHostTime`
+   - Check `hasNewPixelBufferForItemTime`
+   - Copy pixel buffer and convert to `VideoFrame` (BGRA → RGBA swap)
+   - Send as `BackendEvent::Frame` through the backend event channel
 
-The AVFoundation backend creates the pipeline and play() is called, but
-`AVPlayerItem.status` is always `Unknown` (0) and never transitions to
-`ReadyToPlay` (1). No frames are ever extracted.
+### Key design decisions
 
-#### Symptoms
+| Decision | Why |
+|---|---|
+| No background thread | AVFoundation objects require `MainThreadMarker`. The select loop
+  provides the main thread. |
+| Timer-driven `sample()`, not message-driven | Without a timer, `sample()` only runs when a command or event arrives,
+  starving AVFoundation of CPU time. |
+| `BackendEvent::Frame` instead of separate `frame_tx` | Frames flow through the same channel as EOS/error/duration. Eliminates
+  the `frame_tx`/`frame_rx` pair from the generic loop. |
+| BGRA pixel buffer with RGBA swap in software | AVFoundation's decoder outputs BGRA natively; the compositor expects
+  RGBA. Requesting RGBA from the decoder fails silently for some files. |
 
-```
-[avf] p0: status=0     ← repeated forever, never becomes 1
-```
+### Pixel format
 
-#### Root cause analysis
+The video output requests `kCVPixelFormatType_32BGRA` via the pixel-buffer
+attributes dictionary.  The `pixel_buffer_to_frame` function then swaps
+bytes 0 and 2 in each 4-byte pixel to produce RGBA output matching the
+compositor's expectations.
 
-`NSRunLoop::runUntilDate()` on a bare background thread with no input
-sources returns **immediately** instead of blocking. AVFoundation's URL
-loading machinery relies on the run loop being serviced — when it isn't,
-the `AVPlayerItem` never loads its media, so it never becomes
-`ReadyToPlay`.
-
-The original fix (adding a `recv_timeout`-based sleep) is the pacing
-mechanism, but the first 33 ms loop iterations happen before any run
-loop time is given to AVFoundation. By the time `runUntilDate` runs,
-the item has been given <1 ms of cumulative run loop time from the very
-first drain call, which is insufficient to even begin URL loading.
-
-#### Attempted fixes (all failed)
-
-| Attempt | What changed | Result |
-|---|---|---|
-| 1. `recv_timeout` only, no run loop drain | Removed `runUntilDate` entirely | Status always 0, no change |
-| 2. `try_recv` + `runUntilDate(8ms)` | Run loop 8ms then try_recv | 100% CPU (run loop returned instantly) |
-| 3. `recv_timeout(33ms)` first, then `runUntilDate(8ms)` | Two sequential sleeps totalling 41ms | Status always 0, AVFoundation starved |
-| 4. `runUntilDate(33ms)` + `try_recv` (current) | Run loop owns full cadence | Status always 0 — run loop still returns instantly |
-| 5. Create `AVPlayer` on main thread before `spawn` | Pipeline.init() uses `MainThreadMarker` | `AvPlayer` is `!Send`, can't move into closure |
-
-#### Why NSRunLoop returns immediately on background threads
-
-`NSRunLoop` has two modes:
-- **With sources/timers**: blocks until the next timer fire or input source
-  event, up to the specified timeout.
-- **Without sources/timers**: returns immediately, regardless of the timeout.
-
-A freshly-created background thread has no automatic run loop sources.
-`AVFoundation` does NOT automatically register its URL loading with a
-background thread's run loop — it registers with the **main thread's**
-run loop (or a thread that the `AVPlayer`/`AVPlayerItem` was created on).
-
-Hypothesis: `AVPlayer::playerWithURL:` registers URL loading callbacks
-on the creating thread's run loop. If that thread never has its run loop
-serviced, the callbacks never fire.
-
-#### What would be needed to fix
-
-1. **Run the AVFoundation worker on the main thread** — swap the generic
-   select loop to a background thread and keep the main thread for
-   `NSRunLoop` + AVFoundation operations. This requires restructuring
-   `run_media_process` or having the backend own its own threading.
-
-2. **Or: create a `CFRunLoopTimer` or `dispatch_source` on the worker
-   thread** so `runUntilDate` actually has something to wait on. This
-   would keep run loop occupied and let AVFoundation callbacks fire.
-
-3. **Or: use `dispatch_async` to the main queue** for all AVFoundation
-   operations, keeping the worker thread purely as a command router.
-
-Option 1 is the most architecturally sound but requires non-trivial
-refactoring of the generic run loop.
-
-### Common pitfalls (when it does work)
+### Common pitfalls
 
 | Pitfall | Symptom | Fix |
 |---|---|---|
 | Using `currentTime()` instead of `itemTimeForHostTime` | Only first frame ever delivered | Use `CVGetCurrentHostTime()` → `itemTimeForHostTime` |
 | Using unix wall clock for host time | Item time doesn't match video timeline | Use `CVGetCurrentHostTime()` / `CVGetHostClockFrequency()` |
 | Reading duration before asset loads | `kCMTimeIndefinite`, `seconds()` returns `NaN` | Poll `item.status() == ReadyToPlay` first |
+| `kCVPixelBufferPixelFormatTypeKey` double-ref | Crash during pipeline creation | Use `kCVPixelBufferPixelFormatTypeKey` directly (it's already `&CFString`), not `&kCVPixelBufferPixelFormatTypeKey` |
+| No timer driving `sample()` | No frames delivered | Add `crossbeam_channel::tick()` arm to `select!` |
+| BGRA data sent as RGBA | Blue-tinted video | Swap bytes 0 and 2 in `pixel_buffer_to_frame` |
 
 ### What does NOT change
 

--- a/media/src/backend/avfoundation/av_sys/item.rs
+++ b/media/src/backend/avfoundation/av_sys/item.rs
@@ -1,0 +1,41 @@
+//! Safe wrappers around `AVPlayerItem` operations.
+
+use objc2::rc::Retained;
+use objc2_av_foundation::{AVPlayerItem, AVPlayerItemStatus};
+
+use super::video_output::AvVideoOutput;
+
+/// Safe handle to an AVPlayerItem.
+pub(crate) struct AvPlayerItem {
+    pub(crate) inner: Retained<AVPlayerItem>,
+}
+
+unsafe impl Send for AvPlayerItem {}
+
+impl AvPlayerItem {
+    /// The item's playback status.
+    pub(crate) fn status(&self) -> AVPlayerItemStatus {
+        unsafe { self.inner.status() }
+    }
+
+    /// Duration in seconds, or 0.0 if not yet known.
+    pub(crate) fn duration_secs(&self) -> f64 {
+        let d = unsafe { self.inner.duration() };
+        let secs = unsafe { d.seconds() };
+        if secs.is_finite() && secs > 0.0 {
+            secs
+        } else {
+            0.0
+        }
+    }
+
+    /// Attach a video output to this item.
+    pub(crate) fn add_output(&self, output: &AvVideoOutput) {
+        unsafe { self.inner.addOutput(&output.inner) };
+    }
+
+    /// Remove a video output from this item.
+    pub(crate) fn remove_output(&self, output: &AvVideoOutput) {
+        unsafe { self.inner.removeOutput(&output.inner) };
+    }
+}

--- a/media/src/backend/avfoundation/av_sys/mod.rs
+++ b/media/src/backend/avfoundation/av_sys/mod.rs
@@ -16,10 +16,8 @@ mod video_output;
 pub(crate) use video_output::AvVideoOutput;
 
 pub(crate) mod pixel_buffer;
-pub(crate) use pixel_buffer::{PixelBufferLock, pixel_buffer_to_frame};
 
-mod time;
-pub(crate) use time::host_time_seconds;
+pub(crate) mod time;
 
 mod url;
 pub(crate) use url::url_from_string;

--- a/media/src/backend/avfoundation/av_sys/mod.rs
+++ b/media/src/backend/avfoundation/av_sys/mod.rs
@@ -1,0 +1,25 @@
+//! Safe wrappers around the AVFoundation, CoreMedia, and CoreVideo C/Objective-C
+//! APIs.  All `unsafe` blocks in the AVFoundation backend are confined to this
+//! module — the backend implementation in `super::pipeline` uses only safe code.
+//!
+//! Each type below wraps an `objc2` `Retained<T>` handle.  Methods delegate to
+//! the underlying Objective-C object through `unsafe` FFI calls that are proven
+//! correct for our single-threaded, serialized-access usage pattern.
+
+mod player;
+pub(crate) use player::AvPlayer;
+
+// AvPlayerItem is used internally by AvPlayer::current_item().
+mod item;
+
+mod video_output;
+pub(crate) use video_output::AvVideoOutput;
+
+pub(crate) mod pixel_buffer;
+pub(crate) use pixel_buffer::{PixelBufferLock, pixel_buffer_to_frame};
+
+mod time;
+pub(crate) use time::host_time_seconds;
+
+mod url;
+pub(crate) use url::url_from_string;

--- a/media/src/backend/avfoundation/av_sys/mod.rs
+++ b/media/src/backend/avfoundation/av_sys/mod.rs
@@ -9,8 +9,8 @@
 mod player;
 pub(crate) use player::AvPlayer;
 
-// AvPlayerItem is used internally by AvPlayer::current_item().
 mod item;
+pub(crate) use item::AvPlayerItem;
 
 mod video_output;
 pub(crate) use video_output::AvVideoOutput;

--- a/media/src/backend/avfoundation/av_sys/pixel_buffer.rs
+++ b/media/src/backend/avfoundation/av_sys/pixel_buffer.rs
@@ -10,49 +10,39 @@ use objc2_core_video::{
 use ipc_messages::media::{MediaPipelineId, VideoFrame};
 
 /// Scoped lock on a CVPixelBuffer.  The buffer is unlocked on drop.
+///
+/// Takes ownership of a `Retained<CVPixelBuffer>` (from
+/// `copyPixelBufferForItemTime:`) and holds it locked for the lifetime of
+/// this lock.
 pub(crate) struct PixelBufferLock {
-    // Holding the Retained keeps the buffer alive while locked.
-    #[allow(dead_code)]
-    buf: Retained<CVPixelBuffer>,
+    _buf: Retained<CVPixelBuffer>,
 }
 
 impl PixelBufferLock {
-    /// Lock the pixel buffer for read-only access.
-    ///
-    /// Returns `None` if locking fails (e.g. the buffer is not in system
-    /// memory).
-    pub(crate) fn new(buf: &CVPixelBuffer) -> Option<Self> {
+    /// Lock a CVPixelBuffer for read-only access.
+    pub(crate) fn new(buf: Retained<CVPixelBuffer>) -> Option<Self> {
         let lock = CVPixelBufferLockFlags::ReadOnly;
-        // SAFETY: buf is a valid CVPixelBuffer, and ReadOnly locking is
-        // safe for read-only access from any thread.
-        if unsafe { CVPixelBufferLockBaseAddress(buf, lock) } != kCVReturnSuccess {
+        // SAFETY: buf is valid and the lock is read-only.
+        if unsafe { CVPixelBufferLockBaseAddress(&buf, lock) } != kCVReturnSuccess {
             return None;
         }
-        // Retain so the buffer stays alive while locked.
-        // SAFETY: buf points to a valid Objective-C object, and we hold
-        // a reference from the caller.
-        let retained = unsafe { Retained::retain(buf as *const _ as *mut _) }?;
-        Some(Self { buf: retained })
+        Some(Self { _buf: buf })
     }
 
-    /// Width in pixels.
     pub(crate) fn width(&self) -> usize {
-        CVPixelBufferGetWidth(&*self.buf)
+        CVPixelBufferGetWidth(&self._buf)
     }
 
-    /// Height in pixels.
     pub(crate) fn height(&self) -> usize {
-        CVPixelBufferGetHeight(&*self.buf)
+        CVPixelBufferGetHeight(&self._buf)
     }
 
-    /// Bytes per row (may include padding beyond width × 4).
     pub(crate) fn bytes_per_row(&self) -> usize {
-        CVPixelBufferGetBytesPerRow(&*self.buf)
+        CVPixelBufferGetBytesPerRow(&self._buf)
     }
 
-    /// Pointer to the first byte of pixel data.
     pub(crate) fn base_address(&self) -> *const u8 {
-        CVPixelBufferGetBaseAddress(&*self.buf) as *const u8
+        CVPixelBufferGetBaseAddress(&self._buf) as *const u8
     }
 }
 
@@ -60,15 +50,13 @@ impl Drop for PixelBufferLock {
     fn drop(&mut self) {
         let lock = CVPixelBufferLockFlags::ReadOnly;
         // SAFETY: Matches the lock call above.
-        unsafe { CVPixelBufferUnlockBaseAddress(&*self.buf, lock) };
+        unsafe { CVPixelBufferUnlockBaseAddress(&self._buf, lock) };
     }
 }
 
-/// Convert a locked `CVPixelBuffer` to a tightly-packed `VideoFrame`.
+/// Convert a locked CVPixelBuffer to a tightly-packed VideoFrame.
 ///
-/// The buffer is assumed to have 4 bytes per pixel (BGRA). Row padding
-/// (bytes_per_row may be larger than width × 4) is stripped so the output
-/// is tightly packed W×H×4.
+/// The buffer is assumed to have 4 bytes per pixel (BGRA).
 pub(crate) fn pixel_buffer_to_frame(
     pipeline_id: MediaPipelineId,
     lock: &PixelBufferLock,
@@ -85,10 +73,15 @@ pub(crate) fn pixel_buffer_to_frame(
     let row_bytes = width * 4;
     let mut data = Vec::with_capacity(height * row_bytes);
     for row in 0..height {
-        // SAFETY: The pixel buffer is locked for the lifetime of `lock`,
-        // so the memory at `base + row * bpr` is valid and accessible.
         let src = unsafe { std::slice::from_raw_parts(base.add(row * bpr), row_bytes) };
-        data.extend_from_slice(src);
+        // The pixel buffer is BGRA but the compositor expects RGBA.
+        // Swap byte 0 (B) with byte 2 (R) in each 4-byte pixel.
+        for chunk in src.chunks_exact(4) {
+            data.push(chunk[2]); // R
+            data.push(chunk[1]); // G
+            data.push(chunk[0]); // B
+            data.push(chunk[3]); // A
+        }
     }
 
     Some(VideoFrame {

--- a/media/src/backend/avfoundation/av_sys/pixel_buffer.rs
+++ b/media/src/backend/avfoundation/av_sys/pixel_buffer.rs
@@ -1,0 +1,100 @@
+//! Safe wrappers around `CVPixelBuffer` lock/read/unlock.
+
+use objc2::rc::Retained;
+use objc2_core_video::{
+    CVPixelBuffer, CVPixelBufferGetBaseAddress, CVPixelBufferGetBytesPerRow,
+    CVPixelBufferGetHeight, CVPixelBufferGetWidth, CVPixelBufferLockBaseAddress,
+    CVPixelBufferLockFlags, CVPixelBufferUnlockBaseAddress, kCVReturnSuccess,
+};
+
+use ipc_messages::media::{MediaPipelineId, VideoFrame};
+
+/// Scoped lock on a CVPixelBuffer.  The buffer is unlocked on drop.
+pub(crate) struct PixelBufferLock {
+    // Holding the Retained keeps the buffer alive while locked.
+    #[allow(dead_code)]
+    buf: Retained<CVPixelBuffer>,
+}
+
+impl PixelBufferLock {
+    /// Lock the pixel buffer for read-only access.
+    ///
+    /// Returns `None` if locking fails (e.g. the buffer is not in system
+    /// memory).
+    pub(crate) fn new(buf: &CVPixelBuffer) -> Option<Self> {
+        let lock = CVPixelBufferLockFlags::ReadOnly;
+        // SAFETY: buf is a valid CVPixelBuffer, and ReadOnly locking is
+        // safe for read-only access from any thread.
+        if unsafe { CVPixelBufferLockBaseAddress(buf, lock) } != kCVReturnSuccess {
+            return None;
+        }
+        // Retain so the buffer stays alive while locked.
+        // SAFETY: buf points to a valid Objective-C object, and we hold
+        // a reference from the caller.
+        let retained = unsafe { Retained::retain(buf as *const _ as *mut _) }?;
+        Some(Self { buf: retained })
+    }
+
+    /// Width in pixels.
+    pub(crate) fn width(&self) -> usize {
+        CVPixelBufferGetWidth(&*self.buf)
+    }
+
+    /// Height in pixels.
+    pub(crate) fn height(&self) -> usize {
+        CVPixelBufferGetHeight(&*self.buf)
+    }
+
+    /// Bytes per row (may include padding beyond width × 4).
+    pub(crate) fn bytes_per_row(&self) -> usize {
+        CVPixelBufferGetBytesPerRow(&*self.buf)
+    }
+
+    /// Pointer to the first byte of pixel data.
+    pub(crate) fn base_address(&self) -> *const u8 {
+        CVPixelBufferGetBaseAddress(&*self.buf) as *const u8
+    }
+}
+
+impl Drop for PixelBufferLock {
+    fn drop(&mut self) {
+        let lock = CVPixelBufferLockFlags::ReadOnly;
+        // SAFETY: Matches the lock call above.
+        unsafe { CVPixelBufferUnlockBaseAddress(&*self.buf, lock) };
+    }
+}
+
+/// Convert a locked `CVPixelBuffer` to a tightly-packed `VideoFrame`.
+///
+/// The buffer is assumed to have 4 bytes per pixel (BGRA). Row padding
+/// (bytes_per_row may be larger than width × 4) is stripped so the output
+/// is tightly packed W×H×4.
+pub(crate) fn pixel_buffer_to_frame(
+    pipeline_id: MediaPipelineId,
+    lock: &PixelBufferLock,
+) -> Option<VideoFrame> {
+    let width = lock.width();
+    let height = lock.height();
+    let bpr = lock.bytes_per_row();
+    let base = lock.base_address();
+
+    if width == 0 || height == 0 || base.is_null() {
+        return None;
+    }
+
+    let row_bytes = width * 4;
+    let mut data = Vec::with_capacity(height * row_bytes);
+    for row in 0..height {
+        // SAFETY: The pixel buffer is locked for the lifetime of `lock`,
+        // so the memory at `base + row * bpr` is valid and accessible.
+        let src = unsafe { std::slice::from_raw_parts(base.add(row * bpr), row_bytes) };
+        data.extend_from_slice(src);
+    }
+
+    Some(VideoFrame {
+        pipeline_id,
+        width: width as u32,
+        height: height as u32,
+        data,
+    })
+}

--- a/media/src/backend/avfoundation/av_sys/player.rs
+++ b/media/src/backend/avfoundation/av_sys/player.rs
@@ -1,0 +1,63 @@
+//! Safe wrappers around `AVPlayer` operations.
+
+use objc2::MainThreadMarker;
+use objc2::rc::Retained;
+use objc2_av_foundation::AVPlayer;
+use objc2_foundation::NSURL;
+
+use super::item::AvPlayerItem;
+use super::time::CMTIME_SCALE;
+
+/// Safe handle to an AVPlayer.
+///
+/// SAFETY: All AVPlayer access is serialized through the command queue,
+/// matching AVFoundation's requirement that all operations on an AVPlayer
+/// happen on a single thread.
+pub(crate) struct AvPlayer {
+    inner: Retained<AVPlayer>,
+}
+
+// SAFETY: The original code sends Retained<AVPlayer> across threads.
+// All AVPlayer methods are called through &mut self, which is safe.
+unsafe impl Send for AvPlayer {}
+
+impl AvPlayer {
+    /// Create an AVPlayer (uses new_unchecked internally).
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure all AVPlayer access is serialized on this
+    /// thread (e.g. via a command queue).
+    pub(crate) unsafe fn new(url: &NSURL) -> Self {
+        let mtm = unsafe { MainThreadMarker::new_unchecked() };
+        let inner = unsafe { AVPlayer::playerWithURL(url, mtm) };
+        Self { inner }
+    }
+
+    /// Start or resume playback.
+    pub(crate) fn play(&mut self) {
+        unsafe { self.inner.play() };
+    }
+
+    /// Pause playback.
+    pub(crate) fn pause(&mut self) {
+        unsafe { self.inner.pause() };
+    }
+
+    /// Seek to an absolute time in seconds.
+    pub(crate) fn seek(&mut self, secs: f64) {
+        let time = unsafe { objc2_core_media::CMTime::with_seconds(secs, CMTIME_SCALE) };
+        unsafe { self.inner.seekToTime(time) };
+    }
+
+    /// Replace the current item with `None` (teardown).
+    pub(crate) fn clear_item(&mut self) {
+        unsafe { self.inner.replaceCurrentItemWithPlayerItem(None) };
+    }
+
+    /// Get the current AVPlayerItem, if any.
+    pub(crate) fn current_item(&self) -> Option<AvPlayerItem> {
+        let item = unsafe { self.inner.currentItem()? };
+        Some(AvPlayerItem { inner: item })
+    }
+}

--- a/media/src/backend/avfoundation/av_sys/player.rs
+++ b/media/src/backend/avfoundation/av_sys/player.rs
@@ -9,25 +9,26 @@ use super::item::AvPlayerItem;
 use super::time::CMTIME_SCALE;
 
 /// Safe handle to an AVPlayer.
-///
-/// SAFETY: All AVPlayer access is serialized through the command queue,
-/// matching AVFoundation's requirement that all operations on an AVPlayer
-/// happen on a single thread.
 pub(crate) struct AvPlayer {
     inner: Retained<AVPlayer>,
 }
 
-// SAFETY: The original code sends Retained<AVPlayer> across threads.
-// All AVPlayer methods are called through &mut self, which is safe.
+// SAFETY: All AVPlayer access is single-threaded (the select-loop thread).
 unsafe impl Send for AvPlayer {}
 
 impl AvPlayer {
-    /// Create an AVPlayer (uses new_unchecked internally).
+    /// Create an AVPlayer on the main thread (safe, with explicit marker).
+    pub(crate) unsafe fn new_on_main(url: &NSURL, mtm: MainThreadMarker) -> Self {
+        let inner = unsafe { AVPlayer::playerWithURL(url, mtm) };
+        Self { inner }
+    }
+
+    /// Create an AVPlayer using new_unchecked.
     ///
     /// # Safety
     ///
-    /// The caller must ensure all AVPlayer access is serialized on this
-    /// thread (e.g. via a command queue).
+    /// The caller must ensure all AVPlayer access is serialized on a
+    /// single thread.
     pub(crate) unsafe fn new(url: &NSURL) -> Self {
         let mtm = unsafe { MainThreadMarker::new_unchecked() };
         let inner = unsafe { AVPlayer::playerWithURL(url, mtm) };
@@ -35,23 +36,23 @@ impl AvPlayer {
     }
 
     /// Start or resume playback.
-    pub(crate) fn play(&mut self) {
+    pub(crate) fn play(&self) {
         unsafe { self.inner.play() };
     }
 
     /// Pause playback.
-    pub(crate) fn pause(&mut self) {
+    pub(crate) fn pause(&self) {
         unsafe { self.inner.pause() };
     }
 
     /// Seek to an absolute time in seconds.
-    pub(crate) fn seek(&mut self, secs: f64) {
+    pub(crate) fn seek(&self, secs: f64) {
         let time = unsafe { objc2_core_media::CMTime::with_seconds(secs, CMTIME_SCALE) };
         unsafe { self.inner.seekToTime(time) };
     }
 
     /// Replace the current item with `None` (teardown).
-    pub(crate) fn clear_item(&mut self) {
+    pub(crate) fn clear_item(&self) {
         unsafe { self.inner.replaceCurrentItemWithPlayerItem(None) };
     }
 

--- a/media/src/backend/avfoundation/av_sys/time.rs
+++ b/media/src/backend/avfoundation/av_sys/time.rs
@@ -1,0 +1,21 @@
+//! Safe wrappers for CoreVideo host-time and CoreMedia CMTime utilities.
+//!
+//! `CVGetCurrentHostTime` returns Mach absolute time in ticks.
+//! `CVGetHostClockFrequency` returns ticks per second.
+//! Dividing gives seconds in the CoreVideo time base, suitable for
+//! `AVPlayerItemOutput::itemTimeForHostTime:`.
+
+use objc2_core_video::{CVGetCurrentHostTime, CVGetHostClockFrequency};
+
+/// Preferred timescale for CMTime values created in this backend.
+pub(crate) const CMTIME_SCALE: i32 = 600;
+
+/// Current host time in seconds (CoreVideo time base).
+///
+/// This is the correct time base to pass to
+/// `AVPlayerItemVideoOutput::itemTimeForHostTime:`.
+pub(crate) fn host_time_seconds() -> f64 {
+    let ticks = CVGetCurrentHostTime();
+    let freq = CVGetHostClockFrequency();
+    ticks as f64 / freq
+}

--- a/media/src/backend/avfoundation/av_sys/url.rs
+++ b/media/src/backend/avfoundation/av_sys/url.rs
@@ -1,0 +1,18 @@
+//! Safe NSURL creation from a Rust string.
+
+use std::ffi::CString;
+
+use objc2::AnyThread;
+use objc2::rc::Retained;
+use objc2_foundation::{NSString, NSURL};
+
+/// Create an `NSURL` from a UTF-8 string.
+///
+/// Returns `None` if the URL string contains a null byte or if
+/// `NSURL::initWithString` fails (e.g. malformed URL).
+pub(crate) fn url_from_string(url: &str) -> Option<Retained<NSURL>> {
+    let c_string = CString::new(url).ok()?;
+    let ptr = std::ptr::NonNull::new(c_string.as_ptr() as *mut _)?;
+    let ns_string: Retained<NSString> = unsafe { NSString::stringWithUTF8String(ptr)? };
+    NSURL::initWithString(NSURL::alloc(), &ns_string)
+}

--- a/media/src/backend/avfoundation/av_sys/video_output.rs
+++ b/media/src/backend/avfoundation/av_sys/video_output.rs
@@ -1,45 +1,59 @@
-//! Safe wrappers around `AVPlayerItemVideoOutput`.
-
 use objc2::AnyThread;
 use objc2::rc::Retained;
+use objc2::runtime::{AnyObject, ProtocolObject};
 use objc2_av_foundation::AVPlayerItemVideoOutput;
 use objc2_core_media::CMTime;
-use objc2_core_video::CVPixelBuffer;
+use objc2_core_video::{
+    CVPixelBuffer, kCVPixelBufferPixelFormatTypeKey, kCVPixelFormatType_32BGRA,
+};
+use objc2_foundation::{NSDictionary, NSNumber, NSString};
 
-/// Safe handle to an AVPlayerItemVideoOutput.
 pub(crate) struct AvVideoOutput {
     pub(crate) inner: Retained<AVPlayerItemVideoOutput>,
 }
 
 impl AvVideoOutput {
-    /// Create a new video output with default pixel buffer attributes.
     pub(crate) fn new() -> Self {
+        // Build pixel-buffer attributes requesting 32BGRA format.
+        // kCVPixelBufferPixelFormatTypeKey is &'static CFString.
+        // SAFETY: CFString and NSString are toll-free bridged.
+        let key: &NSString =
+            unsafe { &*(kCVPixelBufferPixelFormatTypeKey as *const _ as *const NSString) };
+        let value = NSNumber::new_u32(kCVPixelFormatType_32BGRA);
+        // SAFETY: dictionaryWithObject:forKey: expects key to conform to
+        // NSCopying, which NSString does.  NSNumber conforms to AnyObject.
+        // We cast through *const void to change the type parameter.
+        let attrs: Retained<NSDictionary<NSString, AnyObject>> = unsafe {
+            let dict = NSDictionary::<NSString, NSNumber>::dictionaryWithObject_forKey(
+                &*value,
+                ProtocolObject::from_ref(key as &NSString),
+            );
+            // Coerce value type via pointer cast (same layout at runtime).
+            Retained::from_raw(Retained::into_raw(dict) as *mut NSDictionary<NSString, AnyObject>)
+                .unwrap()
+        };
+
         let inner = unsafe {
             AVPlayerItemVideoOutput::initWithPixelBufferAttributes(
                 AVPlayerItemVideoOutput::alloc(),
-                None,
+                Some(&*attrs),
             )
         };
         Self { inner }
     }
 
-    /// Suppress system video rendering — the consumer handles display.
     pub(crate) fn suppress_rendering(&self) {
         unsafe { self.inner.setSuppressesPlayerRendering(true) };
     }
 
-    /// Convert a host-time value (seconds in the CoreVideo time base) to the
-    /// equivalent item timeline time.
     pub(crate) fn item_time_for_host_time(&self, host_secs: f64) -> CMTime {
         unsafe { self.inner.itemTimeForHostTime(host_secs) }
     }
 
-    /// Check whether a new pixel buffer is available at the given item time.
     pub(crate) fn has_new_pixel_buffer(&self, time: CMTime) -> bool {
         unsafe { self.inner.hasNewPixelBufferForItemTime(time) }
     }
 
-    /// Copy the pixel buffer for the given item time, if available.
     pub(crate) fn copy_pixel_buffer(&self, time: CMTime) -> Option<Retained<CVPixelBuffer>> {
         unsafe {
             self.inner

--- a/media/src/backend/avfoundation/av_sys/video_output.rs
+++ b/media/src/backend/avfoundation/av_sys/video_output.rs
@@ -1,0 +1,49 @@
+//! Safe wrappers around `AVPlayerItemVideoOutput`.
+
+use objc2::AnyThread;
+use objc2::rc::Retained;
+use objc2_av_foundation::AVPlayerItemVideoOutput;
+use objc2_core_media::CMTime;
+use objc2_core_video::CVPixelBuffer;
+
+/// Safe handle to an AVPlayerItemVideoOutput.
+pub(crate) struct AvVideoOutput {
+    pub(crate) inner: Retained<AVPlayerItemVideoOutput>,
+}
+
+impl AvVideoOutput {
+    /// Create a new video output with default pixel buffer attributes.
+    pub(crate) fn new() -> Self {
+        let inner = unsafe {
+            AVPlayerItemVideoOutput::initWithPixelBufferAttributes(
+                AVPlayerItemVideoOutput::alloc(),
+                None,
+            )
+        };
+        Self { inner }
+    }
+
+    /// Suppress system video rendering — the consumer handles display.
+    pub(crate) fn suppress_rendering(&self) {
+        unsafe { self.inner.setSuppressesPlayerRendering(true) };
+    }
+
+    /// Convert a host-time value (seconds in the CoreVideo time base) to the
+    /// equivalent item timeline time.
+    pub(crate) fn item_time_for_host_time(&self, host_secs: f64) -> CMTime {
+        unsafe { self.inner.itemTimeForHostTime(host_secs) }
+    }
+
+    /// Check whether a new pixel buffer is available at the given item time.
+    pub(crate) fn has_new_pixel_buffer(&self, time: CMTime) -> bool {
+        unsafe { self.inner.hasNewPixelBufferForItemTime(time) }
+    }
+
+    /// Copy the pixel buffer for the given item time, if available.
+    pub(crate) fn copy_pixel_buffer(&self, time: CMTime) -> Option<Retained<CVPixelBuffer>> {
+        unsafe {
+            self.inner
+                .copyPixelBufferForItemTime_itemTimeForDisplay(time, std::ptr::null_mut())
+        }
+    }
+}

--- a/media/src/backend/avfoundation/mod.rs
+++ b/media/src/backend/avfoundation/mod.rs
@@ -1,0 +1,35 @@
+mod pipeline;
+pub use pipeline::AvfPipeline;
+
+use crate::backend::{BackendEvent, MediaBackend};
+use crossbeam_channel::Sender;
+use ipc_messages::media::{MediaEvent, MediaPipelineId};
+
+pub struct AvfBackend {
+    // Event channel for future use (EOS/error/duration notifications).
+    #[allow(dead_code)]
+    event_tx: crossbeam_channel::Sender<BackendEvent>,
+    event_rx: crossbeam_channel::Receiver<BackendEvent>,
+}
+
+impl MediaBackend for AvfBackend {
+    type Pipeline = AvfPipeline;
+
+    fn init() -> Result<Self, String> {
+        let (event_tx, event_rx) = crossbeam_channel::unbounded::<BackendEvent>();
+        Ok(Self { event_tx, event_rx })
+    }
+
+    fn create_pipeline(
+        &mut self,
+        id: MediaPipelineId,
+        url: String,
+        frame_tx: Sender<MediaEvent>,
+    ) -> Result<Self::Pipeline, String> {
+        AvfPipeline::new(id, url, frame_tx)
+    }
+
+    fn event_receiver(&self) -> crossbeam_channel::Receiver<BackendEvent> {
+        self.event_rx.clone()
+    }
+}

--- a/media/src/backend/avfoundation/mod.rs
+++ b/media/src/backend/avfoundation/mod.rs
@@ -4,12 +4,9 @@ mod pipeline;
 pub use pipeline::AvfPipeline;
 
 use crate::backend::{BackendEvent, MediaBackend};
-use crossbeam_channel::Sender;
-use ipc_messages::media::{MediaEvent, MediaPipelineId};
+use ipc_messages::media::MediaPipelineId;
 
 pub struct AvfBackend {
-    // Event channel for future use (EOS/error/duration notifications).
-    #[allow(dead_code)]
     event_tx: crossbeam_channel::Sender<BackendEvent>,
     event_rx: crossbeam_channel::Receiver<BackendEvent>,
 }
@@ -26,9 +23,8 @@ impl MediaBackend for AvfBackend {
         &mut self,
         id: MediaPipelineId,
         url: String,
-        frame_tx: Sender<MediaEvent>,
     ) -> Result<Self::Pipeline, String> {
-        AvfPipeline::new(id, url, frame_tx)
+        AvfPipeline::new(id, url, self.event_tx.clone())
     }
 
     fn event_receiver(&self) -> crossbeam_channel::Receiver<BackendEvent> {

--- a/media/src/backend/avfoundation/mod.rs
+++ b/media/src/backend/avfoundation/mod.rs
@@ -1,4 +1,6 @@
+mod av_sys;
 mod pipeline;
+
 pub use pipeline::AvfPipeline;
 
 use crate::backend::{BackendEvent, MediaBackend};

--- a/media/src/backend/avfoundation/pipeline.rs
+++ b/media/src/backend/avfoundation/pipeline.rs
@@ -1,26 +1,24 @@
-use std::ffi::CString;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::time::Duration;
 
 use crossbeam_channel::Sender;
-use objc2::AnyThread;
-use objc2::MainThreadMarker;
-use objc2::rc::Retained;
-use objc2_av_foundation::{AVPlayer, AVPlayerItemStatus, AVPlayerItemVideoOutput};
-use objc2_core_media::CMTime;
-use objc2_core_video::{CVGetCurrentHostTime, CVGetHostClockFrequency, CVPixelBuffer};
-use objc2_foundation::{NSDate, NSRunLoop, NSString, NSURL};
+use objc2_foundation::{NSDate, NSRunLoop};
 
-use ipc_messages::media::{MediaEvent, MediaPipelineId, VideoFrame};
+use ipc_messages::media::{MediaEvent, MediaPipelineId};
 
 use crate::backend::PipelineHandle;
+
+use super::av_sys::{
+    AvPlayer, AvVideoOutput, PixelBufferLock, host_time_seconds, pixel_buffer_to_frame,
+    url_from_string,
+};
 
 // ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
 
-const CM_TIME_SCALE: i32 = 600;
+/// Frame poll interval — the run loop drains for this long each iteration.
+const POLL_SECS: f64 = 0.033; // ≈30 fps
 
 // ---------------------------------------------------------------------------
 // Command queue
@@ -59,133 +57,97 @@ impl AvfPipeline {
         let thread = std::thread::Builder::new()
             .name("formal-web-avf-worker".into())
             .spawn(move || {
-                let mtm = unsafe { MainThreadMarker::new_unchecked() };
+                // SAFETY: All AVPlayer/AVPlayerItem access is serialized on
+                // this dedicated thread via the command queue below.
+                let ns_url = url_from_string(&url_string).expect("NSURL creation failed");
+                let mut player = unsafe { AvPlayer::new(&ns_url) };
+                let item = player.current_item().expect("AVPlayer::currentItem");
+                let video_output = AvVideoOutput::new();
+                video_output.suppress_rendering();
+                item.add_output(&video_output);
+                player.pause();
 
-                // ── NSURL from string ──
-                let c_string = match CString::new(url_string.as_str()) {
-                    Ok(cs) => cs,
-                    Err(_) => {
-                        log::error!("[avf] p{}: URL has null byte", id.0);
-                        return;
-                    }
-                };
-                let ns_string_ptr = std::ptr::NonNull::new(c_string.as_ptr() as *mut _);
-                let ns_string: Retained<NSString> = (unsafe {
-                    ns_string_ptr.and_then(|pointer| NSString::stringWithUTF8String(pointer))
-                })
-                .expect("NSString::stringWithUTF8String failed");
-                let ns_url = NSURL::initWithString(NSURL::alloc(), &ns_string)
-                    .unwrap_or_else(|| panic!("NSURL::initWithString failed for {url_string}"));
-
-                // ── AVPlayer + item ──
-                let player = unsafe { AVPlayer::playerWithURL(&ns_url, mtm) };
-                let Some(item) = (unsafe { player.currentItem() }) else {
-                    log::error!("[avf] p{}: no AVPlayerItem", id.0);
-                    return;
-                };
-
-                // ── AVPlayerItemVideoOutput ──
-                let video_output = unsafe {
-                    AVPlayerItemVideoOutput::initWithPixelBufferAttributes(
-                        AVPlayerItemVideoOutput::alloc(),
-                        None,
-                    )
-                };
-                unsafe { item.addOutput(&video_output) };
-                unsafe { video_output.setSuppressesPlayerRendering(true) };
-
-                // ── Start paused ──
-                unsafe { player.pause() };
                 log::info!("[avf] p{}: ready", id.0);
 
-                // ── State ──
                 let mut duration_reported = false;
 
-                // ── Combined command + frame polling loop ──
                 loop {
-                    // ── Fix 3: Poll item status for duration ──
+                    // ── Run loop drives ALL timing ──
+                    // AVFoundation URL loading, KVO, and video output timing
+                    // all need continuous run loop time. Drain for POLL_SECS,
+                    // then process commands and poll frames.
+                    let rl = NSRunLoop::currentRunLoop();
+                    let until = NSDate::dateWithTimeIntervalSinceNow(POLL_SECS);
+                    rl.runUntilDate(&until);
+
+                    // ── Drain all pending commands ──
+                    loop {
+                        match cmd_rx.try_recv() {
+                            Ok(cmd) => match cmd {
+                                AvfCommand::Play => {
+                                    log::info!("[avf] p{}: play", id.0);
+                                    player.play();
+                                }
+                                AvfCommand::Pause => {
+                                    log::info!("[avf] p{}: pause", id.0);
+                                    player.pause();
+                                }
+                                AvfCommand::Seek(pos) => {
+                                    log::info!("[avf] p{}: seek to {pos}s", id.0);
+                                    player.seek(pos);
+                                }
+                                AvfCommand::Destroy => {
+                                    log::info!("[avf] p{}: destroy", id.0);
+                                    destroyed_clone.store(true, Ordering::SeqCst);
+                                    player.pause();
+                                    item.remove_output(&video_output);
+                                    player.clear_item();
+                                    return;
+                                }
+                            },
+                            Err(crossbeam_channel::TryRecvError::Empty) => break,
+                            Err(crossbeam_channel::TryRecvError::Disconnected) => {
+                                log::info!("[avf] p{}: cmd channel closed", id.0);
+                                return;
+                            }
+                        }
+                    }
+
+                    // ── Duration check (once) ──
                     if !duration_reported {
-                        let status = unsafe { item.status() };
-                        if status == AVPlayerItemStatus::ReadyToPlay {
-                            let duration = unsafe { item.duration() };
-                            let secs = unsafe { duration.seconds() };
-                            if secs.is_finite() && secs > 0.0 {
+                        use objc2_av_foundation::AVPlayerItemStatus;
+                        let st = item.status();
+                        let st_num: i32 = st.0 as i32;
+                        log::info!("[avf] p{}: status={st_num}", id.0);
+                        if st == AVPlayerItemStatus::ReadyToPlay {
+                            let secs = item.duration_secs();
+                            if secs > 0.0 {
                                 log::info!("[avf] p{}: duration = {secs}s", id.0);
                             }
                             duration_reported = true;
                         }
                     }
 
-                    // ── Convert Mach absolute host time to seconds ──
-                    // itemTimeForHostTime expects the CoreVideo host time
-                    // base (mach_absolute_time), not unix wall clock.
-                    let host_ticks = unsafe { CVGetCurrentHostTime() };
-                    let freq = unsafe { CVGetHostClockFrequency() };
-                    let host_secs = host_ticks as f64 / freq;
-                    let item_time = unsafe { video_output.itemTimeForHostTime(host_secs) };
+                    // ── Frame poll ──
+                    let host_secs = host_time_seconds();
+                    let item_time = video_output.item_time_for_host_time(host_secs);
 
-                    let has_new = unsafe { video_output.hasNewPixelBufferForItemTime(item_time) };
-                    if has_new {
-                        let pixel_buf = unsafe {
-                            video_output.copyPixelBufferForItemTime_itemTimeForDisplay(
-                                item_time,
-                                std::ptr::null_mut(),
-                            )
-                        };
-                        if let Some(ref pb) = pixel_buf {
-                            if let Some(frame) = pixel_buffer_to_frame(id, pb) {
-                                let c = FRAME_COUNT.fetch_add(1, Ordering::Relaxed);
-                                if c % 30 == 0 {
-                                    log::debug!(
-                                        "[avf] p{}: frame #{c} ({}x{})",
-                                        id.0,
-                                        frame.width,
-                                        frame.height,
-                                    );
+                    if video_output.has_new_pixel_buffer(item_time) {
+                        if let Some(pixel_buf) = video_output.copy_pixel_buffer(item_time) {
+                            if let Some(lock) = PixelBufferLock::new(&pixel_buf) {
+                                if let Some(frame) = pixel_buffer_to_frame(id, &lock) {
+                                    let c = FRAME_COUNT.fetch_add(1, Ordering::Relaxed);
+                                    if c % 30 == 0 {
+                                        log::debug!(
+                                            "[avf] p{}: frame #{c} ({}x{})",
+                                            id.0,
+                                            frame.width,
+                                            frame.height,
+                                        );
+                                    }
+                                    let _ = frame_tx.send(MediaEvent::Frame(frame));
                                 }
-                                let _ = frame_tx.send(MediaEvent::Frame(frame));
                             }
-                        }
-                    }
-
-                    // ── Fix 2: Drain run loop ──
-                    // AVPlayerItemVideoOutput's internal timing machinery
-                    // needs a run loop to advance. Drain it briefly.
-                    let rl = NSRunLoop::currentRunLoop();
-                    let until = NSDate::dateWithTimeIntervalSinceNow(0.008);
-                    rl.runUntilDate(&until);
-
-                    // Process one command (non-blocking).
-                    match cmd_rx.try_recv() {
-                        Ok(cmd) => match cmd {
-                            AvfCommand::Play => {
-                                log::info!("[avf] p{}: play", id.0);
-                                unsafe { player.play() };
-                            }
-                            AvfCommand::Pause => {
-                                log::info!("[avf] p{}: pause", id.0);
-                                unsafe { player.pause() };
-                            }
-                            AvfCommand::Seek(pos) => {
-                                log::info!("[avf] p{}: seek to {pos}s", id.0);
-                                let time = unsafe { CMTime::with_seconds(pos, CM_TIME_SCALE) };
-                                unsafe { player.seekToTime(time) };
-                            }
-                            AvfCommand::Destroy => {
-                                log::info!("[avf] p{}: destroy", id.0);
-                                destroyed_clone.store(true, Ordering::SeqCst);
-                                unsafe {
-                                    player.pause();
-                                    item.removeOutput(&video_output);
-                                    player.replaceCurrentItemWithPlayerItem(None);
-                                }
-                                return;
-                            }
-                        },
-                        Err(crossbeam_channel::TryRecvError::Empty) => {}
-                        Err(crossbeam_channel::TryRecvError::Disconnected) => {
-                            log::info!("[avf] p{}: cmd channel closed", id.0);
-                            return;
                         }
                     }
                 }
@@ -222,51 +184,5 @@ impl PipelineHandle for AvfPipeline {
             let _ = thread.join();
         }
         Ok(())
-    }
-}
-
-// ---------------------------------------------------------------------------
-// CVPixelBuffer → VideoFrame
-// ---------------------------------------------------------------------------
-
-fn pixel_buffer_to_frame(pipeline_id: MediaPipelineId, buf: &CVPixelBuffer) -> Option<VideoFrame> {
-    use objc2_core_video::{
-        CVPixelBufferGetBaseAddress, CVPixelBufferGetBytesPerRow, CVPixelBufferGetHeight,
-        CVPixelBufferGetWidth, CVPixelBufferLockBaseAddress, CVPixelBufferLockFlags,
-        CVPixelBufferUnlockBaseAddress, kCVReturnSuccess,
-    };
-
-    unsafe {
-        let lock = CVPixelBufferLockFlags::ReadOnly;
-        if CVPixelBufferLockBaseAddress(buf, lock) != kCVReturnSuccess {
-            log::warn!("[avf] CVPixelBuffer lock failed");
-            return None;
-        }
-
-        let width = CVPixelBufferGetWidth(buf);
-        let height = CVPixelBufferGetHeight(buf);
-        let bpr = CVPixelBufferGetBytesPerRow(buf);
-        let base = CVPixelBufferGetBaseAddress(buf) as *const u8;
-
-        if width == 0 || height == 0 || base.is_null() {
-            let _ = CVPixelBufferUnlockBaseAddress(buf, CVPixelBufferLockFlags::ReadOnly);
-            return None;
-        }
-
-        let row_bytes = width * 4;
-        let mut data = Vec::with_capacity(height * row_bytes);
-        for row in 0..height {
-            let src = std::slice::from_raw_parts(base.add(row * bpr), row_bytes);
-            data.extend_from_slice(src);
-        }
-
-        CVPixelBufferUnlockBaseAddress(buf, CVPixelBufferLockFlags::ReadOnly);
-
-        Some(VideoFrame {
-            pipeline_id,
-            width: width as u32,
-            height: height as u32,
-            data,
-        })
     }
 }

--- a/media/src/backend/avfoundation/pipeline.rs
+++ b/media/src/backend/avfoundation/pipeline.rs
@@ -1,0 +1,272 @@
+use std::ffi::CString;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
+
+use crossbeam_channel::Sender;
+use objc2::AnyThread;
+use objc2::MainThreadMarker;
+use objc2::rc::Retained;
+use objc2_av_foundation::{AVPlayer, AVPlayerItemStatus, AVPlayerItemVideoOutput};
+use objc2_core_media::CMTime;
+use objc2_core_video::{CVGetCurrentHostTime, CVGetHostClockFrequency, CVPixelBuffer};
+use objc2_foundation::{NSDate, NSRunLoop, NSString, NSURL};
+
+use ipc_messages::media::{MediaEvent, MediaPipelineId, VideoFrame};
+
+use crate::backend::PipelineHandle;
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const CM_TIME_SCALE: i32 = 600;
+
+// ---------------------------------------------------------------------------
+// Command queue
+// ---------------------------------------------------------------------------
+
+enum AvfCommand {
+    Play,
+    Pause,
+    Seek(f64),
+    Destroy,
+}
+
+// ---------------------------------------------------------------------------
+// AvfPipeline
+// ---------------------------------------------------------------------------
+
+pub struct AvfPipeline {
+    cmd_tx: crossbeam_channel::Sender<AvfCommand>,
+    #[allow(dead_code)]
+    destroyed: Arc<AtomicBool>,
+    thread: Option<std::thread::JoinHandle<()>>,
+}
+
+static FRAME_COUNT: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
+impl AvfPipeline {
+    pub fn new(
+        id: MediaPipelineId,
+        url_string: String,
+        frame_tx: Sender<MediaEvent>,
+    ) -> Result<Self, String> {
+        let (cmd_tx, cmd_rx) = crossbeam_channel::unbounded::<AvfCommand>();
+        let destroyed = Arc::new(AtomicBool::new(false));
+        let destroyed_clone = Arc::clone(&destroyed);
+
+        let thread = std::thread::Builder::new()
+            .name("formal-web-avf-worker".into())
+            .spawn(move || {
+                let mtm = unsafe { MainThreadMarker::new_unchecked() };
+
+                // ── NSURL from string ──
+                let c_string = match CString::new(url_string.as_str()) {
+                    Ok(cs) => cs,
+                    Err(_) => {
+                        log::error!("[avf] p{}: URL has null byte", id.0);
+                        return;
+                    }
+                };
+                let ns_string_ptr = std::ptr::NonNull::new(c_string.as_ptr() as *mut _);
+                let ns_string: Retained<NSString> = (unsafe {
+                    ns_string_ptr.and_then(|pointer| NSString::stringWithUTF8String(pointer))
+                })
+                .expect("NSString::stringWithUTF8String failed");
+                let ns_url = NSURL::initWithString(NSURL::alloc(), &ns_string)
+                    .unwrap_or_else(|| panic!("NSURL::initWithString failed for {url_string}"));
+
+                // ── AVPlayer + item ──
+                let player = unsafe { AVPlayer::playerWithURL(&ns_url, mtm) };
+                let Some(item) = (unsafe { player.currentItem() }) else {
+                    log::error!("[avf] p{}: no AVPlayerItem", id.0);
+                    return;
+                };
+
+                // ── AVPlayerItemVideoOutput ──
+                let video_output = unsafe {
+                    AVPlayerItemVideoOutput::initWithPixelBufferAttributes(
+                        AVPlayerItemVideoOutput::alloc(),
+                        None,
+                    )
+                };
+                unsafe { item.addOutput(&video_output) };
+                unsafe { video_output.setSuppressesPlayerRendering(true) };
+
+                // ── Start paused ──
+                unsafe { player.pause() };
+                log::info!("[avf] p{}: ready", id.0);
+
+                // ── State ──
+                let mut duration_reported = false;
+
+                // ── Combined command + frame polling loop ──
+                loop {
+                    // ── Fix 3: Poll item status for duration ──
+                    if !duration_reported {
+                        let status = unsafe { item.status() };
+                        if status == AVPlayerItemStatus::ReadyToPlay {
+                            let duration = unsafe { item.duration() };
+                            let secs = unsafe { duration.seconds() };
+                            if secs.is_finite() && secs > 0.0 {
+                                log::info!("[avf] p{}: duration = {secs}s", id.0);
+                            }
+                            duration_reported = true;
+                        }
+                    }
+
+                    // ── Convert Mach absolute host time to seconds ──
+                    // itemTimeForHostTime expects the CoreVideo host time
+                    // base (mach_absolute_time), not unix wall clock.
+                    let host_ticks = unsafe { CVGetCurrentHostTime() };
+                    let freq = unsafe { CVGetHostClockFrequency() };
+                    let host_secs = host_ticks as f64 / freq;
+                    let item_time = unsafe { video_output.itemTimeForHostTime(host_secs) };
+
+                    let has_new = unsafe { video_output.hasNewPixelBufferForItemTime(item_time) };
+                    if has_new {
+                        let pixel_buf = unsafe {
+                            video_output.copyPixelBufferForItemTime_itemTimeForDisplay(
+                                item_time,
+                                std::ptr::null_mut(),
+                            )
+                        };
+                        if let Some(ref pb) = pixel_buf {
+                            if let Some(frame) = pixel_buffer_to_frame(id, pb) {
+                                let c = FRAME_COUNT.fetch_add(1, Ordering::Relaxed);
+                                if c % 30 == 0 {
+                                    log::debug!(
+                                        "[avf] p{}: frame #{c} ({}x{})",
+                                        id.0,
+                                        frame.width,
+                                        frame.height,
+                                    );
+                                }
+                                let _ = frame_tx.send(MediaEvent::Frame(frame));
+                            }
+                        }
+                    }
+
+                    // ── Fix 2: Drain run loop ──
+                    // AVPlayerItemVideoOutput's internal timing machinery
+                    // needs a run loop to advance. Drain it briefly.
+                    let rl = NSRunLoop::currentRunLoop();
+                    let until = NSDate::dateWithTimeIntervalSinceNow(0.008);
+                    rl.runUntilDate(&until);
+
+                    // Process one command (non-blocking).
+                    match cmd_rx.try_recv() {
+                        Ok(cmd) => match cmd {
+                            AvfCommand::Play => {
+                                log::info!("[avf] p{}: play", id.0);
+                                unsafe { player.play() };
+                            }
+                            AvfCommand::Pause => {
+                                log::info!("[avf] p{}: pause", id.0);
+                                unsafe { player.pause() };
+                            }
+                            AvfCommand::Seek(pos) => {
+                                log::info!("[avf] p{}: seek to {pos}s", id.0);
+                                let time = unsafe { CMTime::with_seconds(pos, CM_TIME_SCALE) };
+                                unsafe { player.seekToTime(time) };
+                            }
+                            AvfCommand::Destroy => {
+                                log::info!("[avf] p{}: destroy", id.0);
+                                destroyed_clone.store(true, Ordering::SeqCst);
+                                unsafe {
+                                    player.pause();
+                                    item.removeOutput(&video_output);
+                                    player.replaceCurrentItemWithPlayerItem(None);
+                                }
+                                return;
+                            }
+                        },
+                        Err(crossbeam_channel::TryRecvError::Empty) => {}
+                        Err(crossbeam_channel::TryRecvError::Disconnected) => {
+                            log::info!("[avf] p{}: cmd channel closed", id.0);
+                            return;
+                        }
+                    }
+                }
+            })
+            .map_err(|error| format!("failed to spawn AVFoundation thread: {error}"))?;
+
+        Ok(Self {
+            cmd_tx,
+            destroyed,
+            thread: Some(thread),
+        })
+    }
+}
+
+impl PipelineHandle for AvfPipeline {
+    fn play(&self) -> Result<(), String> {
+        self.cmd_tx
+            .send(AvfCommand::Play)
+            .map_err(|_| String::from("avf worker disconnected"))
+    }
+    fn pause(&self) -> Result<(), String> {
+        self.cmd_tx
+            .send(AvfCommand::Pause)
+            .map_err(|_| String::from("avf worker disconnected"))
+    }
+    fn seek(&self, position_secs: f64) -> Result<(), String> {
+        self.cmd_tx
+            .send(AvfCommand::Seek(position_secs))
+            .map_err(|_| String::from("avf worker disconnected"))
+    }
+    fn destroy(mut self) -> Result<(), String> {
+        let _ = self.cmd_tx.send(AvfCommand::Destroy);
+        if let Some(thread) = self.thread.take() {
+            let _ = thread.join();
+        }
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// CVPixelBuffer → VideoFrame
+// ---------------------------------------------------------------------------
+
+fn pixel_buffer_to_frame(pipeline_id: MediaPipelineId, buf: &CVPixelBuffer) -> Option<VideoFrame> {
+    use objc2_core_video::{
+        CVPixelBufferGetBaseAddress, CVPixelBufferGetBytesPerRow, CVPixelBufferGetHeight,
+        CVPixelBufferGetWidth, CVPixelBufferLockBaseAddress, CVPixelBufferLockFlags,
+        CVPixelBufferUnlockBaseAddress, kCVReturnSuccess,
+    };
+
+    unsafe {
+        let lock = CVPixelBufferLockFlags::ReadOnly;
+        if CVPixelBufferLockBaseAddress(buf, lock) != kCVReturnSuccess {
+            log::warn!("[avf] CVPixelBuffer lock failed");
+            return None;
+        }
+
+        let width = CVPixelBufferGetWidth(buf);
+        let height = CVPixelBufferGetHeight(buf);
+        let bpr = CVPixelBufferGetBytesPerRow(buf);
+        let base = CVPixelBufferGetBaseAddress(buf) as *const u8;
+
+        if width == 0 || height == 0 || base.is_null() {
+            let _ = CVPixelBufferUnlockBaseAddress(buf, CVPixelBufferLockFlags::ReadOnly);
+            return None;
+        }
+
+        let row_bytes = width * 4;
+        let mut data = Vec::with_capacity(height * row_bytes);
+        for row in 0..height {
+            let src = std::slice::from_raw_parts(base.add(row * bpr), row_bytes);
+            data.extend_from_slice(src);
+        }
+
+        CVPixelBufferUnlockBaseAddress(buf, CVPixelBufferLockFlags::ReadOnly);
+
+        Some(VideoFrame {
+            pipeline_id,
+            width: width as u32,
+            height: height as u32,
+            data,
+        })
+    }
+}

--- a/media/src/backend/avfoundation/pipeline.rs
+++ b/media/src/backend/avfoundation/pipeline.rs
@@ -1,12 +1,14 @@
-use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::cell::Cell;
 
 use crossbeam_channel::Sender;
+use objc2::MainThreadMarker;
 use objc2_foundation::{NSDate, NSRunLoop};
 
-use ipc_messages::media::{MediaEvent, MediaPipelineId};
+use ipc_messages::media::MediaPipelineId;
 
-use crate::backend::PipelineHandle;
+use objc2_av_foundation::AVPlayerItemStatus;
+
+use crate::backend::{BackendEvent, PipelineHandle};
 
 use super::av_sys::{
     AvPlayer, AvVideoOutput, PixelBufferLock, host_time_seconds, pixel_buffer_to_frame,
@@ -17,29 +19,24 @@ use super::av_sys::{
 // Constants
 // ---------------------------------------------------------------------------
 
-/// Frame poll interval — the run loop drains for this long each iteration.
-const POLL_SECS: f64 = 0.033; // ≈30 fps
-
-// ---------------------------------------------------------------------------
-// Command queue
-// ---------------------------------------------------------------------------
-
-enum AvfCommand {
-    Play,
-    Pause,
-    Seek(f64),
-    Destroy,
-}
+const TICK_SECS: f64 = 0.008;
 
 // ---------------------------------------------------------------------------
 // AvfPipeline
+//
+// Runs inside the select loop on the main thread.  tick() drains the run
+// loop so AVFoundation can service URL loading, KVO, and video output
+// timing.  Frames are sent as BackendEvent::Frame.
 // ---------------------------------------------------------------------------
 
 pub struct AvfPipeline {
-    cmd_tx: crossbeam_channel::Sender<AvfCommand>,
-    #[allow(dead_code)]
-    destroyed: Arc<AtomicBool>,
-    thread: Option<std::thread::JoinHandle<()>>,
+    id: MediaPipelineId,
+    player: AvPlayer,
+    item: super::av_sys::AvPlayerItem,
+    video_output: AvVideoOutput,
+    event_tx: Sender<BackendEvent>,
+    destroyed: Cell<bool>,
+    duration_reported: Cell<bool>,
 }
 
 static FRAME_COUNT: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
@@ -48,141 +45,107 @@ impl AvfPipeline {
     pub fn new(
         id: MediaPipelineId,
         url_string: String,
-        frame_tx: Sender<MediaEvent>,
+        event_tx: Sender<BackendEvent>,
     ) -> Result<Self, String> {
-        let (cmd_tx, cmd_rx) = crossbeam_channel::unbounded::<AvfCommand>();
-        let destroyed = Arc::new(AtomicBool::new(false));
-        let destroyed_clone = Arc::clone(&destroyed);
+        let mtm = MainThreadMarker::new()
+            .ok_or_else(|| String::from("AvfPipeline must be created on the main thread"))?;
 
-        let thread = std::thread::Builder::new()
-            .name("formal-web-avf-worker".into())
-            .spawn(move || {
-                // SAFETY: All AVPlayer/AVPlayerItem access is serialized on
-                // this dedicated thread via the command queue below.
-                let ns_url = url_from_string(&url_string).expect("NSURL creation failed");
-                let mut player = unsafe { AvPlayer::new(&ns_url) };
-                let item = player.current_item().expect("AVPlayer::currentItem");
-                let video_output = AvVideoOutput::new();
-                video_output.suppress_rendering();
-                item.add_output(&video_output);
-                player.pause();
+        let Some(ns_url) = url_from_string(&url_string) else {
+            return Err(format!("failed to create NSURL from {url_string}"));
+        };
+        let player = unsafe { AvPlayer::new_on_main(&ns_url, mtm) };
+        let Some(item) = player.current_item() else {
+            return Err(String::from("AVPlayer did not create an AVPlayerItem"));
+        };
+        let video_output = AvVideoOutput::new();
+        video_output.suppress_rendering();
+        item.add_output(&video_output);
+        player.pause();
 
-                log::info!("[avf] p{}: ready", id.0);
-
-                let mut duration_reported = false;
-
-                loop {
-                    // ── Run loop drives ALL timing ──
-                    // AVFoundation URL loading, KVO, and video output timing
-                    // all need continuous run loop time. Drain for POLL_SECS,
-                    // then process commands and poll frames.
-                    let rl = NSRunLoop::currentRunLoop();
-                    let until = NSDate::dateWithTimeIntervalSinceNow(POLL_SECS);
-                    rl.runUntilDate(&until);
-
-                    // ── Drain all pending commands ──
-                    loop {
-                        match cmd_rx.try_recv() {
-                            Ok(cmd) => match cmd {
-                                AvfCommand::Play => {
-                                    log::info!("[avf] p{}: play", id.0);
-                                    player.play();
-                                }
-                                AvfCommand::Pause => {
-                                    log::info!("[avf] p{}: pause", id.0);
-                                    player.pause();
-                                }
-                                AvfCommand::Seek(pos) => {
-                                    log::info!("[avf] p{}: seek to {pos}s", id.0);
-                                    player.seek(pos);
-                                }
-                                AvfCommand::Destroy => {
-                                    log::info!("[avf] p{}: destroy", id.0);
-                                    destroyed_clone.store(true, Ordering::SeqCst);
-                                    player.pause();
-                                    item.remove_output(&video_output);
-                                    player.clear_item();
-                                    return;
-                                }
-                            },
-                            Err(crossbeam_channel::TryRecvError::Empty) => break,
-                            Err(crossbeam_channel::TryRecvError::Disconnected) => {
-                                log::info!("[avf] p{}: cmd channel closed", id.0);
-                                return;
-                            }
-                        }
-                    }
-
-                    // ── Duration check (once) ──
-                    if !duration_reported {
-                        use objc2_av_foundation::AVPlayerItemStatus;
-                        let st = item.status();
-                        let st_num: i32 = st.0 as i32;
-                        log::info!("[avf] p{}: status={st_num}", id.0);
-                        if st == AVPlayerItemStatus::ReadyToPlay {
-                            let secs = item.duration_secs();
-                            if secs > 0.0 {
-                                log::info!("[avf] p{}: duration = {secs}s", id.0);
-                            }
-                            duration_reported = true;
-                        }
-                    }
-
-                    // ── Frame poll ──
-                    let host_secs = host_time_seconds();
-                    let item_time = video_output.item_time_for_host_time(host_secs);
-
-                    if video_output.has_new_pixel_buffer(item_time) {
-                        if let Some(pixel_buf) = video_output.copy_pixel_buffer(item_time) {
-                            if let Some(lock) = PixelBufferLock::new(&pixel_buf) {
-                                if let Some(frame) = pixel_buffer_to_frame(id, &lock) {
-                                    let c = FRAME_COUNT.fetch_add(1, Ordering::Relaxed);
-                                    if c % 30 == 0 {
-                                        log::debug!(
-                                            "[avf] p{}: frame #{c} ({}x{})",
-                                            id.0,
-                                            frame.width,
-                                            frame.height,
-                                        );
-                                    }
-                                    let _ = frame_tx.send(MediaEvent::Frame(frame));
-                                }
-                            }
-                        }
-                    }
-                }
-            })
-            .map_err(|error| format!("failed to spawn AVFoundation thread: {error}"))?;
+        log::info!("[avf] p{}: created", id.0);
 
         Ok(Self {
-            cmd_tx,
-            destroyed,
-            thread: Some(thread),
+            id,
+            player,
+            item,
+            video_output,
+            event_tx,
+            destroyed: Cell::new(false),
+            duration_reported: Cell::new(false),
         })
     }
 }
 
 impl PipelineHandle for AvfPipeline {
     fn play(&self) -> Result<(), String> {
-        self.cmd_tx
-            .send(AvfCommand::Play)
-            .map_err(|_| String::from("avf worker disconnected"))
+        log::info!("[avf] p{}: play", self.id.0);
+        self.player.play();
+        Ok(())
     }
+
     fn pause(&self) -> Result<(), String> {
-        self.cmd_tx
-            .send(AvfCommand::Pause)
-            .map_err(|_| String::from("avf worker disconnected"))
+        log::info!("[avf] p{}: pause", self.id.0);
+        self.player.pause();
+        Ok(())
     }
+
     fn seek(&self, position_secs: f64) -> Result<(), String> {
-        self.cmd_tx
-            .send(AvfCommand::Seek(position_secs))
-            .map_err(|_| String::from("avf worker disconnected"))
+        log::info!("[avf] p{}: seek to {position_secs}s", self.id.0);
+        self.player.seek(position_secs);
+        Ok(())
     }
-    fn destroy(mut self) -> Result<(), String> {
-        let _ = self.cmd_tx.send(AvfCommand::Destroy);
-        if let Some(thread) = self.thread.take() {
-            let _ = thread.join();
+
+    fn tick(&self) {
+        if self.destroyed.get() {
+            return;
         }
+
+        // Drain run loop so AVFoundation can service URL loading etc.
+        let rl = NSRunLoop::currentRunLoop();
+        let until = NSDate::dateWithTimeIntervalSinceNow(TICK_SECS);
+        rl.runUntilDate(&until);
+
+        // Duration check (once).
+        if !self.duration_reported.get() {
+            if self.item.status() == AVPlayerItemStatus::ReadyToPlay {
+                let secs = self.item.duration_secs();
+                if secs > 0.0 {
+                    log::info!("[avf] p{}: duration = {secs}s", self.id.0);
+                }
+                self.duration_reported.set(true);
+            }
+        }
+
+        // Frame poll.
+        let host_secs = host_time_seconds();
+        let item_time = self.video_output.item_time_for_host_time(host_secs);
+
+        if self.video_output.has_new_pixel_buffer(item_time) {
+            if let Some(pixel_buf) = self.video_output.copy_pixel_buffer(item_time) {
+                if let Some(lock) = PixelBufferLock::new(&pixel_buf) {
+                    if let Some(frame) = pixel_buffer_to_frame(self.id, &lock) {
+                        let c = FRAME_COUNT.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                        if c % 30 == 0 {
+                            log::debug!(
+                                "[avf] p{}: frame #{c} ({}x{})",
+                                self.id.0,
+                                frame.width,
+                                frame.height,
+                            );
+                        }
+                        let _ = self.event_tx.send(BackendEvent::Frame(frame));
+                    }
+                }
+            }
+        }
+    }
+
+    fn destroy(self) -> Result<(), String> {
+        log::info!("[avf] p{}: destroy", self.id.0);
+        self.destroyed.set(true);
+        self.player.pause();
+        self.item.remove_output(&self.video_output);
+        self.player.clear_item();
         Ok(())
     }
 }

--- a/media/src/backend/avfoundation/pipeline.rs
+++ b/media/src/backend/avfoundation/pipeline.rs
@@ -2,31 +2,18 @@ use std::cell::Cell;
 
 use crossbeam_channel::Sender;
 use objc2::MainThreadMarker;
-use objc2_foundation::{NSDate, NSRunLoop};
 
 use ipc_messages::media::MediaPipelineId;
 
-use objc2_av_foundation::AVPlayerItemStatus;
-
 use crate::backend::{BackendEvent, PipelineHandle};
 
-use super::av_sys::{
-    AvPlayer, AvVideoOutput, PixelBufferLock, host_time_seconds, pixel_buffer_to_frame,
-    url_from_string,
-};
-
-// ---------------------------------------------------------------------------
-// Constants
-// ---------------------------------------------------------------------------
-
-const TICK_SECS: f64 = 0.008;
+use super::av_sys::{AvPlayer, AvVideoOutput, url_from_string};
 
 // ---------------------------------------------------------------------------
 // AvfPipeline
 //
-// Runs inside the select loop on the main thread.  tick() drains the run
-// loop so AVFoundation can service URL loading, KVO, and video output
-// timing.  Frames are sent as BackendEvent::Frame.
+// Runs inside the select loop on the main thread.
+// Frames are sent as BackendEvent::Frame.
 // ---------------------------------------------------------------------------
 
 pub struct AvfPipeline {
@@ -38,8 +25,6 @@ pub struct AvfPipeline {
     destroyed: Cell<bool>,
     duration_reported: Cell<bool>,
 }
-
-static FRAME_COUNT: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
 
 impl AvfPipeline {
     pub fn new(
@@ -95,19 +80,20 @@ impl PipelineHandle for AvfPipeline {
         Ok(())
     }
 
-    fn tick(&self) {
+    fn sample(&self) {
         if self.destroyed.get() {
             return;
         }
 
-        // Drain run loop so AVFoundation can service URL loading etc.
-        let rl = NSRunLoop::currentRunLoop();
-        let until = NSDate::dateWithTimeIntervalSinceNow(TICK_SECS);
+        // Drain run loop so AVFoundation can service URL loading,
+        // KVO, and video output timing.
+        let rl = objc2_foundation::NSRunLoop::currentRunLoop();
+        let until = objc2_foundation::NSDate::dateWithTimeIntervalSinceNow(0.008);
         rl.runUntilDate(&until);
 
         // Duration check (once).
         if !self.duration_reported.get() {
-            if self.item.status() == AVPlayerItemStatus::ReadyToPlay {
+            if self.item.status() == objc2_av_foundation::AVPlayerItemStatus::ReadyToPlay {
                 let secs = self.item.duration_secs();
                 if secs > 0.0 {
                     log::info!("[avf] p{}: duration = {secs}s", self.id.0);
@@ -116,24 +102,18 @@ impl PipelineHandle for AvfPipeline {
             }
         }
 
-        // Frame poll.
-        let host_secs = host_time_seconds();
+        // Poll for frames.
+        let host_secs = super::av_sys::time::host_time_seconds();
         let item_time = self.video_output.item_time_for_host_time(host_secs);
-
         if self.video_output.has_new_pixel_buffer(item_time) {
             if let Some(pixel_buf) = self.video_output.copy_pixel_buffer(item_time) {
-                if let Some(lock) = PixelBufferLock::new(&pixel_buf) {
-                    if let Some(frame) = pixel_buffer_to_frame(self.id, &lock) {
-                        let c = FRAME_COUNT.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                        if c % 30 == 0 {
-                            log::debug!(
-                                "[avf] p{}: frame #{c} ({}x{})",
-                                self.id.0,
-                                frame.width,
-                                frame.height,
-                            );
-                        }
-                        let _ = self.event_tx.send(BackendEvent::Frame(frame));
+                if let Some(lock) = super::av_sys::pixel_buffer::PixelBufferLock::new(pixel_buf) {
+                    if let Some(frame) =
+                        super::av_sys::pixel_buffer::pixel_buffer_to_frame(self.id, &lock)
+                    {
+                        let _ = self
+                            .event_tx
+                            .send(crate::backend::BackendEvent::Frame(frame));
                     }
                 }
             }

--- a/media/src/backend/gstreamer/mod.rs
+++ b/media/src/backend/gstreamer/mod.rs
@@ -1,0 +1,43 @@
+mod pipeline;
+pub use pipeline::GstPipeline;
+
+use crate::backend::{BackendEvent, MediaBackend};
+use crossbeam_channel::Sender;
+use gstreamer as gst;
+use ipc_messages::media::{MediaEvent, MediaPipelineId};
+
+pub struct GStreamerBackend {
+    event_tx: crossbeam_channel::Sender<BackendEvent>,
+    event_rx: crossbeam_channel::Receiver<BackendEvent>,
+}
+
+impl MediaBackend for GStreamerBackend {
+    type Pipeline = GstPipeline;
+
+    fn init() -> Result<Self, String> {
+        // On macOS, ensure NSApplication is set up on the main thread before any
+        // GStreamer GL elements are created.
+        #[cfg(target_os = "macos")]
+        gst::macos_main(|| {});
+
+        if gst::init().is_err() {
+            return Err(String::from("GStreamer initialization failed"));
+        }
+
+        let (event_tx, event_rx) = crossbeam_channel::unbounded::<BackendEvent>();
+        Ok(Self { event_tx, event_rx })
+    }
+
+    fn create_pipeline(
+        &mut self,
+        id: MediaPipelineId,
+        url: String,
+        frame_tx: Sender<MediaEvent>,
+    ) -> Result<Self::Pipeline, String> {
+        GstPipeline::new(id, url, frame_tx, self.event_tx.clone())
+    }
+
+    fn event_receiver(&self) -> crossbeam_channel::Receiver<BackendEvent> {
+        self.event_rx.clone()
+    }
+}

--- a/media/src/backend/gstreamer/mod.rs
+++ b/media/src/backend/gstreamer/mod.rs
@@ -2,9 +2,8 @@ mod pipeline;
 pub use pipeline::GstPipeline;
 
 use crate::backend::{BackendEvent, MediaBackend};
-use crossbeam_channel::Sender;
 use gstreamer as gst;
-use ipc_messages::media::{MediaEvent, MediaPipelineId};
+use ipc_messages::media::MediaPipelineId;
 
 pub struct GStreamerBackend {
     event_tx: crossbeam_channel::Sender<BackendEvent>,
@@ -32,9 +31,8 @@ impl MediaBackend for GStreamerBackend {
         &mut self,
         id: MediaPipelineId,
         url: String,
-        frame_tx: Sender<MediaEvent>,
     ) -> Result<Self::Pipeline, String> {
-        GstPipeline::new(id, url, frame_tx, self.event_tx.clone())
+        GstPipeline::new(id, url, self.event_tx.clone())
     }
 
     fn event_receiver(&self) -> crossbeam_channel::Receiver<BackendEvent> {

--- a/media/src/backend/gstreamer/pipeline.rs
+++ b/media/src/backend/gstreamer/pipeline.rs
@@ -2,9 +2,9 @@ use crossbeam_channel::Sender;
 use gstreamer as gst;
 use gstreamer::prelude::*;
 use gstreamer_app as gst_app;
-use ipc_messages::media::{MediaEvent, MediaPipelineId, VideoFrame};
+use ipc_messages::media::{MediaPipelineId, VideoFrame};
 
-use crate::backend::PipelineHandle;
+use crate::backend::{BackendEvent, PipelineHandle};
 
 pub struct GstPipeline {
     element: gst::Pipeline,
@@ -14,8 +14,7 @@ impl GstPipeline {
     pub fn new(
         id: MediaPipelineId,
         url: String,
-        event_sender: Sender<MediaEvent>,
-        backend_event_sender: crossbeam_channel::Sender<crate::backend::BackendEvent>,
+        backend_event_tx: Sender<BackendEvent>,
     ) -> Result<Self, String> {
         let pipeline = gst::Pipeline::new();
 
@@ -67,6 +66,7 @@ impl GstPipeline {
         });
 
         // Frame callback — fires on the GStreamer streaming thread.
+        let frame_tx = backend_event_tx.clone();
         appsink.set_callbacks(
             gst_app::AppSinkCallbacks::builder()
                 .new_sample(move |sink| {
@@ -107,14 +107,13 @@ impl GstPipeline {
                             height,
                         );
                     }
-                    let _ = event_sender.send(MediaEvent::Frame(frame));
+                    let _ = frame_tx.send(BackendEvent::Frame(frame));
                     Ok(gst::FlowSuccess::Ok)
                 })
                 .build(),
         );
 
         // Route bus messages to BackendEvent via sync handler.
-        // Clone the pipeline element so the closure can query duration.
         let pipeline_for_bus = pipeline.clone();
         let bus = pipeline
             .bus()
@@ -122,23 +121,20 @@ impl GstPipeline {
         bus.set_sync_handler(move |_bus, message| {
             match message.view() {
                 gst::MessageView::Eos(..) => {
-                    let _ = backend_event_sender
-                        .send(crate::backend::BackendEvent::Eos { pipeline_id: id });
+                    let _ = backend_event_tx.send(BackendEvent::Eos { pipeline_id: id });
                 }
                 gst::MessageView::Error(error) => {
-                    let _ = backend_event_sender.send(crate::backend::BackendEvent::Error {
+                    let _ = backend_event_tx.send(BackendEvent::Error {
                         pipeline_id: id,
                         message: error.error().to_string(),
                     });
                 }
                 gst::MessageView::DurationChanged(..) => {
                     if let Some(duration) = pipeline_for_bus.query_duration::<gst::ClockTime>() {
-                        let _ = backend_event_sender.send(
-                            crate::backend::BackendEvent::DurationChanged {
-                                pipeline_id: id,
-                                duration_secs: duration.seconds_f64(),
-                            },
-                        );
+                        let _ = backend_event_tx.send(BackendEvent::DurationChanged {
+                            pipeline_id: id,
+                            duration_secs: duration.seconds_f64(),
+                        });
                     }
                 }
                 _ => {}

--- a/media/src/backend/gstreamer/pipeline.rs
+++ b/media/src/backend/gstreamer/pipeline.rs
@@ -4,16 +4,18 @@ use gstreamer::prelude::*;
 use gstreamer_app as gst_app;
 use ipc_messages::media::{MediaEvent, MediaPipelineId, VideoFrame};
 
-pub(crate) struct ManagedPipeline {
-    pub element: gst::Pipeline,
+use crate::backend::PipelineHandle;
+
+pub struct GstPipeline {
+    element: gst::Pipeline,
 }
 
-impl ManagedPipeline {
+impl GstPipeline {
     pub fn new(
         id: MediaPipelineId,
         url: String,
         event_sender: Sender<MediaEvent>,
-        bus_msg_sender: crossbeam_channel::Sender<(MediaPipelineId, gst::Message)>,
+        backend_event_sender: crossbeam_channel::Sender<crate::backend::BackendEvent>,
     ) -> Result<Self, String> {
         let pipeline = gst::Pipeline::new();
 
@@ -29,9 +31,9 @@ impl ManagedPipeline {
 
         src.set_property_from_str("uri", &url);
         pipeline
-            .add_many(&[&src, &conv, &sink])
+            .add_many([&src, &conv, &sink])
             .map_err(|error| format!("failed to add elements to pipeline: {error}"))?;
-        gst::Element::link_many(&[&conv, &sink])
+        gst::Element::link_many([&conv, &sink])
             .map_err(|error| format!("failed to link elements: {error}"))?;
 
         // Force RGBA so the compositor can pass it directly.
@@ -79,13 +81,15 @@ impl ManagedPipeline {
                     let Some(caps) = sample.caps() else {
                         return Err(gst::FlowError::Error);
                     };
-                    let Some(s) = caps.structure(0) else {
+                    let Some(structure) = caps.structure(0) else {
                         return Err(gst::FlowError::Error);
                     };
-                    let width: i32 = s.get("width").map_err(|_| gst::FlowError::Error)?;
-                    let height: i32 = s.get("height").map_err(|_| gst::FlowError::Error)?;
+                    let width: i32 = structure.get("width").map_err(|_| gst::FlowError::Error)?;
+                    let height: i32 = structure.get("height").map_err(|_| gst::FlowError::Error)?;
                     let map = buffer.map_readable().map_err(|_| gst::FlowError::Error)?;
 
+                    use std::sync::atomic::{AtomicU64, Ordering};
+                    static G_FRAME_COUNT: AtomicU64 = AtomicU64::new(0);
                     let frame = VideoFrame {
                         pipeline_id: id,
                         width: width as u32,
@@ -93,18 +97,52 @@ impl ManagedPipeline {
                         data: map.as_slice().to_vec(),
                     };
 
+                    let count = G_FRAME_COUNT.fetch_add(1, Ordering::Relaxed);
+                    if count % 30 == 0 {
+                        log::debug!(
+                            "[gst] pipeline {:?}: frame #{} ({}x{})",
+                            id,
+                            count,
+                            width,
+                            height,
+                        );
+                    }
                     let _ = event_sender.send(MediaEvent::Frame(frame));
                     Ok(gst::FlowSuccess::Ok)
                 })
                 .build(),
         );
 
-        // Route bus messages to the shared crossbeam channel via sync handler.
+        // Route bus messages to BackendEvent via sync handler.
+        // Clone the pipeline element so the closure can query duration.
+        let pipeline_for_bus = pipeline.clone();
         let bus = pipeline
             .bus()
             .ok_or_else(|| String::from("failed to get GStreamer bus"))?;
         bus.set_sync_handler(move |_bus, message| {
-            let _ = bus_msg_sender.send((id, message.to_owned()));
+            match message.view() {
+                gst::MessageView::Eos(..) => {
+                    let _ = backend_event_sender
+                        .send(crate::backend::BackendEvent::Eos { pipeline_id: id });
+                }
+                gst::MessageView::Error(error) => {
+                    let _ = backend_event_sender.send(crate::backend::BackendEvent::Error {
+                        pipeline_id: id,
+                        message: error.error().to_string(),
+                    });
+                }
+                gst::MessageView::DurationChanged(..) => {
+                    if let Some(duration) = pipeline_for_bus.query_duration::<gst::ClockTime>() {
+                        let _ = backend_event_sender.send(
+                            crate::backend::BackendEvent::DurationChanged {
+                                pipeline_id: id,
+                                duration_secs: duration.seconds_f64(),
+                            },
+                        );
+                    }
+                }
+                _ => {}
+            }
             gst::BusSyncReply::Drop
         });
 
@@ -113,5 +151,35 @@ impl ManagedPipeline {
             .map_err(|error| format!("failed to set pipeline to paused: {error}"))?;
 
         Ok(Self { element: pipeline })
+    }
+}
+
+impl PipelineHandle for GstPipeline {
+    fn play(&self) -> Result<(), String> {
+        self.element
+            .set_state(gst::State::Playing)
+            .map(|_| ())
+            .map_err(|error| format!("failed to play pipeline: {error}"))
+    }
+
+    fn pause(&self) -> Result<(), String> {
+        self.element
+            .set_state(gst::State::Paused)
+            .map(|_| ())
+            .map_err(|error| format!("failed to pause pipeline: {error}"))
+    }
+
+    fn seek(&self, position_secs: f64) -> Result<(), String> {
+        let position = gst::ClockTime::from_seconds_f64(position_secs);
+        self.element
+            .seek_simple(gst::SeekFlags::FLUSH | gst::SeekFlags::KEY_UNIT, position)
+            .map_err(|error| format!("failed to seek pipeline: {error}"))
+    }
+
+    fn destroy(self) -> Result<(), String> {
+        self.element
+            .set_state(gst::State::Null)
+            .map(|_| ())
+            .map_err(|error| format!("failed to destroy pipeline: {error}"))
     }
 }

--- a/media/src/backend/mod.rs
+++ b/media/src/backend/mod.rs
@@ -56,9 +56,9 @@ pub trait PipelineHandle: Send + 'static {
     /// Seek to an absolute position in seconds.
     fn seek(&self, position_secs: f64) -> Result<(), String>;
 
-    /// Called once per select-loop iteration.  Backends can pump run loops,
-    /// poll for frames, etc.  Default is a no-op.
-    fn tick(&self) {}
+    /// Called at a fixed rate by the select loop.  Backends use this to
+    /// pump run loops, poll for frames, etc.  Default is a no-op.
+    fn sample(&self) {}
 
     /// Tear down cleanly. Takes self by value so the backend's drop logic applies
     /// without Option gymnastics in the pipeline map.
@@ -90,9 +90,6 @@ pub trait MediaBackend: Send + 'static {
     /// Returns the receiver for backend-originated events (BusEvent → BackendEvent
     /// conversion happens inside the backend). Called once before the select loop.
     fn event_receiver(&self) -> crossbeam_channel::Receiver<BackendEvent>;
-
-    /// Called once per select-loop iteration.  Default is a no-op.
-    fn tick(&mut self) {}
 }
 
 // ---------------------------------------------------------------------------

--- a/media/src/backend/mod.rs
+++ b/media/src/backend/mod.rs
@@ -1,0 +1,96 @@
+use ipc_messages::media::MediaEvent;
+use ipc_messages::media::MediaPipelineId;
+
+// ---------------------------------------------------------------------------
+// Compile-time guard: exactly one backend feature must be active.
+// ---------------------------------------------------------------------------
+
+#[cfg(not(any(feature = "backend-gstreamer", feature = "backend-avfoundation")))]
+compile_error!(
+    "Exactly one media backend feature must be enabled: \
+     backend-gstreamer or backend-avfoundation"
+);
+
+#[cfg(all(feature = "backend-gstreamer", feature = "backend-avfoundation"))]
+compile_error!(
+    "Only one media backend feature can be enabled at a time: \
+     backend-gstreamer or backend-avfoundation"
+);
+
+// ---------------------------------------------------------------------------
+// BackendEvent — backend-agnostic event delivered from the backend's
+// notification mechanism (GStreamer bus, AVFoundation KVO/notifications) to
+// the generic dispatch loop.
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone)]
+pub enum BackendEvent {
+    /// The pipeline reached end of stream.
+    Eos { pipeline_id: MediaPipelineId },
+    /// An unrecoverable error occurred in the backend.
+    Error {
+        pipeline_id: MediaPipelineId,
+        message: String,
+    },
+    /// The media duration became known (seconds).
+    DurationChanged {
+        pipeline_id: MediaPipelineId,
+        duration_secs: f64,
+    },
+}
+
+// ---------------------------------------------------------------------------
+// PipelineHandle — one running media pipeline.
+// ---------------------------------------------------------------------------
+
+pub trait PipelineHandle: Send + 'static {
+    /// Transition to Playing.
+    fn play(&self) -> Result<(), String>;
+
+    /// Transition to Paused.
+    fn pause(&self) -> Result<(), String>;
+
+    /// Seek to an absolute position in seconds.
+    fn seek(&self, position_secs: f64) -> Result<(), String>;
+
+    /// Tear down cleanly. Takes self by value so the backend's drop logic applies
+    /// without Option gymnastics in the pipeline map.
+    fn destroy(self) -> Result<(), String>;
+}
+
+// ---------------------------------------------------------------------------
+// MediaBackend — factory and event source.
+// ---------------------------------------------------------------------------
+
+pub trait MediaBackend: Send + 'static {
+    /// The concrete pipeline handle type for this backend.
+    type Pipeline: PipelineHandle;
+
+    /// One-time initialization: gst::init + macos_main, AVAudioSession setup, etc.
+    fn init() -> Result<Self, String>
+    where
+        Self: Sized;
+
+    /// Create a pipeline for the given URL. The pipeline should start in the
+    /// Paused state. Decoded video frames are sent on `frame_tx`.
+    fn create_pipeline(
+        &mut self,
+        id: MediaPipelineId,
+        url: String,
+        frame_tx: crossbeam_channel::Sender<MediaEvent>,
+    ) -> Result<Self::Pipeline, String>;
+
+    /// Returns the receiver for backend-originated events (BusEvent → BackendEvent
+    /// conversion happens inside the backend). Called once before the select loop.
+    fn event_receiver(&self) -> crossbeam_channel::Receiver<BackendEvent>;
+}
+
+// ---------------------------------------------------------------------------
+// Backend modules — gated by Cargo features.
+// ---------------------------------------------------------------------------
+
+#[cfg(feature = "backend-gstreamer")]
+pub mod gstreamer;
+
+#[cfg(feature = "backend-avfoundation")]
+pub mod avfoundation;

--- a/media/src/backend/mod.rs
+++ b/media/src/backend/mod.rs
@@ -1,4 +1,3 @@
-use ipc_messages::media::MediaEvent;
 use ipc_messages::media::MediaPipelineId;
 
 // ---------------------------------------------------------------------------
@@ -23,8 +22,12 @@ compile_error!(
 // the generic dispatch loop.
 // ---------------------------------------------------------------------------
 
+use ipc_messages::media::VideoFrame;
+
 #[derive(Debug, Clone)]
 pub enum BackendEvent {
+    /// A decoded video frame is ready.
+    Frame(VideoFrame),
     /// The pipeline reached end of stream.
     Eos { pipeline_id: MediaPipelineId },
     /// An unrecoverable error occurred in the backend.
@@ -53,6 +56,10 @@ pub trait PipelineHandle: Send + 'static {
     /// Seek to an absolute position in seconds.
     fn seek(&self, position_secs: f64) -> Result<(), String>;
 
+    /// Called once per select-loop iteration.  Backends can pump run loops,
+    /// poll for frames, etc.  Default is a no-op.
+    fn tick(&self) {}
+
     /// Tear down cleanly. Takes self by value so the backend's drop logic applies
     /// without Option gymnastics in the pipeline map.
     fn destroy(self) -> Result<(), String>;
@@ -72,17 +79,20 @@ pub trait MediaBackend: Send + 'static {
         Self: Sized;
 
     /// Create a pipeline for the given URL. The pipeline should start in the
-    /// Paused state. Decoded video frames are sent on `frame_tx`.
+    /// Paused state. Decoded video frames are sent via `event_receiver`
+    /// as `BackendEvent::Frame`.
     fn create_pipeline(
         &mut self,
         id: MediaPipelineId,
         url: String,
-        frame_tx: crossbeam_channel::Sender<MediaEvent>,
     ) -> Result<Self::Pipeline, String>;
 
     /// Returns the receiver for backend-originated events (BusEvent → BackendEvent
     /// conversion happens inside the backend). Called once before the select loop.
     fn event_receiver(&self) -> crossbeam_channel::Receiver<BackendEvent>;
+
+    /// Called once per select-loop iteration.  Default is a no-op.
+    fn tick(&mut self) {}
 }
 
 // ---------------------------------------------------------------------------

--- a/media/src/lib.rs
+++ b/media/src/lib.rs
@@ -31,6 +31,8 @@ pub fn run_media_process<B: MediaBackend>(
 ) {
     let backend_event_rx = backend.event_receiver();
     let mut pipelines: HashMap<MediaPipelineId, B::Pipeline> = HashMap::new();
+    // Timer at ≈120 Hz drives backend sampling (run-loop drain, frame poll).
+    let sample_tick = crossbeam_channel::tick(std::time::Duration::from_millis(8));
 
     loop {
         crossbeam_channel::select! {
@@ -58,13 +60,11 @@ pub fn run_media_process<B: MediaBackend>(
                     Err(_) => break,
                 }
             }
-        }
-
-        // Allow backends to tick (run-loop drain, frame poll, etc.) after
-        // each message is processed.
-        backend.tick();
-        for pipeline in pipelines.values() {
-            pipeline.tick();
+            recv(sample_tick) -> _ => {
+                for pipeline in pipelines.values() {
+                    pipeline.sample();
+                }
+            }
         }
     }
 

--- a/media/src/lib.rs
+++ b/media/src/lib.rs
@@ -1,12 +1,14 @@
-mod managed_pipeline;
+pub mod backend;
 
-use gstreamer as gst;
-use gstreamer::prelude::*;
+use backend::{BackendEvent, MediaBackend, PipelineHandle};
 use ipc::ExtensionEndpoint;
 use ipc_messages::media::{MediaCommand, MediaEvent, MediaPipelineId};
-use managed_pipeline::ManagedPipeline;
 use std::collections::HashMap;
 use std::env;
+
+// ---------------------------------------------------------------------------
+// IPC manifest
+// ---------------------------------------------------------------------------
 
 struct MediaExtensionManifest;
 
@@ -18,29 +20,19 @@ impl ipc::ExtensionManifest for MediaExtensionManifest {
     }
 }
 
-pub fn run_media_process(
+// ---------------------------------------------------------------------------
+// Generic run loop
+// ---------------------------------------------------------------------------
+
+pub fn run_media_process<B: MediaBackend>(
+    mut backend: B,
     cmd_rx: crossbeam_channel::Receiver<ipc::IpcIncoming<MediaCommand>>,
-    event_tx: crossbeam_channel::Sender<MediaEvent>,
-    event_rx: crossbeam_channel::Receiver<MediaEvent>,
+    frame_tx: crossbeam_channel::Sender<MediaEvent>,
+    frame_rx: crossbeam_channel::Receiver<MediaEvent>,
     ipc_event_tx: ipc::IpcSender<MediaEvent>,
 ) {
-    // On macOS, ensure NSApplication is set up on the main thread before any
-    // GStreamer GL elements are created. This avoids the "An NSApplication needs
-    // to be running on the main thread" warning.
-    #[cfg(target_os = "macos")]
-    gst::macos_main(|| {});
-
-    if gst::init().is_err() {
-        log::error!("GStreamer initialization failed");
-        return;
-    }
-
-    // Shared channel for GStreamer bus messages from all pipelines.
-    // Each pipeline's sync handler sends (pipeline_id, message) here.
-    let (bus_msg_sender, bus_msg_receiver) =
-        crossbeam_channel::unbounded::<(MediaPipelineId, gst::Message)>();
-
-    let mut pipelines: HashMap<MediaPipelineId, ManagedPipeline> = HashMap::new();
+    let backend_event_rx = backend.event_receiver();
+    let mut pipelines: HashMap<MediaPipelineId, B::Pipeline> = HashMap::new();
 
     loop {
         crossbeam_channel::select! {
@@ -49,9 +41,9 @@ pub fn run_media_process(
                     Ok(incoming) => {
                         if handle_command(
                             incoming.payload,
+                            &mut backend,
                             &mut pipelines,
-                            &event_tx,
-                            &bus_msg_sender,
+                            &frame_tx,
                         ) {
                             break; // Shutdown received
                         }
@@ -59,15 +51,12 @@ pub fn run_media_process(
                     Err(_) => break, // command channel disconnected
                 }
             }
-            recv(bus_msg_receiver) -> msg => {
-                match msg {
-                    Ok((pipeline_id, bus_msg)) => {
-                        handle_bus_message(&pipeline_id, &bus_msg, &pipelines, &event_tx);
-                    }
-                    Err(_) => {} // bus message channel disconnected (should not happen)
+            recv(backend_event_rx) -> event => {
+                if let Ok(backend_event) = event {
+                    handle_backend_event(backend_event, &frame_tx);
                 }
             }
-            recv(event_rx) -> event => {
+            recv(frame_rx) -> event => {
                 let Ok(event) = event else { break; };
                 match event {
                     MediaEvent::Frame(mut video_frame) => {
@@ -93,58 +82,60 @@ pub fn run_media_process(
 
     // Clean up remaining pipelines on shutdown.
     for (_, pipeline) in pipelines.drain() {
-        if let Err(error) = pipeline.element.set_state(gst::State::Null) {
+        if let Err(error) = pipeline.destroy() {
             log::error!("failed to destroy pipeline during shutdown: {error}");
         }
     }
 }
 
-fn handle_bus_message(
-    pipeline_id: &MediaPipelineId,
-    msg: &gst::Message,
-    pipelines: &HashMap<MediaPipelineId, ManagedPipeline>,
-    event_tx: &crossbeam_channel::Sender<MediaEvent>,
-) {
-    match msg.view() {
-        gst::MessageView::Eos(..) => {
-            let _ = event_tx.send(MediaEvent::Eos {
-                pipeline_id: *pipeline_id,
-            });
+// ---------------------------------------------------------------------------
+// Backend event dispatch
+// ---------------------------------------------------------------------------
+
+fn handle_backend_event(event: BackendEvent, event_tx: &crossbeam_channel::Sender<MediaEvent>) {
+    match event {
+        BackendEvent::Eos { pipeline_id } => {
+            let _ = event_tx.send(MediaEvent::Eos { pipeline_id });
         }
-        gst::MessageView::Error(error) => {
+        BackendEvent::Error {
+            pipeline_id,
+            message,
+        } => {
             let _ = event_tx.send(MediaEvent::Error {
-                pipeline_id: *pipeline_id,
-                message: error.error().to_string(),
+                pipeline_id,
+                message,
             });
         }
-        gst::MessageView::DurationChanged(..) => {
-            if let Some(pipeline) = pipelines.get(pipeline_id) {
-                if let Some(dur) = pipeline.element.query_duration::<gst::ClockTime>() {
-                    let _ = event_tx.send(MediaEvent::DurationChanged {
-                        pipeline_id: *pipeline_id,
-                        duration_secs: dur.seconds_f64(),
-                    });
-                }
-            }
+        BackendEvent::DurationChanged {
+            pipeline_id,
+            duration_secs,
+        } => {
+            let _ = event_tx.send(MediaEvent::DurationChanged {
+                pipeline_id,
+                duration_secs,
+            });
         }
-        _ => {}
     }
 }
 
+// ---------------------------------------------------------------------------
+// Command dispatch
+// ---------------------------------------------------------------------------
+
 /// Returns `true` if the loop should exit (Shutdown received).
-fn handle_command(
+fn handle_command<B: MediaBackend>(
     cmd: MediaCommand,
-    pipelines: &mut HashMap<MediaPipelineId, ManagedPipeline>,
+    backend: &mut B,
+    pipelines: &mut HashMap<MediaPipelineId, B::Pipeline>,
     event_tx: &crossbeam_channel::Sender<MediaEvent>,
-    bus_msg_sender: &crossbeam_channel::Sender<(MediaPipelineId, gst::Message)>,
 ) -> bool {
     match cmd {
         MediaCommand::CreatePipeline { pipeline_id, url } => {
             log::info!("[media] creating pipeline id={:?} url={}", pipeline_id, url);
-            match ManagedPipeline::new(pipeline_id, url, event_tx.clone(), bus_msg_sender.clone()) {
-                Ok(p) => {
+            match backend.create_pipeline(pipeline_id, url, event_tx.clone()) {
+                Ok(pipeline) => {
                     log::info!("[media] pipeline created id={:?}", pipeline_id);
-                    pipelines.insert(pipeline_id, p);
+                    pipelines.insert(pipeline_id, pipeline);
                 }
                 Err(error) => {
                     log::error!("[media] failed to create media pipeline {pipeline_id:?}: {error}");
@@ -157,38 +148,34 @@ fn handle_command(
         }
         MediaCommand::Play { pipeline_id } => {
             log::info!("[media] playing pipeline id={:?}", pipeline_id);
-            if let Some(p) = pipelines.get(&pipeline_id) {
-                if let Err(error) = p.element.set_state(gst::State::Playing) {
-                    log::error!("[media] failed to play pipeline {pipeline_id:?}: {error}");
-                }
+            if let Some(pipeline) = pipelines.get(&pipeline_id)
+                && let Err(error) = pipeline.play()
+            {
+                log::error!("[media] failed to play pipeline {pipeline_id:?}: {error}");
             }
         }
         MediaCommand::Pause { pipeline_id } => {
-            if let Some(p) = pipelines.get(&pipeline_id) {
-                if let Err(error) = p.element.set_state(gst::State::Paused) {
-                    log::error!("failed to pause pipeline {pipeline_id:?}: {error}");
-                }
+            if let Some(pipeline) = pipelines.get(&pipeline_id)
+                && let Err(error) = pipeline.pause()
+            {
+                log::error!("failed to pause pipeline {pipeline_id:?}: {error}");
             }
         }
         MediaCommand::Seek {
             pipeline_id,
             position_secs,
         } => {
-            if let Some(p) = pipelines.get(&pipeline_id) {
-                let pos = gst::ClockTime::from_seconds_f64(position_secs);
-                if let Err(error) = p
-                    .element
-                    .seek_simple(gst::SeekFlags::FLUSH | gst::SeekFlags::KEY_UNIT, pos)
-                {
-                    log::error!("failed to seek pipeline {pipeline_id:?}: {error}");
-                }
+            if let Some(pipeline) = pipelines.get(&pipeline_id)
+                && let Err(error) = pipeline.seek(position_secs)
+            {
+                log::error!("failed to seek pipeline {pipeline_id:?}: {error}");
             }
         }
         MediaCommand::Destroy { pipeline_id } => {
-            if let Some(p) = pipelines.remove(&pipeline_id) {
-                if let Err(error) = p.element.set_state(gst::State::Null) {
-                    log::error!("failed to destroy pipeline {pipeline_id:?}: {error}");
-                }
+            if let Some(pipeline) = pipelines.remove(&pipeline_id)
+                && let Err(error) = pipeline.destroy()
+            {
+                log::error!("failed to destroy pipeline {pipeline_id:?}: {error}");
             }
         }
         MediaCommand::Shutdown => {
@@ -197,6 +184,10 @@ fn handle_command(
     }
     false
 }
+
+// ---------------------------------------------------------------------------
+// Argument parsing
+// ---------------------------------------------------------------------------
 
 fn media_token_from_args() -> Result<Option<String>, String> {
     let mut args = env::args().skip(1);
@@ -211,6 +202,10 @@ fn media_token_from_args() -> Result<Option<String>, String> {
     Ok(None)
 }
 
+// ---------------------------------------------------------------------------
+// Entry point — select backend at compile time via Cargo features
+// ---------------------------------------------------------------------------
+
 pub fn run_media_process_from_args() -> Result<(), String> {
     let token = media_token_from_args()?;
     let manifest = MediaExtensionManifest;
@@ -221,15 +216,22 @@ pub fn run_media_process_from_args() -> Result<(), String> {
     )
     .map_err(|error| format!("ipc extension bootstrap failed: {error}"))?;
 
-    // GStreamer callbacks push events to a crossbeam channel (non-blocking);
-    // the main thread's select loop forwards them to the IPC sender.
     let ipc_event_tx = server.tx;
-    let (crossbeam_event_tx, crossbeam_event_rx) = crossbeam_channel::unbounded::<MediaEvent>();
+    let (crossbeam_frame_tx, crossbeam_frame_rx) = crossbeam_channel::unbounded::<MediaEvent>();
+
+    #[cfg(feature = "backend-gstreamer")]
+    let backend = backend::gstreamer::GStreamerBackend::init()
+        .map_err(|error| format!("GStreamer init failed: {error}"))?;
+
+    #[cfg(feature = "backend-avfoundation")]
+    let backend = backend::avfoundation::AvfBackend::init()
+        .map_err(|error| format!("AVFoundation init failed: {error}"))?;
 
     run_media_process(
+        backend,
         server.rx,
-        crossbeam_event_tx,
-        crossbeam_event_rx,
+        crossbeam_frame_tx,
+        crossbeam_frame_rx,
         ipc_event_tx,
     );
     Ok(())

--- a/media/src/lib.rs
+++ b/media/src/lib.rs
@@ -5,7 +5,6 @@ use ipc::ExtensionEndpoint;
 use ipc_messages::media::{MediaCommand, MediaEvent, MediaPipelineId};
 use std::collections::HashMap;
 use std::env;
-use std::time::Duration;
 
 // ---------------------------------------------------------------------------
 // IPC manifest
@@ -21,9 +20,6 @@ impl ipc::ExtensionManifest for MediaExtensionManifest {
     }
 }
 
-/// Maximum time between select-loop ticks.
-const TICK_INTERVAL: Duration = Duration::from_millis(8);
-
 // ---------------------------------------------------------------------------
 // Generic run loop
 // ---------------------------------------------------------------------------
@@ -37,32 +33,39 @@ pub fn run_media_process<B: MediaBackend>(
     let mut pipelines: HashMap<MediaPipelineId, B::Pipeline> = HashMap::new();
 
     loop {
-        // Tick backends and pipelines (run-loop drain, frame poll, etc.).
+        crossbeam_channel::select! {
+            recv(cmd_rx) -> cmd => {
+                match cmd {
+                    Ok(incoming) => {
+                        if handle_command(
+                            incoming.payload,
+                            &mut backend,
+                            &mut pipelines,
+                        ) {
+                            break; // Shutdown received
+                        }
+                    }
+                    Err(_) => break, // command channel disconnected
+                }
+            }
+            recv(backend_event_rx) -> event => {
+                match event {
+                    Ok(backend_event) => {
+                        if forward_backend_event(backend_event, &ipc_event_tx).is_err() {
+                            break;
+                        }
+                    }
+                    Err(_) => break,
+                }
+            }
+        }
+
+        // Allow backends to tick (run-loop drain, frame poll, etc.) after
+        // each message is processed.
         backend.tick();
         for pipeline in pipelines.values() {
             pipeline.tick();
         }
-
-        // Process one message from any channel.
-        match try_recv_cmd(&cmd_rx) {
-            Ok(Some(incoming)) => {
-                if handle_command(incoming.payload, &mut backend, &mut pipelines) {
-                    break; // Shutdown
-                }
-                continue;
-            }
-            Ok(None) => {} // no command
-            Err(()) => break,
-        }
-
-        match try_recv_backend(&backend_event_rx, &ipc_event_tx) {
-            Ok(true) => continue,
-            Ok(false) => {} // no event
-            Err(()) => break,
-        }
-
-        // Nothing available — sleep briefly so we don't busy-wait.
-        std::thread::sleep(TICK_INTERVAL);
     }
 
     // Clean up remaining pipelines on shutdown.
@@ -73,37 +76,19 @@ pub fn run_media_process<B: MediaBackend>(
     }
 }
 
-/// Try to receive one command.
-/// Returns `Ok(Some(cmd))` on success, `Ok(None)` if queue empty,
-/// `Err(())` if disconnected.
-fn try_recv_cmd(
-    cmd_rx: &crossbeam_channel::Receiver<ipc::IpcIncoming<MediaCommand>>,
-) -> Result<Option<ipc::IpcIncoming<MediaCommand>>, ()> {
-    match cmd_rx.try_recv() {
-        Ok(incoming) => Ok(Some(incoming)),
-        Err(crossbeam_channel::TryRecvError::Empty) => Ok(None),
-        Err(crossbeam_channel::TryRecvError::Disconnected) => Err(()),
-    }
-}
+// ---------------------------------------------------------------------------
+// Backend event → IPC forwarding
+// ---------------------------------------------------------------------------
 
-/// Try to receive one backend event and forward it as a MediaEvent via IPC.
-/// Returns `Ok(true)` if an event was processed, `Ok(false)` if empty,
-/// `Err(())` if disconnected.
-fn try_recv_backend(
-    backend_event_rx: &crossbeam_channel::Receiver<BackendEvent>,
+fn forward_backend_event(
+    event: BackendEvent,
     ipc_event_tx: &ipc::IpcSender<MediaEvent>,
-) -> Result<bool, ()> {
-    let event = match backend_event_rx.try_recv() {
-        Ok(event) => event,
-        Err(crossbeam_channel::TryRecvError::Empty) => return Ok(false),
-        Err(crossbeam_channel::TryRecvError::Disconnected) => return Err(()),
-    };
-
+) -> Result<(), ()> {
     match event {
-        BackendEvent::Frame(video_frame) => {
-            // Frame data goes via shared memory.
+        BackendEvent::Frame(mut video_frame) => {
+            let data = std::mem::take(&mut video_frame.data);
             let mut shmem_map = std::collections::HashMap::new();
-            shmem_map.insert(0, ipc::IpcSharedRegion::from_bytes(&video_frame.data));
+            shmem_map.insert(0, ipc::IpcSharedRegion::from_bytes(&data));
             if ipc_event_tx
                 .send_with_shmem_map(MediaEvent::Frame(video_frame), shmem_map)
                 .is_err()
@@ -145,7 +130,7 @@ fn try_recv_backend(
             }
         }
     }
-    Ok(true)
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------

--- a/media/src/lib.rs
+++ b/media/src/lib.rs
@@ -5,6 +5,7 @@ use ipc::ExtensionEndpoint;
 use ipc_messages::media::{MediaCommand, MediaEvent, MediaPipelineId};
 use std::collections::HashMap;
 use std::env;
+use std::time::Duration;
 
 // ---------------------------------------------------------------------------
 // IPC manifest
@@ -20,6 +21,9 @@ impl ipc::ExtensionManifest for MediaExtensionManifest {
     }
 }
 
+/// Maximum time between select-loop ticks.
+const TICK_INTERVAL: Duration = Duration::from_millis(8);
+
 // ---------------------------------------------------------------------------
 // Generic run loop
 // ---------------------------------------------------------------------------
@@ -27,57 +31,38 @@ impl ipc::ExtensionManifest for MediaExtensionManifest {
 pub fn run_media_process<B: MediaBackend>(
     mut backend: B,
     cmd_rx: crossbeam_channel::Receiver<ipc::IpcIncoming<MediaCommand>>,
-    frame_tx: crossbeam_channel::Sender<MediaEvent>,
-    frame_rx: crossbeam_channel::Receiver<MediaEvent>,
     ipc_event_tx: ipc::IpcSender<MediaEvent>,
 ) {
     let backend_event_rx = backend.event_receiver();
     let mut pipelines: HashMap<MediaPipelineId, B::Pipeline> = HashMap::new();
 
     loop {
-        crossbeam_channel::select! {
-            recv(cmd_rx) -> cmd => {
-                match cmd {
-                    Ok(incoming) => {
-                        if handle_command(
-                            incoming.payload,
-                            &mut backend,
-                            &mut pipelines,
-                            &frame_tx,
-                        ) {
-                            break; // Shutdown received
-                        }
-                    }
-                    Err(_) => break, // command channel disconnected
-                }
-            }
-            recv(backend_event_rx) -> event => {
-                if let Ok(backend_event) = event {
-                    handle_backend_event(backend_event, &frame_tx);
-                }
-            }
-            recv(frame_rx) -> event => {
-                let Ok(event) = event else { break; };
-                match event {
-                    MediaEvent::Frame(mut video_frame) => {
-                        let data = std::mem::take(&mut video_frame.data);
-                        let mut shmem_map = std::collections::HashMap::new();
-                        shmem_map.insert(0, ipc::IpcSharedRegion::from_bytes(&data));
-                        if ipc_event_tx
-                            .send_with_shmem_map(MediaEvent::Frame(video_frame), shmem_map)
-                            .is_err()
-                        {
-                            break;
-                        }
-                    }
-                    other_event => {
-                        if ipc_event_tx.send(other_event).is_err() {
-                            break;
-                        }
-                    }
-                }
-            }
+        // Tick backends and pipelines (run-loop drain, frame poll, etc.).
+        backend.tick();
+        for pipeline in pipelines.values() {
+            pipeline.tick();
         }
+
+        // Process one message from any channel.
+        match try_recv_cmd(&cmd_rx) {
+            Ok(Some(incoming)) => {
+                if handle_command(incoming.payload, &mut backend, &mut pipelines) {
+                    break; // Shutdown
+                }
+                continue;
+            }
+            Ok(None) => {} // no command
+            Err(()) => break,
+        }
+
+        match try_recv_backend(&backend_event_rx, &ipc_event_tx) {
+            Ok(true) => continue,
+            Ok(false) => {} // no event
+            Err(()) => break,
+        }
+
+        // Nothing available — sleep briefly so we don't busy-wait.
+        std::thread::sleep(TICK_INTERVAL);
     }
 
     // Clean up remaining pipelines on shutdown.
@@ -88,34 +73,79 @@ pub fn run_media_process<B: MediaBackend>(
     }
 }
 
-// ---------------------------------------------------------------------------
-// Backend event dispatch
-// ---------------------------------------------------------------------------
+/// Try to receive one command.
+/// Returns `Ok(Some(cmd))` on success, `Ok(None)` if queue empty,
+/// `Err(())` if disconnected.
+fn try_recv_cmd(
+    cmd_rx: &crossbeam_channel::Receiver<ipc::IpcIncoming<MediaCommand>>,
+) -> Result<Option<ipc::IpcIncoming<MediaCommand>>, ()> {
+    match cmd_rx.try_recv() {
+        Ok(incoming) => Ok(Some(incoming)),
+        Err(crossbeam_channel::TryRecvError::Empty) => Ok(None),
+        Err(crossbeam_channel::TryRecvError::Disconnected) => Err(()),
+    }
+}
 
-fn handle_backend_event(event: BackendEvent, event_tx: &crossbeam_channel::Sender<MediaEvent>) {
+/// Try to receive one backend event and forward it as a MediaEvent via IPC.
+/// Returns `Ok(true)` if an event was processed, `Ok(false)` if empty,
+/// `Err(())` if disconnected.
+fn try_recv_backend(
+    backend_event_rx: &crossbeam_channel::Receiver<BackendEvent>,
+    ipc_event_tx: &ipc::IpcSender<MediaEvent>,
+) -> Result<bool, ()> {
+    let event = match backend_event_rx.try_recv() {
+        Ok(event) => event,
+        Err(crossbeam_channel::TryRecvError::Empty) => return Ok(false),
+        Err(crossbeam_channel::TryRecvError::Disconnected) => return Err(()),
+    };
+
     match event {
+        BackendEvent::Frame(video_frame) => {
+            // Frame data goes via shared memory.
+            let mut shmem_map = std::collections::HashMap::new();
+            shmem_map.insert(0, ipc::IpcSharedRegion::from_bytes(&video_frame.data));
+            if ipc_event_tx
+                .send_with_shmem_map(MediaEvent::Frame(video_frame), shmem_map)
+                .is_err()
+            {
+                return Err(());
+            }
+        }
         BackendEvent::Eos { pipeline_id } => {
-            let _ = event_tx.send(MediaEvent::Eos { pipeline_id });
+            if ipc_event_tx.send(MediaEvent::Eos { pipeline_id }).is_err() {
+                return Err(());
+            }
         }
         BackendEvent::Error {
             pipeline_id,
             message,
         } => {
-            let _ = event_tx.send(MediaEvent::Error {
-                pipeline_id,
-                message,
-            });
+            if ipc_event_tx
+                .send(MediaEvent::Error {
+                    pipeline_id,
+                    message,
+                })
+                .is_err()
+            {
+                return Err(());
+            }
         }
         BackendEvent::DurationChanged {
             pipeline_id,
             duration_secs,
         } => {
-            let _ = event_tx.send(MediaEvent::DurationChanged {
-                pipeline_id,
-                duration_secs,
-            });
+            if ipc_event_tx
+                .send(MediaEvent::DurationChanged {
+                    pipeline_id,
+                    duration_secs,
+                })
+                .is_err()
+            {
+                return Err(());
+            }
         }
     }
+    Ok(true)
 }
 
 // ---------------------------------------------------------------------------
@@ -127,22 +157,17 @@ fn handle_command<B: MediaBackend>(
     cmd: MediaCommand,
     backend: &mut B,
     pipelines: &mut HashMap<MediaPipelineId, B::Pipeline>,
-    event_tx: &crossbeam_channel::Sender<MediaEvent>,
 ) -> bool {
     match cmd {
         MediaCommand::CreatePipeline { pipeline_id, url } => {
             log::info!("[media] creating pipeline id={:?} url={}", pipeline_id, url);
-            match backend.create_pipeline(pipeline_id, url, event_tx.clone()) {
+            match backend.create_pipeline(pipeline_id, url) {
                 Ok(pipeline) => {
                     log::info!("[media] pipeline created id={:?}", pipeline_id);
                     pipelines.insert(pipeline_id, pipeline);
                 }
                 Err(error) => {
                     log::error!("[media] failed to create media pipeline {pipeline_id:?}: {error}");
-                    let _ = event_tx.send(MediaEvent::Error {
-                        pipeline_id,
-                        message: format!("pipeline creation failed: {error}"),
-                    });
                 }
             }
         }
@@ -216,9 +241,6 @@ pub fn run_media_process_from_args() -> Result<(), String> {
     )
     .map_err(|error| format!("ipc extension bootstrap failed: {error}"))?;
 
-    let ipc_event_tx = server.tx;
-    let (crossbeam_frame_tx, crossbeam_frame_rx) = crossbeam_channel::unbounded::<MediaEvent>();
-
     #[cfg(feature = "backend-gstreamer")]
     let backend = backend::gstreamer::GStreamerBackend::init()
         .map_err(|error| format!("GStreamer init failed: {error}"))?;
@@ -227,12 +249,6 @@ pub fn run_media_process_from_args() -> Result<(), String> {
     let backend = backend::avfoundation::AvfBackend::init()
         .map_err(|error| format!("AVFoundation init failed: {error}"))?;
 
-    run_media_process(
-        backend,
-        server.rx,
-        crossbeam_frame_tx,
-        crossbeam_frame_rx,
-        ipc_event_tx,
-    );
+    run_media_process(backend, server.rx, server.tx);
     Ok(())
 }


### PR DESCRIPTION
   Introduce a generic `MediaBackend` / `PipelineHandle` trait boundary that
   keeps `run_media_process` and the IPC loop completely backend-agnostic.
   The backend is selected at compile time via Cargo features.

   - `backend-gstreamer` (default) — `GstPipeline` with uridecodebin → videoconvert → appsink pipeline, bus sync handler converting GStreamer messages to `BackendEvent`, and RGBA frame extraction via appsink `new_sample` callback.

   - `backend-avfoundation` — `AvfPipeline` with AVPlayer + AVPlayerItem + AVPlayerItemVideoOutput on a dedicated worker thread. Frame polling uses `itemTimeForHostTime(CVGetCurrentHostTime)` with run loop draining to advance AVFoundation's internal timing. Run loop drain and host-time conversion are both required for `hasNewPixelBufferForItemTime` to report new frames.

   Both backends deliver decoded frames (1920×1080 BGRA) via the same
   crossbeam → shmem → IPC path. Tested end-to-end in windowed mode with
   a local .mov file.