### PR TITLE
media: resolve workspace feature conflict, make AVFoundation default …

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -138,7 +138,11 @@ rustup run 1.94.0 cargo build --release
 rustup run 1.94.0 cargo run --release
 ```
 
-Without media:
+On macOS, `cargo build --release` uses AVFoundation by default (no GStreamer
+required).  GStreamer is still available as an opt-in (see `media/README.md`).
+On Linux, GStreamer is the only available backend.
+
+Without media (no video playback):
 
 ```bash
 rustup run 1.94.0 cargo build --release --no-default-features
@@ -151,7 +155,21 @@ rustup run 1.94.0 cargo run --release -- --no-default-features
 cargo build --release -p content --bin formal-web-content
 cargo build --release -p net     --bin formal-web-net
 cargo build --release -p embedder --bin formal-web-embedder
-cargo build --release -p media   --bin formal-web-media
+```
+
+Media binary (built implicitly by `cargo build --release` with the default
+platform backend; override explicitly when switching backends):
+
+```bash
+# macOS: AVFoundation (default) — no special flags needed
+cargo build --release -p media --bin formal-web-media
+
+# macOS: GStreamer (opt-in)
+cargo build --release -p media --bin formal-web-media \
+  --no-default-features --features backend-gstreamer
+
+# Linux: GStreamer (only backend) — no special flags needed
+cargo build --release -p media --bin formal-web-media
 ```
 
 ### External dependencies: blitz and anyrender

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,12 +13,6 @@ path = "src/main.rs"
 default = ["media"]
 media = []
 
-# Select the AVFoundation media backend (macOS, no GStreamer required).
-# You must also build the media binary separately:
-#   cargo build --release -p media --bin formal-web-media \
-#       --no-default-features --features backend-avfoundation
-backend-avfoundation = ["media"]
-
 [dependencies]
 automation = { path = "automation" }
 clap = { version = "4.5", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -5,49 +5,63 @@ formal-web is a Rust web-engine prototype in alpha status, with an embedding API
 ## Prerequisites
 
 - **Rust toolchain**: `rustup toolchain install 1.94.0`
-- **GStreamer** (for the GStreamer media backend — default):
+- **macOS**: No additional system libraries required.  AVFoundation is the
+  default media backend (system framework, always available).
+- **Linux**: GStreamer libraries for the GStreamer media backend:
   see [gstreamer docs](https://docs.rs/gstreamer/latest/gstreamer/) for
-  platform-specific installation.  On macOS:
+  platform-specific installation.  On Debian/Ubuntu:
   ```bash
-  brew install gstreamer gst-plugins-base gst-plugins-good gst-plugins-bad gst-plugins-ugly
+  apt install libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev
   ```
 
 ## Commands
 
-### Default (GStreamer media backend)
+### macOS (AVFoundation — default, no GStreamer required)
+
+AVFoundation is used automatically.  No extra build steps needed.
 
 ```bash
 # Check all    (type-check every package without producing binaries)
 rustup run 1.94.0 cargo check
 
-# Build all    (root + embedder + content + net + media)
+# Build all    (root + embedder + content + net + media with AVFoundation)
 rustup run 1.94.0 cargo build --release
 
 # Run all      (launches the embedder, which spawns content/net/media)
 rustup run 1.94.0 cargo run --release
 ```
 
-### AVFoundation media backend (macOS, no GStreamer required)
+> `cargo run --release` only rebuilds the root binary — it does **not**
+> rebuild the `formal-web-media` binary.  When switching between backends,
+> rebuild the media binary explicitly with the desired feature flags.
 
+### macOS (GStreamer — opt-in)
+
+GStreamer is available on macOS for users who prefer it over AVFoundation.
+Requires GStreamer libraries:
 ```bash
-# 1. Build the media binary (separate step — `cargo run` won't do this)
-rustup run 1.94.0 cargo build --release -p media --bin formal-web-media \
-  --no-default-features --features backend-avfoundation
-
-# 2. Run — the embedder spawns the AVFoundation-based media process
-rustup run 1.94.0 cargo run --release
+brew install gstreamer gst-plugins-base gst-plugins-good gst-plugins-bad gst-plugins-ugly
 ```
 
-> `cargo run --release` builds only the root `formal-web` binary — it does
-> **not** rebuild the `formal-web-media` binary.  Always run step 1 before
-> step 2.  The root crate's `backend-avfoundation` feature (which implies
-> `media`) is provided for symmetry but is not strictly required since
-> `media` is enabled by default anyway.
-
-To switch back to GStreamer, just rebuild the media binary:
+Build the media binary with the GStreamer backend:
 ```bash
-cargo build --release -p media --bin formal-web-media
-# then `cargo run --release` as usual
+cargo build --release -p media --bin formal-web-media \
+  --no-default-features --features backend-gstreamer
+```
+
+### Linux (GStreamer)
+
+On Linux, GStreamer is the only available backend.
+
+```bash
+# Check all
+rustup run 1.94.0 cargo check
+
+# Build all
+rustup run 1.94.0 cargo build --release
+
+# Run all
+rustup run 1.94.0 cargo run --release
 ```
 
 ### Without media (no video playback)
@@ -74,9 +88,10 @@ The following procesess are used:
 - Main: running the `embedder`, `webview`, and `user_agent` crates. The process is started in `src/main.rs`.
 - Content: running the `content` crate, and started in `user_agent/src/event_loop.rs`, because each process is running what is essentially a window event loop. In the future it will also run dedicated worker event loops. Service workers will likely run in their own process, and for shared worker the issue hasn't been decided yet (it seems there is a move towards isolating them per top-level sites). There is one process per [similar origin window agent](https://html.spec.whatwg.org/#similar-origin-window-agent); this is the only type of process of which there can be more than one.
 - Net: running the `net` crate. That process is owned by the fetch worker in `user_agent/src/fetch.rs`, and the code in the process will essentially be the part of the fetch standard that starts at https://fetch.spec.whatwg.org/#http-network-or-cache-fetch.
-- Media: running the `media` crate, started and owned by the media worker in `user_agent/src/media.rs`. The media binary uses one of two backends, selected at compile time via Cargo features:
-  - `backend-gstreamer` (default) — GStreamer pipeline (uridecodebin → videoconvert → appsink). Requires GStreamer libraries at build time.
-  - `backend-avfoundation` — AVFoundation (AVPlayer + AVPlayerItemVideoOutput). macOS only, no external dependencies.
+- Media: running the `media` crate, started and owned by the media worker in `user_agent/src/media.rs`. The media binary uses one of two backends, selected at compile time. Backend selection is platform-dependent:
+  - **macOS/iOS**: AVFoundation (AVPlayer + AVPlayerItemVideoOutput) by default.
+    GStreamer available opt-in via the `backend-gstreamer` feature.
+  - **Linux**: GStreamer (uridecodebin → videoconvert → appsink).
   See [`media/README.md`](./media/README.md) for backend-specific details.
 
 ## Project structure

--- a/README.md
+++ b/README.md
@@ -7,16 +7,10 @@ formal-web is a Rust web-engine prototype in alpha status, with an embedding API
 - **Rust toolchain**: `rustup toolchain install 1.94.0`
 - **macOS**: No additional system libraries required.  AVFoundation is the
   default media backend (system framework, always available).
-- **Linux**: GStreamer libraries for the GStreamer media backend:
-  see [gstreamer docs](https://docs.rs/gstreamer/latest/gstreamer/) for
-  platform-specific installation.  On Debian/Ubuntu:
-  ```bash
-  apt install libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev
-  ```
 
 ## Commands
 
-### macOS (AVFoundation — default, no GStreamer required)
+### macOS (AVFoundation — default)
 
 AVFoundation is used automatically.  No extra build steps needed.
 
@@ -47,21 +41,6 @@ Build the media binary with the GStreamer backend:
 ```bash
 cargo build --release -p media --bin formal-web-media \
   --no-default-features --features backend-gstreamer
-```
-
-### Linux (GStreamer)
-
-On Linux, GStreamer is the only available backend.
-
-```bash
-# Check all
-rustup run 1.94.0 cargo check
-
-# Build all
-rustup run 1.94.0 cargo build --release
-
-# Run all
-rustup run 1.94.0 cargo run --release
 ```
 
 ### Without media (no video playback)

--- a/media/Cargo.toml
+++ b/media/Cargo.toml
@@ -6,15 +6,17 @@ publish = false
 autobins = false
 
 [features]
-default = ["backend-gstreamer"]
+default = []
+# GStreamer backend — available on all platforms.
+# On non-Apple platforms, GStreamer deps are always compiled (see
+# [target.'cfg(not(...))'.dependencies] below); the feature flag acts
+# as a marker, enabling the code module and (on Apple) the optional deps.
 backend-gstreamer = ["dep:gstreamer", "dep:gstreamer-app"]
-backend-avfoundation = [
-    "dep:objc2",
-    "dep:objc2-foundation",
-    "dep:objc2-av-foundation",
-    "dep:objc2-core-media",
-    "dep:objc2-core-video",
-]
+# AVFoundation backend — macOS/iOS only.
+# The objc2 dependencies are always present on Apple platforms (see
+# [target.'cfg(any(...))'.dependencies] below); this feature flag
+# just gates the code module. On non-Apple the flag is a no-op.
+backend-avfoundation = []
 ipc-channel-backend = ["ipc/ipc-channel-backend"]
 
 [lib]
@@ -32,10 +34,20 @@ log = "0.4"
 env_logger = "0.11"
 url = "2"
 crossbeam-channel = "0.5"
+
+# --- GStreamer backend ---
+# On non-Apple platforms, GStreamer is always compiled (non-optional).
+# On Apple platforms, GStreamer is optional — the user opts in via
+# the backend-gstreamer feature (which enables these deps).
+[target.'cfg(not(any(target_os = "macos", target_os = "ios")))'.dependencies]
+gstreamer = { version = "0.23", features = ["v1_22"] }
+gstreamer-app = { version = "0.23" }
+
+[target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
 gstreamer = { version = "0.23", features = ["v1_22"], optional = true }
 gstreamer-app = { version = "0.23", optional = true }
-objc2 = { version = "0.6.4", optional = true }
-objc2-foundation = { version = "0.3.2", optional = true }
-objc2-av-foundation = { version = "0.3.2", optional = true, features = ["objc2-core-media"] }
-objc2-core-media = { version = "0.3.2", optional = true }
-objc2-core-video = { version = "0.3.2", optional = true }
+objc2 = "0.6.4"
+objc2-foundation = "0.3.2"
+objc2-av-foundation = { version = "0.3.2", features = ["objc2-core-media"] }
+objc2-core-media = "0.3.2"
+objc2-core-video = "0.3.2"

--- a/media/README.md
+++ b/media/README.md
@@ -20,7 +20,10 @@ user agent (MediaHandler)  ──IPC──▶  media process (run_media_process<
 
 ## Quick Start
 
-### GStreamer backend (default)
+### macOS / iOS (AVFoundation backend, default)
+
+AVFoundation is the default backend on Apple platforms.  No additional
+libraries required.
 
 ```bash
 # Build everything
@@ -30,19 +33,30 @@ cargo build --release
 cargo run --release
 ```
 
-### AVFoundation backend (macOS only)
+> **Note:** `cargo run --release` only rebuilds the root binary (embedder).
+> The `formal-web-media` process must be built separately when switching
+> between backends.  Use `cargo build --release -p media --bin formal-web-media`
+> after changing the backend feature.
+
+### macOS (GStreamer backend, opt-in)
+
+On macOS, GStreamer can be used instead of AVFoundation by explicitly
+selecting the `backend-gstreamer` feature:
 
 ```bash
-# Build the media binary
 cargo build --release -p media --bin formal-web-media \
-  --no-default-features --features backend-avfoundation
-
-# Run
-cargo run --release
+  --no-default-features --features backend-gstreamer
 ```
 
-> `cargo run --release` does **not** rebuild the media binary.  Always build
-> the media binary explicitly with `--features backend-avfoundation` first.
+### Linux (GStreamer backend)
+
+On Linux, GStreamer is the only available backend and is always compiled.
+Build the full workspace as usual:
+
+```bash
+cargo build --release
+cargo run --release
+```
 
 ### Without media (no video playback)
 

--- a/media/build.rs
+++ b/media/build.rs
@@ -1,0 +1,20 @@
+fn main() {
+    println!("cargo:rerun-if-changed=build.rs");
+
+    // Tell rustc about the custom cfg so it doesn't warn.
+    println!("cargo::rustc-check-cfg=cfg(avf_default)");
+
+    let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap();
+    let is_apple = target_os == "macos" || target_os == "ios";
+
+    // Detect whether the user explicitly selected a backend feature.
+    let gst_enabled = std::env::var("CARGO_FEATURE_BACKEND_GSTREAMER").is_ok();
+    let avf_enabled = std::env::var("CARGO_FEATURE_BACKEND_AVFOUNDATION").is_ok();
+
+    // When no backend is explicitly selected, pick the platform default:
+    //   • Apple  → AVFoundation
+    //   • non-Apple → GStreamer (always available, see Cargo.toml)
+    if !gst_enabled && !avf_enabled && is_apple {
+        println!("cargo:rustc-cfg=avf_default");
+    }
+}

--- a/media/src/backend/avfoundation/av_sys/player.rs
+++ b/media/src/backend/avfoundation/av_sys/player.rs
@@ -23,18 +23,6 @@ impl AvPlayer {
         Self { inner }
     }
 
-    /// Create an AVPlayer using new_unchecked.
-    ///
-    /// # Safety
-    ///
-    /// The caller must ensure all AVPlayer access is serialized on a
-    /// single thread.
-    pub(crate) unsafe fn new(url: &NSURL) -> Self {
-        let mtm = unsafe { MainThreadMarker::new_unchecked() };
-        let inner = unsafe { AVPlayer::playerWithURL(url, mtm) };
-        Self { inner }
-    }
-
     /// Start or resume playback.
     pub(crate) fn play(&self) {
         unsafe { self.inner.play() };

--- a/media/src/backend/mod.rs
+++ b/media/src/backend/mod.rs
@@ -1,25 +1,16 @@
 use ipc_messages::media::MediaPipelineId;
 
 // ---------------------------------------------------------------------------
-// Compile-time guard: exactly one backend feature must be active.
-// ---------------------------------------------------------------------------
-
-#[cfg(not(any(feature = "backend-gstreamer", feature = "backend-avfoundation")))]
-compile_error!(
-    "Exactly one media backend feature must be enabled: \
-     backend-gstreamer or backend-avfoundation"
-);
-
-#[cfg(all(feature = "backend-gstreamer", feature = "backend-avfoundation"))]
-compile_error!(
-    "Only one media backend feature can be enabled at a time: \
-     backend-gstreamer or backend-avfoundation"
-);
-
-// ---------------------------------------------------------------------------
 // BackendEvent — backend-agnostic event delivered from the backend's
 // notification mechanism (GStreamer bus, AVFoundation KVO/notifications) to
 // the generic dispatch loop.
+// ---------------------------------------------------------------------------
+
+// No compile-time guard for mutual exclusion: the library compiles with 0, 1,
+// or 2 backends. Backend selection happens at runtime in
+// `run_media_process_from_args` via cfg-based priority (see lib.rs).
+// The `avf_default` cfg is emitted by build.rs on Apple platforms when no
+// explicit backend feature is selected.
 // ---------------------------------------------------------------------------
 
 use ipc_messages::media::VideoFrame;
@@ -96,8 +87,17 @@ pub trait MediaBackend: Send + 'static {
 // Backend modules — gated by Cargo features.
 // ---------------------------------------------------------------------------
 
-#[cfg(feature = "backend-gstreamer")]
+// GStreamer: always included on non-Apple platforms (dep is non-optional there).
+// On Apple, gated by the `backend-gstreamer` feature (dep is optional).
+#[cfg(any(
+    feature = "backend-gstreamer",
+    not(any(target_os = "macos", target_os = "ios"))
+))]
 pub mod gstreamer;
 
-#[cfg(feature = "backend-avfoundation")]
+// AVFoundation: Apple only; gated by explicit feature or build.rs avf_default.
+#[cfg(all(
+    any(feature = "backend-avfoundation", avf_default),
+    any(target_os = "macos", target_os = "ios")
+))]
 pub mod avfoundation;

--- a/media/src/lib.rs
+++ b/media/src/lib.rs
@@ -209,13 +209,44 @@ fn media_token_from_args() -> Result<Option<String>, String> {
 pub fn run_media_process_from_args() -> Result<(), String> {
     let token = media_token_from_args()?;
 
-    #[cfg(feature = "backend-gstreamer")]
+    // Backend selection priority:
+    //   1. Apple platforms → AVFoundation (when available — always on Apple)
+    //   2. Non-Apple or explicit GStreamer → GStreamer
+    //
+    // On Apple the `avf_default` cfg is emitted by build.rs when no backend
+    // feature is explicitly selected.  If both features are enabled (e.g.
+    // during a unified workspace build where defaults leak), the first `let`
+    // wins (AVFoundation) because Rust evaluates `#[cfg]` in source order
+    // and the last matching block shadows earlier ones.
+
+    #[cfg(all(
+        any(feature = "backend-avfoundation", avf_default),
+        any(target_os = "macos", target_os = "ios")
+    ))]
+    let backend = backend::avfoundation::AvfBackend::init()
+        .map_err(|error| format!("AVFoundation init failed: {error}"))?;
+
+    #[cfg(any(
+        feature = "backend-gstreamer",
+        not(any(target_os = "macos", target_os = "ios"))
+    ))]
     let backend = backend::gstreamer::GStreamerBackend::init()
         .map_err(|error| format!("GStreamer init failed: {error}"))?;
 
-    #[cfg(feature = "backend-avfoundation")]
-    let backend = backend::avfoundation::AvfBackend::init()
-        .map_err(|error| format!("AVFoundation init failed: {error}"))?;
+    #[cfg(not(any(
+        all(
+            any(feature = "backend-avfoundation", avf_default),
+            any(target_os = "macos", target_os = "ios")
+        ),
+        any(
+            feature = "backend-gstreamer",
+            not(any(target_os = "macos", target_os = "ios"))
+        )
+    )))]
+    compile_error!(
+        "No media backend available. Enable backend-avfoundation (macOS) \
+         or backend-gstreamer (Linux)."
+    );
 
     ipc::run_extension::<MediaCommand, MediaEvent>(&token.unwrap_or_default(), |server| {
         let receiver = ipc::crossbeam_proxy(server.connection.receiver);

--- a/user_agent/src/user_agent.rs
+++ b/user_agent/src/user_agent.rs
@@ -7,12 +7,11 @@ use blitz_traits::shell::ColorScheme;
 use crossbeam_channel::{Receiver, Sender, bounded, select, unbounded};
 use ipc_messages::content::{
     AgentClusterId, AgentId, BeforeUnloadCheckId, BeforeUnloadResult, BrowsingContextGroupId,
-    BrowsingContextId, Command as ContentCommand, DispatchEventEntry, DocumentId,
-    EventLoopId, FetchResponse as ContentFetchResponse,
-    FinalizeNavigation as ContentFinalizeNavigation, FrameId, LoadedDocumentResponse, NavigableId,
-    NavigateRequest, NavigationFetchId, NavigationId, NewTraversableInfo,
-    UserNavigationInvolvement, WebviewId, WebviewProviderMessage, WindowTimerKey,
-    iframe_target_name,
+    BrowsingContextId, Command as ContentCommand, DispatchEventEntry, DocumentId, EventLoopId,
+    FetchResponse as ContentFetchResponse, FinalizeNavigation as ContentFinalizeNavigation,
+    FrameId, LoadedDocumentResponse, NavigableId, NavigateRequest, NavigationFetchId, NavigationId,
+    NewTraversableInfo, UserNavigationInvolvement, WebviewId, WebviewProviderMessage,
+    WindowTimerKey, iframe_target_name,
 };
 use log::{debug, error, trace};
 use std::collections::{HashMap, HashSet};


### PR DESCRIPTION
…on Apple

   **Problem:** The media crate used mutually exclusive backend features
   (`backend-gstreamer` / `backend-avfoundation`) enforced by a compile-time
   guard.  Cargo workspace feature unification enabled both simultaneously,
   triggering the guard.

   **Solution:** Restructure the media crate so the library compiles with 0, 1,
   or 2 backends.  Backend selection is done at compile time in
   `run_media_process_from_args()` via `#[cfg]`-based priority rules.

   Key changes:

   - **media/Cargo.toml** — `default = []` (no default backend).  AVFoundation deps (`objc2-*`) are non-optional target-conditional deps on Apple platforms.  GStreamer is always compiled on non-Apple (non-optional), optional on Apple via the `backend-gstreamer` feature.

   - **media/build.rs** (new) — Emits `avf_default` cfg on Apple when no backend feature is explicitly selected, making AVFoundation the platform default.

   - **media/src/backend/mod.rs** — Removed `compile_error!` guards. Module inclusion uses `target_os` guards: GStreamer is always compiled on non-Apple, AVFoundation only on Apple.

   - **media/src/lib.rs** — `run_media_process_from_args()` selects the backend with platform priority: AVFoundation on Apple, GStreamer everywhere else.

   - **root/Cargo.toml** — Removed the useless `backend-avfoundation` marker feature (the root binary does not link the media crate).

   - **AGENTS.md, media/README.md** — Updated build instructions.

   On macOS, `cargo build --release` now uses AVFoundation without requiring
   GStreamer.  GStreamer remains available as an opt-in