### PR TITLE
Add V8 support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -352,6 +352,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bindgen"
+version = "0.72.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
+dependencies = [
+ "bitflags 2.13.0",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.13.0",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 2.1.2",
+ "shlex 1.3.0",
+ "syn",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -536,7 +556,7 @@ dependencies = [
  "icu_normalizer",
  "indexmap",
  "intrusive-collections",
- "itertools",
+ "itertools 0.14.0",
  "num-bigint",
  "num-integer",
  "num-traits",
@@ -687,6 +707,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 
 [[package]]
+name = "calendrical_calculations"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5abbd6eeda6885048d357edc66748eea6e0268e3dd11f326fff5bd248d779c26"
+dependencies = [
+ "core_maths",
+ "displaydoc",
+]
+
+[[package]]
 name = "calloop"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -721,7 +751,16 @@ dependencies = [
  "find-msvc-tools",
  "jobserver",
  "libc",
- "shlex",
+ "shlex 2.0.1",
+]
+
+[[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
 ]
 
 [[package]]
@@ -755,6 +794,17 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
  "rand_core 0.10.1",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
 ]
 
 [[package]]
@@ -1336,6 +1386,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "diplomat"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7935649d00000f5c5d735448ad3dc07b9738160727017914cf42138b8e8e6611"
+dependencies = [
+ "diplomat_core",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "diplomat-runtime"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "970ac38ad677632efcee6d517e783958da9bc78ec206d8d5e35b459ffc5e4864"
+
+[[package]]
+name = "diplomat_core"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cf41b94101a4bce993febaf0098092b0bb31deaf0ecaf6e0a2562465f61b383"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "smallvec",
+ "strck",
+ "syn",
+]
+
+[[package]]
 name = "directories-next"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1800,6 +1882,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "fslock"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04412b8935272e3a9bae6f48c7bfff74c2911f60525404edfdd28e49884c3bfb"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "futures"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2103,6 +2195,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
 name = "glow"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2186,7 +2284,7 @@ dependencies = [
  "futures-util",
  "glib",
  "gstreamer-sys",
- "itertools",
+ "itertools 0.14.0",
  "libc",
  "muldiv",
  "num-integer",
@@ -2274,6 +2372,15 @@ checksum = "6b17e70c989c36bad147b27a58d148c0741c51448aa5653436547323e524d0ab"
 dependencies = [
  "euclid",
  "svg_fmt",
+]
+
+[[package]]
+name = "gzip-header"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86848f4fd157d91041a62c78046fb7b248bcc2dce78376d436a1756e9a038577"
+dependencies = [
+ "crc32fast",
 ]
 
 [[package]]
@@ -2380,6 +2487,15 @@ name = "hexf-parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
+
+[[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "html-escape"
@@ -2507,6 +2623,28 @@ dependencies = [
  "tower-service",
  "tracing",
 ]
+
+[[package]]
+name = "icu_calendar"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2b2acc6263f494f1df50685b53ff8e57869e47d5c6fe39c23d518ae9a4f3e45"
+dependencies = [
+ "calendrical_calculations",
+ "displaydoc",
+ "icu_calendar_data",
+ "icu_locale",
+ "icu_locale_core",
+ "icu_provider",
+ "tinystr",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_calendar_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "118577bcf3a0fa7c6ac0a7d6e951814da84ee56b9b1f68fb4d8d10b08cefaf4d"
 
 [[package]]
 name = "icu_collections"
@@ -2785,6 +2923,15 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
@@ -2817,6 +2964,12 @@ checksum = "52f5385394064fa2c886205dba02598013ce83d3e92d33dbdc0c52fe0e7bf4fc"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "ixdtf"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ceaf4c6c48465bead8cb6a0b7c4ee0c86ecbb31239032b9c66ab9a08d2f3ee1"
 
 [[package]]
 name = "jiff"
@@ -2930,6 +3083,7 @@ dependencies = [
  "js_engine_macros",
  "log",
  "serde_json",
+ "v8",
 ]
 
 [[package]]
@@ -3189,6 +3343,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3291,6 +3451,16 @@ name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
 
 [[package]]
 name = "num-bigint"
@@ -4206,6 +4376,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8cf8e6a8aa66ce33f63993ffc4ea4271eb5b0530a9002db8455ea6050c77bfa"
 
 [[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro-crate"
 version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4626,6 +4806,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "resb"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22d392791f3c6802a1905a509e9d1a6039cbbcb5e9e00e5a6d3661f7c874f390"
+dependencies = [
+ "potential_utf",
+ "serde_core",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4975,6 +5165,12 @@ dependencies = [
 
 [[package]]
 name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
@@ -5149,6 +5345,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "strck"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42316e70da376f3d113a68d138a60d8a9883c604fe97942721ec2068dab13a9f"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
 name = "strict-num"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5226,7 +5431,7 @@ dependencies = [
  "euclid",
  "icu_segmenter",
  "indexmap",
- "itertools",
+ "itertools 0.14.0",
  "itoa",
  "log",
  "malloc_size_of_derive",
@@ -5464,6 +5669,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "temporal_capi"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c534c1ac4165fb410b5ccd12c79040573622865e881bb8caad70981806a141f1"
+dependencies = [
+ "diplomat",
+ "diplomat-runtime",
+ "icu_calendar",
+ "icu_locale_core",
+ "num-traits",
+ "temporal_rs",
+ "timezone_provider",
+ "writeable",
+ "zoneinfo64",
+]
+
+[[package]]
+name = "temporal_rs"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1afc06e45b0d63943c777d0233523fa2e23a12431a73c37b1c0366777b31717"
+dependencies = [
+ "calendrical_calculations",
+ "core_maths",
+ "icu_calendar",
+ "icu_locale_core",
+ "ixdtf",
+ "num-traits",
+ "timezone_provider",
+ "tinystr",
+ "writeable",
+]
+
+[[package]]
 name = "tendril"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5567,6 +5806,18 @@ checksum = "71c652a3727a9cbb9a02f707f530b618ce00d0ccd762009c8c23bd191df3c17d"
 dependencies = [
  "num-conv",
  "time-core",
+]
+
+[[package]]
+name = "timezone_provider"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48738555f588bc05b58cb55206843cde9875bb1fde50101dd1a7c50ac6535cd5"
+dependencies = [
+ "tinystr",
+ "zerotrie",
+ "zerovec",
+ "zoneinfo64",
 ]
 
 [[package]]
@@ -6053,6 +6304,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "v8"
+version = "150.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ee8c3ecd446c44ce7d74dc2ea8e25e2ad91ef4bfbd954762831b2188b5b7781"
+dependencies = [
+ "bindgen",
+ "bitflags 2.13.0",
+ "fslock",
+ "gzip-header",
+ "home",
+ "miniz_oxide",
+ "paste",
+ "temporal_capi",
+ "which",
+]
+
+[[package]]
 name = "vello"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6468,7 +6736,7 @@ dependencies = [
  "cranelift-frontend",
  "cranelift-native",
  "gimli",
- "itertools",
+ "itertools 0.14.0",
  "log",
  "object",
  "pulley-interpreter",
@@ -6949,6 +7217,18 @@ checksum = "b1352548a4576b7998474fa6fbc54232df5f9ccd90cdea079418c3577e26e220"
 dependencies = [
  "futures-intrusive",
  "wgpu",
+]
+
+[[package]]
+name = "which"
+version = "6.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ee928febd44d98f2f459a4a79bd4d928591333a494a10a868418ac1b39cf1f"
+dependencies = [
+ "either",
+ "home",
+ "rustix 0.38.44",
+ "winsafe",
 ]
 
 [[package]]
@@ -7433,6 +7713,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "winsafe"
+version = "0.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
+
+[[package]]
 name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7690,6 +7976,19 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zoneinfo64"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed6eb2607e906160c457fd573e9297e65029669906b9ac8fb1b5cd5e055f0705"
+dependencies = [
+ "calendrical_calculations",
+ "icu_locale_core",
+ "potential_utf",
+ "resb",
+ "serde",
+]
 
 [[package]]
 name = "zstd"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ media = ["dep:media"]
 # These propagate to the content crate via workspace dependency resolution.
 jsc = ["dep:content", "content/jsc"]
 boa = ["dep:content", "content/boa", "content/media"]
+v8 = ["dep:content", "content/v8"]
 wasm = ["content/wasm"]
 
 [dependencies]
@@ -63,5 +64,4 @@ blitz-traits = { git = "https://github.com/gterzian/blitz", rev = "954b41f25e4fb
 blitz-dom = { git = "https://github.com/gterzian/blitz", rev = "954b41f25e4fbfae39d7c512016d8193ee53ee80", default-features = false }
 blitz-paint = { git = "https://github.com/gterzian/blitz", rev = "954b41f25e4fbfae39d7c512016d8193ee53ee80", default-features = false }
 blitz-html = { git = "https://github.com/gterzian/blitz", rev = "954b41f25e4fbfae39d7c512016d8193ee53ee80", default-features = false }
-
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,16 @@ cargo build --release --no-default-features --features jsc,media
 cargo run --release --no-default-features --features jsc,media
 ```
 
+**V8** (experimental, macOS arm64 only):
+```bash
+cargo build --release --no-default-features --features v8,media
+cargo run --release --no-default-features --features v8,media
+```
+
+V8 cannot be combined with `wasm`. The first build downloads the pinned V8
+archive. Set `RUSTY_V8_ARCHIVE` or `RUSTY_V8_MIRROR` for offline or mirrored
+builds.
+
 **GStreamer** media backend instead of AVFoundation:
 ```bash
 cargo build --release --no-default-features --features backend-gstreamer,boa,media

--- a/build.rs
+++ b/build.rs
@@ -141,10 +141,7 @@ fn selected_javascript_backend() -> Result<JavascriptBackend, String> {
         .collect();
 
     if selected_backends.len() != 1 {
-        let selected_names: Vec<_> = selected_backends
-            .iter()
-            .map(|(_, _, name)| *name)
-            .collect();
+        let selected_names: Vec<_> = selected_backends.iter().map(|(_, _, name)| *name).collect();
         return Err(format!(
             "exactly one JavaScript backend feature must be enabled; selected: {}",
             if selected_names.is_empty() {

--- a/build.rs
+++ b/build.rs
@@ -3,7 +3,14 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-const PREBUILD_TARGET_DIR_NAME: &str = "sidecar-prebuild";
+const PREBUILD_TARGET_DIR_NAME: &str = "helper-prebuild";
+
+#[derive(Clone, Copy)]
+enum JavascriptBackend {
+    Boa,
+    Jsc,
+    V8,
+}
 
 fn main() {
     #[allow(unused_mut)]
@@ -71,27 +78,22 @@ fn prebuild_binaries(prebuild_list: &[(&str, &str)]) -> Result<(), String> {
     if profile == "release" {
         command.arg("--release");
     }
+    let javascript_backend = selected_javascript_backend()?;
+
     // Determine the features to pass to prebuild packages.
-    // The content crate has its own backend features (boa/jsc) and media feature.
+    // The content crate has its own backend and media features.
     let has_media = cfg!(feature = "media");
-    let has_boa = cfg!(feature = "boa");
-    if has_boa {
-        // Boa backend: override content defaults (which use jsc)
-        if has_media {
-            command.args(["--no-default-features", "--features", "boa,media"]);
-        } else {
-            command.args(["--no-default-features", "--features", "boa"]);
-        }
+    let backend_feature = match javascript_backend {
+        JavascriptBackend::Boa => "boa",
+        JavascriptBackend::Jsc => "jsc",
+        JavascriptBackend::V8 => "v8",
+    };
+    let content_features = if has_media {
+        format!("{backend_feature},media")
     } else {
-        // JSC backend
-        if has_media {
-            // Content defaults are ["media", "boa"] — must override to jsc+media.
-            command.args(["--no-default-features", "--features", "jsc,media"]);
-        } else {
-            // JSC without media
-            command.args(["--no-default-features", "--features", "jsc"]);
-        }
-    }
+        backend_feature.to_owned()
+    };
+    command.args(["--no-default-features", "--features", &content_features]);
     command.arg("--target-dir").arg(&prebuild_target_root);
     for (package_name, binary_name) in prebuild_list {
         command
@@ -125,6 +127,40 @@ fn prebuild_binaries(prebuild_list: &[(&str, &str)]) -> Result<(), String> {
     }
 
     Ok(())
+}
+
+fn selected_javascript_backend() -> Result<JavascriptBackend, String> {
+    let enabled_backends = [
+        (cfg!(feature = "boa"), JavascriptBackend::Boa, "boa"),
+        (cfg!(feature = "jsc"), JavascriptBackend::Jsc, "jsc"),
+        (cfg!(feature = "v8"), JavascriptBackend::V8, "v8"),
+    ];
+    let selected_backends: Vec<_> = enabled_backends
+        .into_iter()
+        .filter(|(enabled, _, _)| *enabled)
+        .collect();
+
+    if selected_backends.len() != 1 {
+        let selected_names: Vec<_> = selected_backends
+            .iter()
+            .map(|(_, _, name)| *name)
+            .collect();
+        return Err(format!(
+            "exactly one JavaScript backend feature must be enabled; selected: {}",
+            if selected_names.is_empty() {
+                "none".to_owned()
+            } else {
+                selected_names.join(", ")
+            }
+        ));
+    }
+
+    if cfg!(feature = "v8") && cfg!(feature = "wasm") {
+        return Err("features `v8` and `wasm` cannot be enabled together".to_owned());
+    }
+
+    let (_, selected_backend, _) = selected_backends[0];
+    Ok(selected_backend)
 }
 
 fn copy_prebuilt_binary(

--- a/content/Cargo.toml
+++ b/content/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 autobins = false
 
 [lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(boa_backend)', 'cfg(jsc_backend)'] }
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(boa_backend)', 'cfg(jsc_backend)', 'cfg(v8_backend)'] }
 
 [features]
 default = ["media", "boa"]
@@ -16,6 +16,7 @@ media = []
 # JSC available on macOS by passing --no-default-features --features jsc,media.
 boa = ["js_engine/boa", "dep:boa_engine", "dep:boa_gc"]
 jsc = ["js_engine/jsc"]
+v8 = ["js_engine/v8"]
 
 # Optional WebAssembly support (only meaningful with `boa` backend).
 wasm = ["dep:wasmtime"]

--- a/content/build.rs
+++ b/content/build.rs
@@ -1,20 +1,22 @@
 //! Content crate build script.
 //!
-//! Sets `boa_backend` or `jsc_backend` cfg flags based on the active
-//! Cargo feature (`boa` vs `jsc`).  The features are mutually exclusive.
+//! Sets an engine-specific cfg flag based on the active Cargo feature.
+//! The engine features are mutually exclusive.
 //!
 //! On non-Apple platforms, `jsc` is rejected with a compile error.
 
 fn main() {
     let has_jsc = std::env::var("CARGO_FEATURE_JSC").is_ok();
     let has_boa = std::env::var("CARGO_FEATURE_BOA").is_ok();
+    let has_v8 = std::env::var("CARGO_FEATURE_V8").is_ok();
+    let has_wasm = std::env::var("CARGO_FEATURE_WASM").is_ok();
+    let enabled_backend_count = [has_boa, has_jsc, has_v8]
+        .into_iter()
+        .filter(|enabled| *enabled)
+        .count();
 
-    if has_jsc && has_boa {
-        panic!("features `boa` and `jsc` are mutually exclusive — enable only one");
-    }
-
-    if !has_jsc && !has_boa {
-        panic!("one of `boa` or `jsc` feature must be enabled");
+    if enabled_backend_count != 1 {
+        panic!("exactly one of `boa`, `jsc`, or `v8` must be enabled");
     }
 
     if has_jsc {
@@ -27,12 +29,26 @@ fn main() {
             );
         }
         println!("cargo:rustc-cfg=jsc_backend");
-    } else {
+    } else if has_boa {
         println!("cargo:rustc-cfg=boa_backend");
+    } else {
+        let target_arch = std::env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_default();
+        let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
+        if target_arch != "aarch64" || target_os != "macos" {
+            panic!(
+                "v8 backend currently supports only aarch64-apple-darwin; selected target is {target_arch}-{target_os}"
+            );
+        }
+        if has_wasm {
+            panic!("features `v8` and `wasm` cannot be enabled together");
+        }
+        println!("cargo:rustc-cfg=v8_backend");
     }
 
     // Rerun if the active feature changes.
     println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rerun-if-env-changed=CARGO_FEATURE_JSC");
     println!("cargo:rerun-if-env-changed=CARGO_FEATURE_BOA");
+    println!("cargo:rerun-if-env-changed=CARGO_FEATURE_V8");
+    println!("cargo:rerun-if-env-changed=CARGO_FEATURE_WASM");
 }

--- a/content/src/generic_js_test.rs
+++ b/content/src/generic_js_test.rs
@@ -699,8 +699,7 @@ mod tests {
     use js_engine::TypedArrayElementType;
     use js_engine::{EcmascriptHost, ExecutionContext, JsEngine};
 
-    /// Create an initialized engine context with the TestWidget interface
-    /// registered (Boa) or available (JSC).
+    /// Create an initialized engine context with the TestWidget interface registered.
     /// Returns the concrete engine type so callers can use both
     /// `ExecutionContext` and `JsEngine` trait methods.
     #[cfg(boa_backend)]
@@ -729,6 +728,19 @@ mod tests {
         // the registry so create_test_widget can find the prototype.
         register_interface_spec::<TestTypes, TestWidget, _>(&mut engine).ok();
         register_interface_spec::<TestTypes, TestButton, _>(&mut engine).ok();
+        wire_test_interface_prototypes(&mut engine);
+        engine
+    }
+
+    #[cfg(v8_backend)]
+    fn setup() -> js_engine::v8::V8Engine {
+        use crate::webidl::bindings::{initialize_registry, register_interface_spec};
+        let mut engine = js_engine::v8::V8Engine::new();
+        initialize_registry::<TestTypes>(&mut engine);
+        register_interface_spec::<TestTypes, TestWidget, _>(&mut engine)
+            .expect("register TestWidget on V8");
+        register_interface_spec::<TestTypes, TestButton, _>(&mut engine)
+            .expect("register TestButton on V8");
         wire_test_interface_prototypes(&mut engine);
         engine
     }
@@ -3121,7 +3133,7 @@ mod tests {
     /// Verify that `instanceof` works for platform objects on JSC.
     /// The `hasInstance` callback on BUILTIN_CONSTRUCTOR_CLASS walks the
     /// prototype chain to check against constructor.prototype.
-    #[cfg(not(feature = "boa"))]
+    #[cfg(jsc_backend)]
     #[test]
     fn instanceof_works_for_platform_object_on_jsc() {
         let mut engine = setup();
@@ -3195,7 +3207,7 @@ mod tests {
     /// methods (bind, call, apply) on JSC.  These are copied during
     /// `make_builtin_function` because JSObjectSetPrototype crashes on
     /// objects with callAsConstructor callbacks on macOS 26.
-    #[cfg(not(feature = "boa"))]
+    #[cfg(jsc_backend)]
     #[test]
     fn constructor_has_function_prototype_methods_on_jsc() {
         let mut engine = setup();

--- a/content/src/generic_js_test.rs
+++ b/content/src/generic_js_test.rs
@@ -361,7 +361,8 @@ fn delayed_title(
     let cap = ec.new_promise_capability(intrinsics.promise)?;
     let title_val = ec.value_from_string(ec.js_string_from_str(&title));
     let undef = ec.value_undefined();
-    ec.call(&cap.resolve, &undef, &[title_val])?;
+    let resolve = TestTypes::object_from_function(cap.resolve.clone());
+    ec.call(&resolve, &undef, &[title_val])?;
     Ok(cap.promise)
 }
 
@@ -487,7 +488,8 @@ fn reject_with_message_test(
     let cap = ec.new_promise_capability(intrinsics.promise)?;
     let err = ec.new_type_error(&msg);
     let undef = ec.value_undefined();
-    ec.call(&cap.reject, &undef, &[err])?;
+    let reject = TestTypes::object_from_function(cap.reject.clone());
+    ec.call(&reject, &undef, &[err])?;
     Ok(cap.promise)
 }
 
@@ -1182,7 +1184,8 @@ mod tests {
             .unwrap();
         let undef = engine.value_undefined();
         let val42 = engine.value_from_number(42.0);
-        js_engine::EcmascriptHost::call(&mut engine, &pcap.resolve, &undef, &[val42]).unwrap();
+        let resolve = TestTypes::object_from_function(pcap.resolve.clone());
+        js_engine::EcmascriptHost::call(&mut engine, &resolve, &undef, &[val42]).unwrap();
 
         // Verify the promise is an object (it resolved successfully).
         assert!(TestTypes::value_as_object(&pcap.promise).is_some());
@@ -2038,7 +2041,8 @@ mod tests {
             .unwrap();
         let err = engine.new_type_error("test rejection");
         let undef = engine.value_undefined();
-        engine.call(&cap.reject, &undef, &[err]).unwrap();
+        let reject = TestTypes::object_from_function(cap.reject.clone());
+        engine.call(&reject, &undef, &[err]).unwrap();
         let rejected_promise =
             TestTypes::object_as_promise(&TestTypes::value_as_object(&cap.promise).unwrap())
                 .unwrap();
@@ -2070,7 +2074,8 @@ mod tests {
             .unwrap();
         let val = engine.value_from_number(42.0);
         let undef = engine.value_undefined();
-        engine.call(&cap.resolve, &undef, from_ref(&val)).unwrap();
+        let resolve = TestTypes::object_from_function(cap.resolve.clone());
+        engine.call(&resolve, &undef, from_ref(&val)).unwrap();
 
         // Attach a handler via perform_promise_then.
         let called = std::rc::Rc::new(std::cell::RefCell::new(false));

--- a/content/src/generic_js_test.rs
+++ b/content/src/generic_js_test.rs
@@ -25,6 +25,8 @@
 //! new_promise_capability → perform_promise_then — as a miniature
 //! version of the full `content/` crate.
 
+use std::slice::from_ref;
+
 use crate::webidl::bindings::{AttributeDef, InterfaceDefinition, OperationDef, WebIdlInterface};
 use js_engine::gc::GcRootHandle;
 use js_engine::gc_struct;
@@ -72,7 +74,7 @@ impl TestWidget {
         } else {
             String::from("Untitled")
         };
-        let visible = args.get(1).map_or(true, |v| ec.to_boolean(v));
+        let visible = args.get(1).is_none_or(|value| ec.to_boolean(value));
         let count = args.get(2).map_or(0u32, |_v| 0u32);
         Ok(Self {
             title,
@@ -372,7 +374,7 @@ fn with_callback(
     let title = widget_or_button_with_ref(this, ec, |w| w.title.clone())?;
     let callback_obj = args
         .first()
-        .and_then(|v| TestTypes::value_as_object(v))
+        .and_then(TestTypes::value_as_object)
         .ok_or_else(|| ec.new_type_error("expected a callback function"))?;
     let callback_val = TestTypes::value_from_object(callback_obj.clone());
     if !ec.is_callable(&callback_val) {
@@ -424,7 +426,7 @@ fn create_static(
     } else {
         String::from("Untitled")
     };
-    let visible = args.get(1).map_or(true, |v| ec.to_boolean(v));
+    let visible = args.get(1).is_none_or(|value| ec.to_boolean(value));
     let widget = TestWidget {
         title,
         visible,
@@ -443,7 +445,7 @@ fn store_callback(
 ) -> Completion<JsValue, TestTypes> {
     let callback_obj = args
         .first()
-        .and_then(|v| TestTypes::value_as_object(v))
+        .and_then(TestTypes::value_as_object)
         .ok_or_else(|| ec.new_type_error("expected a callback function"))?;
     let callback_val = TestTypes::value_from_object(callback_obj.clone());
     if !ec.is_callable(&callback_val) {
@@ -461,7 +463,7 @@ fn flush_microtasks_test(
     _args: &[JsValue],
     ec: &mut dyn ExecutionContext<TestTypes>,
 ) -> Completion<JsValue, TestTypes> {
-    let _ = widget_or_button_with_ref(this, ec, |_| ())?;
+    widget_or_button_with_ref(this, ec, |_| ())?;
     ec.perform_a_microtask_checkpoint()?;
     ec.run_jobs();
     Ok(ec.value_undefined())
@@ -474,7 +476,7 @@ fn reject_with_message_test(
     args: &[JsValue],
     ec: &mut dyn ExecutionContext<TestTypes>,
 ) -> Completion<JsValue, TestTypes> {
-    let _ = widget_or_button_with_ref(this, ec, |_| ())?;
+    widget_or_button_with_ref(this, ec, |_| ())?;
     let msg = if let Some(arg) = args.first() {
         ec.to_rust_string(arg.clone())?
     } else {
@@ -762,6 +764,13 @@ mod tests {
         let mut button = TestButton::new("ClickMe");
         button.widget.title = "BtnWidget".into();
         let obj = create_button(button, &mut engine);
+        let button = engine
+            .with_object_any_mut(&obj)
+            .and_then(|data| data.downcast_mut::<TestButton>())
+            .expect("the platform object must contain a TestButton");
+        assert_eq!(button.label_value(), "ClickMe");
+        button.set_label("Pressed");
+        assert_eq!(button.label_value(), "Pressed");
         let js_obj = TestTypes::value_from_object(obj);
 
         // Through the multi-type helper, we should see the widget fields.
@@ -780,11 +789,10 @@ mod tests {
         let mut widget = TestWidget::new();
         widget.title = "PureWidget".into();
         let obj = create_widget(widget, &mut engine);
-        let js_obj = TestTypes::value_from_object(obj);
 
-        // A pure TestWidget (not a TestButton) should still be found
-        // by the multi-type helper (it falls back to TestWidget).
-        let title = widget_or_button_with_ref(&js_obj, &mut engine, |w| w.title.clone()).unwrap();
+        // A pure TestWidget is available through the direct data helper.
+        let title =
+            widget_data::with_ref(&obj, &mut engine, |widget| widget.title.clone()).unwrap();
         assert_eq!(title, "PureWidget");
     }
 
@@ -1456,7 +1464,7 @@ mod tests {
         let js_obj = TestTypes::value_from_object(obj);
         let realm = engine.current_realm();
         let fn_val = JsEngine::evaluate_script(&mut engine, "(function() {})", &realm).unwrap();
-        store_callback(&js_obj, &[fn_val.clone()], &mut engine).unwrap();
+        store_callback(&js_obj, from_ref(&fn_val), &mut engine).unwrap();
         flush_microtasks_test(&js_obj, &[], &mut engine).unwrap();
 
         let obj_ref = TestTypes::value_as_object(&js_obj).unwrap();
@@ -2062,7 +2070,7 @@ mod tests {
             .unwrap();
         let val = engine.value_from_number(42.0);
         let undef = engine.value_undefined();
-        engine.call(&cap.resolve, &undef, &[val.clone()]).unwrap();
+        engine.call(&cap.resolve, &undef, from_ref(&val)).unwrap();
 
         // Attach a handler via perform_promise_then.
         let called = std::rc::Rc::new(std::cell::RefCell::new(false));
@@ -2875,7 +2883,6 @@ mod tests {
     fn bigint_primitive_detection() {
         let mut engine = setup();
         let realm = engine.current_realm();
-        let intrinsics = engine.realm_intrinsics(&realm);
         let bi_val = JsEngine::evaluate_script(&mut engine, "123n", &realm).unwrap();
         let bi = <TestTypes as JsTypes>::value_as_bigint(&bi_val);
         assert!(
@@ -3026,7 +3033,7 @@ mod tests {
 
     #[test]
     fn realm_intrinsics_constructors_and_prototypes() {
-        let mut engine = setup();
+        let engine = setup();
         let realm = engine.current_realm();
         let intrinsics = engine.realm_intrinsics(&realm);
 

--- a/content/src/html.rs
+++ b/content/src/html.rs
@@ -1,6 +1,6 @@
 use js_engine::{Completion, ExecutionContext, JsTypes};
 
-use crate::js::Types;
+use crate::js::{Engine, Types};
 
 type JsValue = <Types as JsTypes>::JsValue;
 type JsObject = <Types as JsTypes>::JsObject;
@@ -109,6 +109,7 @@ pub fn await_a_stable_state<F>(
 }
 
 /// <https://html.spec.whatwg.org/#creating-a-new-browsing-context>
+#[cfg(not(v8_backend))]
 pub(crate) fn create_a_new_browsing_context_and_document(
     event_sender: &IpcSender<ContentEvent>,
     traversable_id: NavigableId,
@@ -220,6 +221,7 @@ pub(crate) fn the_rules_for_choosing_a_navigable(
     noopener: bool,
     global_scope: Option<&GlobalScope>,
     window_global: Option<<crate::js::Types as js_engine::JsTypes>::JsObject>,
+    parent_engine: Option<&mut Engine>,
 ) -> ChosenNavigableResult {
     // Step 1: Let chosen be null.
     let mut chosen: Option<NavigableId> = None;
@@ -292,7 +294,11 @@ pub(crate) fn the_rules_for_choosing_a_navigable(
                 let new_document_id = DocumentId::new();
 
                 let (global_object, settings, document) = match global_scope
-                    .create_auxiliary_context_document(new_traversable_id, new_document_id)
+                    .create_auxiliary_context_document(
+                        parent_engine,
+                        new_traversable_id,
+                        new_document_id,
+                    )
                 {
                     Ok(result) => result,
                     Err(error) => {

--- a/content/src/html.rs
+++ b/content/src/html.rs
@@ -109,8 +109,8 @@ pub fn await_a_stable_state<F>(
 }
 
 /// <https://html.spec.whatwg.org/#creating-a-new-browsing-context>
-#[cfg(not(v8_backend))]
 pub(crate) fn create_a_new_browsing_context_and_document(
+    parent_engine: &mut Engine,
     event_sender: &IpcSender<ContentEvent>,
     traversable_id: NavigableId,
     document_id: DocumentId,
@@ -122,12 +122,17 @@ pub(crate) fn create_a_new_browsing_context_and_document(
     ),
     String,
 > {
-    create_a_new_realm(None, event_sender, traversable_id, document_id)
+    create_a_new_realm(
+        Some(parent_engine),
+        event_sender,
+        traversable_id,
+        document_id,
+    )
 }
 
 /// <https://html.spec.whatwg.org/#creating-a-new-browsing-context>
 pub(crate) fn create_a_new_realm(
-    parent: Option<&mut crate::js::Engine>,
+    parent_engine: Option<&mut Engine>,
     event_sender: &IpcSender<ContentEvent>,
     traversable_id: NavigableId,
     document_id: DocumentId,
@@ -157,7 +162,7 @@ pub(crate) fn create_a_new_realm(
     // Steps 9-10, 13: Obtain agent, create realm, set up window environment
     // settings object.
     let settings = EnvironmentSettingsObject::new_in_realm(
-        parent,
+        parent_engine,
         Rc::clone(&document),
         Url::parse("about:blank").map_err(|error| error.to_string())?,
         Some(event_sender.clone()),
@@ -298,8 +303,7 @@ pub(crate) fn the_rules_for_choosing_a_navigable(
                         parent_engine,
                         new_traversable_id,
                         new_document_id,
-                    )
-                {
+                    ) {
                     Ok(result) => result,
                     Err(error) => {
                         error!(

--- a/content/src/html/environment_settings_object.rs
+++ b/content/src/html/environment_settings_object.rs
@@ -84,7 +84,7 @@ impl EnvironmentSettingsObject {
     }
 
     /// Like `new`, but creates the realm within an existing engine (sharing
-    /// the same JS context / GC heap).  Used by `window.open`.
+    /// the same engine heap). Used by `window.open`.
     pub fn new_in_realm(
         parent: Option<&mut Engine>,
         document: Rc<RefCell<BaseDocument>>,

--- a/content/src/html/global_scope.rs
+++ b/content/src/html/global_scope.rs
@@ -5,7 +5,7 @@ use std::{
     vec::Vec,
 };
 
-use super::environment_settings_object::EnvironmentSettingsObject;
+use super::{create_a_new_realm, environment_settings_object::EnvironmentSettingsObject};
 
 use blitz_dom::BaseDocument;
 use ipc::IpcSender;
@@ -18,7 +18,7 @@ use js_engine::gc::{GcCell, gc_cell_new};
 use js_engine::{JsTypes, gc_struct};
 use log::{debug, error};
 
-use crate::js::Types;
+use crate::js::{Engine, Types};
 use crate::webidl::Callback;
 
 type JsValue = <Types as JsTypes>::JsValue;
@@ -595,6 +595,7 @@ impl GlobalScope {
     /// <https://html.spec.whatwg.org/#creating-a-new-auxiliary-browsing-context>
     pub(crate) fn create_auxiliary_context_document(
         &self,
+        parent_engine: Option<&mut Engine>,
         new_traversable_id: NavigableId,
         new_document_id: DocumentId,
     ) -> Result<
@@ -609,7 +610,12 @@ impl GlobalScope {
         let event_sender = event_sender
             .as_ref()
             .ok_or_else(|| String::from("GlobalScope has no event sender"))?;
-        crate::html::create_a_new_realm(None, event_sender, new_traversable_id, new_document_id)
+        create_a_new_realm(
+            parent_engine,
+            event_sender,
+            new_traversable_id,
+            new_document_id,
+        )
     }
 
     /// Set the shared new-document registry that both GlobalScope and

--- a/content/src/html/html_anchor_element.rs
+++ b/content/src/html/html_anchor_element.rs
@@ -82,6 +82,7 @@ impl HTMLAnchorElement {
             noopener,
             None, // no GlobalScope: anchor nav delegates new traversables to UA
             None, // anchor nav uses no return window
+            None, // anchor navigation does not create a local realm
         );
 
         navigate(

--- a/content/src/html/html_iframe_element.rs
+++ b/content/src/html/html_iframe_element.rs
@@ -14,13 +14,10 @@ use js_engine::{ExecutionContext, gc_struct};
 use url::Url;
 
 use crate::{
-    ContentProcess, EMPTY_HTML_DOCUMENT, NavigableContainerState, dom::event::EventTargetAccess,
-    dom::fire_event, html::HTMLElement, html::navigate, webidl::Callback,
+    ContentDocument, ContentProcess, EMPTY_HTML_DOCUMENT, NavigableContainerState,
+    dom::event::EventTargetAccess, dom::fire_event, html::HTMLElement,
+    html::create_a_new_browsing_context_and_document, html::navigate, webidl::Callback,
 };
-#[cfg(not(v8_backend))]
-use crate::html::create_a_new_browsing_context_and_document;
-#[cfg(v8_backend)]
-use crate::html::create_a_new_realm;
 
 /// <https://html.spec.whatwg.org/#htmliframeelement>
 #[gc_struct]
@@ -359,10 +356,6 @@ pub(crate) fn retire_iframe_traversable(
 }
 
 /// <https://html.spec.whatwg.org/#create-a-new-child-navigable>
-///
-/// Content-process side of the algorithm. Steps 1-9 are executed locally (including
-/// creating the browsing context and document). Step 10, 12-13 (session history
-/// traversal steps, WebDriver notification) are delegated to the user agent.
 fn create_a_new_child_navigable(
     process: &mut ContentProcess,
     parent_navigable_id: NavigableId,
@@ -410,33 +403,24 @@ fn create_a_new_child_navigable(
     // environment settings object.  The content-process side handles this;
     // the UA handles BC allocation, group membership, and session history.
     let content_frame_id = process.allocate_child_frame_id();
-    #[cfg(not(v8_backend))]
+    let event_sender = process.event_sender.clone();
+    let parent_engine = &mut process
+        .documents
+        .get_mut(&parent_document_id)
+        .ok_or_else(|| format!("missing parent document {parent_document_id}"))?
+        .settings
+        .realm_execution_context;
     let (_global_object, settings, new_document) = create_a_new_browsing_context_and_document(
-        &process.event_sender,
+        parent_engine,
+        &event_sender,
         content_navigable,
         new_document_id,
     )?;
-    #[cfg(v8_backend)]
-    let (_global_object, settings, new_document) = {
-        let event_sender = process.event_sender.clone();
-        let parent_engine = &mut process
-            .documents
-            .get_mut(&parent_document_id)
-            .ok_or_else(|| format!("missing parent document {parent_document_id}"))?
-            .settings
-            .realm_execution_context;
-        create_a_new_realm(
-            Some(parent_engine),
-            &event_sender,
-            content_navigable,
-            new_document_id,
-        )?
-    };
 
     // Register the document in ContentProcess immediately.
     process.documents.insert(
         new_document_id,
-        crate::ContentDocument {
+        ContentDocument {
             traversable_id: content_navigable,
             parent_traversable_id: Some(parent_navigable),
             top_level_traversable_id,

--- a/content/src/html/html_iframe_element.rs
+++ b/content/src/html/html_iframe_element.rs
@@ -17,6 +17,10 @@ use crate::{
     ContentProcess, EMPTY_HTML_DOCUMENT, NavigableContainerState, dom::event::EventTargetAccess,
     dom::fire_event, html::HTMLElement, html::navigate, webidl::Callback,
 };
+#[cfg(not(v8_backend))]
+use crate::html::create_a_new_browsing_context_and_document;
+#[cfg(v8_backend)]
+use crate::html::create_a_new_realm;
 
 /// <https://html.spec.whatwg.org/#htmliframeelement>
 #[gc_struct]
@@ -406,12 +410,28 @@ fn create_a_new_child_navigable(
     // environment settings object.  The content-process side handles this;
     // the UA handles BC allocation, group membership, and session history.
     let content_frame_id = process.allocate_child_frame_id();
-    let (_global_object, settings, new_document) =
-        crate::html::create_a_new_browsing_context_and_document(
-            &process.event_sender,
+    #[cfg(not(v8_backend))]
+    let (_global_object, settings, new_document) = create_a_new_browsing_context_and_document(
+        &process.event_sender,
+        content_navigable,
+        new_document_id,
+    )?;
+    #[cfg(v8_backend)]
+    let (_global_object, settings, new_document) = {
+        let event_sender = process.event_sender.clone();
+        let parent_engine = &mut process
+            .documents
+            .get_mut(&parent_document_id)
+            .ok_or_else(|| format!("missing parent document {parent_document_id}"))?
+            .settings
+            .realm_execution_context;
+        create_a_new_realm(
+            Some(parent_engine),
+            &event_sender,
             content_navigable,
             new_document_id,
-        )?;
+        )?
+    };
 
     // Register the document in ContentProcess immediately.
     process.documents.insert(

--- a/content/src/html/location.rs
+++ b/content/src/html/location.rs
@@ -1,13 +1,10 @@
+use ipc::IpcSender;
+use ipc_messages::content::{Event as ContentEvent, NavigableId};
 use ipc_messages::content::UserNavigationInvolvement;
 use log::error;
 use url::{Host, Url};
 
-use super::Window;
-use crate::js::Types;
-use js_engine::JsTypes;
 use js_engine::gc_struct;
-
-type JsObject = <Types as JsTypes>::JsObject;
 
 /// <https://html.spec.whatwg.org/#location>
 #[gc_struct]
@@ -23,11 +20,13 @@ pub struct Location {
     #[ignore_trace]
     relevant_document_origin: Option<String>,
 
-    /// <https://html.spec.whatwg.org/#concept-relevant-global>
-    /// The Window JS object that owns the GlobalScope with navigation state.
-    /// Location uses `downcast_ref` through this handle to access the native
-    /// Window struct — this is safe and doesn't require raw pointer manipulation.
-    window: JsObject,
+    /// <https://html.spec.whatwg.org/#concept-navigable>
+    #[ignore_trace]
+    source_navigable_id: Option<NavigableId>,
+
+    /// <https://html.spec.whatwg.org/#navigate>
+    #[ignore_trace]
+    event_sender: Option<IpcSender<ContentEvent>>,
 }
 
 pub(crate) enum LocationError {
@@ -43,11 +42,16 @@ enum NavigationHistoryBehavior {
 }
 
 impl Location {
-    pub(crate) fn new(url: Url, window: JsObject) -> Self {
+    pub(crate) fn new(
+        url: Url,
+        source_navigable_id: Option<NavigableId>,
+        event_sender: Option<IpcSender<ContentEvent>>,
+    ) -> Self {
         Self {
             relevant_document_origin: Some(url.origin().unicode_serialization()),
             url,
-            window,
+            source_navigable_id,
+            event_sender,
         }
     }
 
@@ -554,27 +558,10 @@ impl Location {
         _history_handling: NavigationHistoryBehavior,
     ) -> Result<(), LocationError> {
         // Step 1: "Let navigable be location's relevant global object's navigable."
-        // Note: Location uses `downcast_ref` through the `window` handle.
-        // This is safe — the Window JsObject is stored as a `#[gc_struct]`
-        // field, and direct `downcast_ref` works because the Location's
-        // `window` field is a raw JsObject handle (not wrapped in
-        // `TraceableBox`).  The downcast finds the Window's NativeDataWrapper
-        // and recovers the concrete type.
-        //
-        // TODO: When Location is created via `create_interface_instance`,
-        // the `window` field becomes a raw JsObject (not TraceableBox), so
-        // `downcast_ref` works.  If the storage strategy changes, switch to
-        // `ec.with_object_any(&self.window).and_then(|data| data.downcast_ref::<Window>())`
-        // and thread `ec` through the navigate call chain.
-        let window = self.window.downcast_ref::<Window>().ok_or_else(|| {
-            LocationError::NotSupported(String::from(
-                "Location window is not a valid Window object",
-            ))
-        })?;
-        let Some(navigable_id) = window.global_scope.source_navigable_id() else {
+        let Some(navigable_id) = self.source_navigable_id else {
             return Ok(());
         };
-        let Some(event_sender) = window.global_scope.event_sender() else {
+        let Some(event_sender) = &self.event_sender else {
             return Err(LocationError::NotSupported(String::from(
                 "Location navigation not available: no IPC sender",
             )));
@@ -596,7 +583,7 @@ impl Location {
         // Step 4: "Navigate navigable to url using sourceDocument, with exceptionsEnabled
         // set to true and historyHandling set to historyHandling."
         super::navigate(
-            &event_sender,
+            event_sender,
             navigable_id,
             Some(navigable_id),
             url.to_string(),

--- a/content/src/html/location.rs
+++ b/content/src/html/location.rs
@@ -1,6 +1,6 @@
 use ipc::IpcSender;
-use ipc_messages::content::{Event as ContentEvent, NavigableId};
 use ipc_messages::content::UserNavigationInvolvement;
+use ipc_messages::content::{Event as ContentEvent, NavigableId};
 use log::error;
 use url::{Host, Url};
 

--- a/content/src/html/ui_events.rs
+++ b/content/src/html/ui_events.rs
@@ -327,7 +327,18 @@ pub(crate) fn dispatch_trusted_click_event(
         document, settings, event_sender, deferred,
     );
     let time_millis = handler.settings.current_time_millis();
-    let event_domain = Event::new("click".into(), true, true, true, true, time_millis);
+    let event = {
+        let ec = handler.settings.ec();
+        let event_object = create_interface_instance::<Types, Event>(
+            Event::new("click".into(), true, true, true, true, time_millis),
+            ec,
+        )
+        .map_err(|error| format!("failed to create trusted click event: {error:?}"))?;
+        ec.with_object_any(&event_object)
+            .and_then(|data| data.downcast_ref::<Event>())
+            .cloned()
+            .ok_or_else(|| String::from("trusted click object does not contain an Event"))?
+    };
     let path = {
         let ec = handler.settings.ec();
         let target = crate::js::platform_objects::resolve_element_object(target_node_id, ec)
@@ -335,6 +346,123 @@ pub(crate) fn dispatch_trusted_click_event(
         crate::js::platform_objects::build_path_from_target_js_object(&target, ec)
     };
     let ec = handler.settings.ec();
-    dispatch_with_path(ec, &path, &event_domain).map_err(|e| format!("failed to dispatch click event: {e:?}"))?;
-    handler.settings.perform_a_microtask_checkpoint().map_err(|e| format!("microtask checkpoint after click: {e:?}"))
+    dispatch_with_path(ec, &path, &event)
+        .map_err(|error| format!("failed to dispatch click event: {error:?}"))?;
+    handler
+        .settings
+        .perform_a_microtask_checkpoint()
+        .map_err(|error| format!("microtask checkpoint after click: {error:?}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{cell::RefCell, rc::Rc};
+
+    use blitz_dom::{BaseDocument, DocumentConfig};
+    use ipc::channel;
+    use ipc_messages::content::{DocumentId, Event as ContentEvent, NavigableId};
+    use serde_json::json;
+    use url::Url;
+
+    use crate::dom::{Event, UIEvent as JsUiEvent, dispatch_with_path};
+    use crate::html::{
+        EnvironmentSettingsObject, execute_parser_scripts, parse_html_into_document,
+    };
+    use crate::js::Types;
+    use crate::js::platform_objects::{build_path_from_target_js_object, resolve_element_object};
+    use crate::webidl::bindings::create_interface_instance;
+
+    use super::dispatch_trusted_click_event;
+
+    fn new_document() -> Rc<RefCell<BaseDocument>> {
+        Rc::new(RefCell::new(BaseDocument::new(DocumentConfig::default())))
+    }
+
+    #[test]
+    fn click_events_invoke_listener_in_child_realm() {
+        let creation_url = Url::parse("about:blank").expect("parse creation URL");
+        let mut parent_settings =
+            EnvironmentSettingsObject::new(new_document(), creation_url.clone(), None, None, None)
+                .expect("build parent settings object");
+        let child_document = new_document();
+        let scripts = parse_html_into_document(
+            &mut child_document.borrow_mut(),
+            r#"<button id="target">Click</button>
+                <script>
+                    globalThis.clickCount = 0;
+                    document.getElementById("target").addEventListener("click", function() {
+                        globalThis.clickCount += 1;
+                    });
+                </script>"#,
+        );
+        let mut child_settings = EnvironmentSettingsObject::new_in_realm(
+            Some(&mut parent_settings.realm_execution_context),
+            Rc::clone(&child_document),
+            creation_url,
+            None,
+            None,
+            None,
+        )
+        .expect("build child settings object");
+        execute_parser_scripts(&mut child_settings, scripts).expect("execute child script");
+        let target_node_id = child_document
+            .borrow()
+            .query_selector("#target")
+            .expect("query selector")
+            .expect("find click target");
+        let (event_sender, _event_receiver) =
+            channel::<ContentEvent>().expect("create event channel");
+
+        dispatch_trusted_click_event(
+            DocumentId::from_u128(1),
+            NavigableId::from_u128(2),
+            Some(NavigableId::from_u128(1)),
+            NavigableId::from_u128(1),
+            Rc::clone(&child_document),
+            &mut child_settings,
+            &event_sender,
+            target_node_id,
+        )
+        .expect("dispatch trusted click");
+
+        assert_eq!(
+            child_settings
+                .evaluate_script_to_json("globalThis.clickCount")
+                .expect("read click count"),
+            json!(1),
+        );
+
+        child_settings
+            .evaluate_script_to_json("globalThis.clickCount = 0")
+            .expect("reset click count");
+        let ui_event = {
+            let ec = child_settings.ec();
+            let event_object = create_interface_instance::<Types, JsUiEvent>(
+                JsUiEvent {
+                    event: Event::new("click".into(), true, true, false, true, 0.0),
+                    view: None,
+                    detail: 0,
+                },
+                ec,
+            )
+            .expect("create UIEvent");
+            ec.with_object_any(&event_object)
+                .and_then(|data| data.downcast_ref::<JsUiEvent>())
+                .map(|ui_event| ui_event.event.clone())
+                .expect("read embedded Event")
+        };
+        let path = {
+            let ec = child_settings.ec();
+            let target = resolve_element_object(target_node_id, ec).expect("resolve click target");
+            build_path_from_target_js_object(&target, ec)
+        };
+        dispatch_with_path(child_settings.ec(), &path, &ui_event).expect("dispatch UIEvent");
+
+        assert_eq!(
+            child_settings
+                .evaluate_script_to_json("globalThis.clickCount")
+                .expect("read UIEvent click count"),
+            json!(1),
+        );
+    }
 }

--- a/content/src/html/window.rs
+++ b/content/src/html/window.rs
@@ -7,7 +7,7 @@ use ipc_messages::content::{Event as ContentEvent, UserNavigationInvolvement};
 
 use js_engine::{Completion, ExecutionContext, JsTypes};
 
-use crate::js::Types;
+use crate::js::{Engine, Types};
 
 type JsValue = <Types as JsTypes>::JsValue;
 
@@ -240,6 +240,8 @@ pub(crate) fn window_open_steps(
         .top_level_traversable_id()
         .unwrap_or(source_navigable_id);
 
+    let window_global = ec.global_object();
+    let parent_engine = ec.as_any_mut().downcast_mut::<Engine>();
     let result = the_rules_for_choosing_a_navigable(
         source_navigable_id,
         parent_traversable_id,
@@ -247,7 +249,8 @@ pub(crate) fn window_open_steps(
         target,
         noopener,
         Some(global_scope),
-        Some(ec.global_object()),
+        Some(window_global),
+        parent_engine,
     );
 
     let navigate_url = url_record.unwrap_or_else(|| String::from("about:blank"));

--- a/content/src/html/windowproxy.rs
+++ b/content/src/html/windowproxy.rs
@@ -31,7 +31,7 @@ fn trap_get_prototype_of(
     _this: JsValue,
     ec: &mut dyn ExecutionContext<crate::js::Types>,
 ) -> Completion<JsValue, crate::js::Types> {
-    let win = target_window(_args)?;
+    let win = target_window(_args, ec)?;
 
     // Step 2: "If IsPlatformObjectSameOrigin(W) is true, then return !
     //           OrdinaryGetPrototypeOf(W)."
@@ -50,7 +50,7 @@ fn trap_set_prototype_of(
     _this: JsValue,
     ec: &mut dyn ExecutionContext<crate::js::Types>,
 ) -> Completion<JsValue, crate::js::Types> {
-    let win = target_window(args)?;
+    let win = target_window(args, ec)?;
     let val = args.get(1).cloned().unwrap_or_else(|| ec.value_undefined());
 
     // Step 1: "Return ! SetImmutablePrototype(this, V)."
@@ -89,7 +89,7 @@ fn trap_define_property(
     _this: JsValue,
     ec: &mut dyn ExecutionContext<crate::js::Types>,
 ) -> Completion<JsValue, crate::js::Types> {
-    let win = target_window(args)?;
+    let win = target_window(args, ec)?;
     let key = args.get(1).cloned().unwrap_or_else(|| ec.value_undefined());
     let desc_obj_val = args.get(2).cloned().unwrap_or_else(|| ec.value_undefined());
 
@@ -115,7 +115,7 @@ fn trap_get(
     _this: JsValue,
     ec: &mut dyn ExecutionContext<crate::js::Types>,
 ) -> Completion<JsValue, crate::js::Types> {
-    let win = target_window(args)?;
+    let win = target_window(args, ec)?;
     let key = args.get(1).cloned().unwrap_or_else(|| ec.value_undefined());
 
     // Step 2: "Check if an access between two browsing contexts should be
@@ -161,7 +161,7 @@ fn trap_set(
     _this: JsValue,
     ec: &mut dyn ExecutionContext<crate::js::Types>,
 ) -> Completion<JsValue, crate::js::Types> {
-    let win = target_window(args)?;
+    let win = target_window(args, ec)?;
     let key = args.get(1).cloned().unwrap_or_else(|| ec.value_undefined());
 
     // Step 2: "Check if an access between two browsing contexts should be
@@ -187,7 +187,7 @@ fn trap_delete_property(
     _this: JsValue,
     ec: &mut dyn ExecutionContext<crate::js::Types>,
 ) -> Completion<JsValue, crate::js::Types> {
-    let win = target_window(args)?;
+    let win = target_window(args, ec)?;
     let key = args.get(1).cloned().unwrap_or_else(|| ec.value_undefined());
 
     // Step 2: "If IsPlatformObjectSameOrigin(W) is true:"
@@ -215,7 +215,7 @@ fn trap_has(
     _this: JsValue,
     ec: &mut dyn ExecutionContext<crate::js::Types>,
 ) -> Completion<JsValue, crate::js::Types> {
-    let win = target_window(args)?;
+    let win = target_window(args, ec)?;
     let key = args.get(1).cloned().unwrap_or_else(|| ec.value_undefined());
 
     // Note: The WindowProxy spec does not override [[HasProperty]].  This
@@ -238,7 +238,7 @@ fn trap_own_keys(
     _this: JsValue,
     ec: &mut dyn ExecutionContext<crate::js::Types>,
 ) -> Completion<JsValue, crate::js::Types> {
-    let win = target_window(_args)?;
+    let win = target_window(_args, ec)?;
 
     // Step 2: "Let maxProperties be W's associated Document's document-tree
     //          child navigables's size."
@@ -249,7 +249,7 @@ fn trap_own_keys(
     let window_keys = ec.own_property_keys(win)?;
     let key_array = ec.create_empty_array();
     for val in window_keys.into_iter() {
-        let js_val: JsValue = val.into();
+        let js_val = ec.value_from_property_key(val);
         ec.array_push(&key_array, js_val)?;
     }
     Ok(<crate::js::Types as JsTypes>::value_from_object(key_array))
@@ -259,10 +259,13 @@ fn trap_own_keys(
 ///
 /// The proxy target IS W (the Window object), passed as `args[0]` by the
 /// ECMAScript Proxy internal methods (10.5).
-fn target_window(args: &[JsValue]) -> Result<JsObject, JsValue> {
+fn target_window(
+    args: &[JsValue],
+    ec: &mut dyn ExecutionContext<crate::js::Types>,
+) -> Result<JsObject, JsValue> {
     args.first()
         .and_then(|value| <Types as JsTypes>::value_as_object(value))
-        .ok_or_else(|| JsValue::default())
+        .ok_or_else(|| ec.value_undefined())
 }
 
 /// Captures for the wrapper function created by `trap_get`.

--- a/content/src/js/bindings/html/html_iframe_element.rs
+++ b/content/src/js/bindings/html/html_iframe_element.rs
@@ -177,8 +177,7 @@ fn set_onload(
     args: &[JsValue],
     ec: &mut dyn ExecutionContext<Types>,
 ) -> Completion<JsValue, Types> {
-    #[allow(unused_mut)]
-    let mut iframe_object = <Types as JsTypes>::value_as_object(this)
+    let iframe_object = <Types as JsTypes>::value_as_object(this)
         .ok_or_else(|| ec.new_type_error("HTMLIFrameElement receiver is not an object"))?;
     let callback = nullable_value(
         args.get(0).unwrap_or(&ec.value_undefined()),
@@ -186,12 +185,12 @@ fn set_onload(
         callback_function_value,
     )?;
 
-    // Note: uses JsObject::downcast_mut — with_object_any_mut borrows ec.
-    #[cfg_attr(jsc_backend, allow(unused_mut))]
-    let previous = if let Some(mut iframe) = iframe_object.downcast_mut::<HTMLIFrameElement>() {
-        iframe.replace_onload(callback.clone())
-    } else {
-        return Err(ec.new_type_error("receiver is not an HTMLIFrameElement"));
+    let previous = match ec
+        .with_object_any_mut(&iframe_object)
+        .and_then(|data| data.downcast_mut::<HTMLIFrameElement>())
+    {
+        Some(iframe) => iframe.replace_onload(callback.clone()),
+        None => return Err(ec.new_type_error("receiver is not an HTMLIFrameElement")),
     };
 
     if let Some(previous) = previous {
@@ -233,8 +232,7 @@ fn set_onerror(
     args: &[JsValue],
     ec: &mut dyn ExecutionContext<Types>,
 ) -> Completion<JsValue, Types> {
-    #[cfg_attr(boa_backend, allow(unused_mut))]
-    let mut iframe_object = <Types as JsTypes>::value_as_object(this)
+    let iframe_object = <Types as JsTypes>::value_as_object(this)
         .ok_or_else(|| ec.new_type_error("HTMLIFrameElement receiver is not an object"))?;
     let callback = nullable_value(
         args.get(0).unwrap_or(&ec.value_undefined()),
@@ -242,12 +240,12 @@ fn set_onerror(
         callback_function_value,
     )?;
 
-    // Note: uses JsObject::downcast_mut — with_object_any_mut borrows ec.
-    #[cfg_attr(jsc_backend, allow(unused_mut))]
-    let previous = if let Some(mut iframe) = iframe_object.downcast_mut::<HTMLIFrameElement>() {
-        iframe.replace_onerror(callback.clone())
-    } else {
-        return Err(ec.new_type_error("receiver is not an HTMLIFrameElement"));
+    let previous = match ec
+        .with_object_any_mut(&iframe_object)
+        .and_then(|data| data.downcast_mut::<HTMLIFrameElement>())
+    {
+        Some(iframe) => iframe.replace_onerror(callback.clone()),
+        None => return Err(ec.new_type_error("receiver is not an HTMLIFrameElement")),
     };
 
     if let Some(previous) = previous {

--- a/content/src/js/bindings/html/window.rs
+++ b/content/src/js/bindings/html/window.rs
@@ -532,8 +532,18 @@ fn location_object(
 
     let url = document_creation_url(ec)?;
     let window = ec.global_object();
-    let object =
-        create_interface_instance::<crate::js::Types, Location>(Location::new(url, window), ec)?;
+    let (source_navigable_id, event_sender) = ec
+        .with_object_any(&window)
+        .and_then(|data| data.downcast_ref::<Window>())
+        .map(|window| {
+            (
+                window.global_scope.source_navigable_id(),
+                window.global_scope.event_sender(),
+            )
+        })
+        .unwrap_or((None, None));
+    let location = Location::new(url, source_navigable_id, event_sender);
+    let object = create_interface_instance::<crate::js::Types, Location>(location, ec)?;
     platform_objects::store_location_object(ec, object.clone())?;
     Ok(object)
 }

--- a/content/src/js/bindings/streams/readablestream.rs
+++ b/content/src/js/bindings/streams/readablestream.rs
@@ -356,7 +356,7 @@ fn get_locked(
     let locked = with_readable_stream_ref(&stream_object, ec, |stream: &ReadableStream| {
         stream.locked()
     })?;
-    Ok(JsValue::from(locked))
+    Ok(ec.value_from_bool(locked))
 }
 
 fn cancel_method(
@@ -490,7 +490,7 @@ fn get_desired_size(
         with_readable_stream_default_controller_ref(&controller_object, ec, |c| c.clone())?;
     let size = controller.desired_size(ec)?;
     Ok(match size {
-        Some(s) => JsValue::from(s),
+        Some(size) => ec.value_from_number(size),
         None => ec.value_null(),
     })
 }
@@ -507,7 +507,7 @@ fn get_byte_desired_size(
         with_readable_byte_stream_controller_ref(&controller_object, ec, |c| c.clone())?;
     let size = controller.desired_size(ec)?;
     Ok(match size {
-        Some(s) => JsValue::from(s),
+        Some(size) => ec.value_from_number(size),
         None => ec.value_null(),
     })
 }

--- a/content/src/js/bindings/streams/transformstream.rs
+++ b/content/src/js/bindings/streams/transformstream.rs
@@ -133,7 +133,7 @@ fn get_desired_size(
     let controller = with_transform_stream_default_controller_ref(&obj, ec, |c| c.clone())?;
     let size = controller.desired_size(ec)?;
     match size {
-        Some(s) => Ok(s.into()),
+        Some(size) => Ok(ec.value_from_number(size)),
         None => Ok(ec.value_null()),
     }
 }

--- a/content/src/js/bindings/streams/writablestream.rs
+++ b/content/src/js/bindings/streams/writablestream.rs
@@ -194,7 +194,7 @@ fn get_locked(
     let stream_object = <Types as JsTypes>::value_as_object(this)
         .ok_or_else(|| ec.new_type_error("WritableStream receiver is not an object"))?;
     let locked = with_writable_stream_ref(&stream_object, ec, |stream| stream.locked())?;
-    Ok(JsValue::from(locked))
+    Ok(ec.value_from_bool(locked))
 }
 
 fn abort_method(
@@ -291,7 +291,7 @@ fn get_desired_size(
     let writer = with_writable_stream_default_writer_ref(&writer_object, ec, |w| w.clone())?;
     let size = writer.desired_size(ec)?;
     Ok(match size {
-        Some(s) => JsValue::from(s),
+        Some(size) => ec.value_from_number(size),
         None => ec.value_null(),
     })
 }

--- a/content/src/js/build_context.rs
+++ b/content/src/js/build_context.rs
@@ -16,10 +16,9 @@ pub(crate) fn build_context(document: Rc<RefCell<BaseDocument>>) -> Result<Engin
     build_context_inner(document)
 }
 
-/// Create a new realm within an existing engine, sharing the same engine heap
-/// but with its own global object, Window, Document, and prototype chain.
+/// Create a new realm associated with an existing engine.
 ///
-/// JSC and V8 share their engine heap. Boa currently creates a fresh engine.
+/// V8 shares its isolate. Boa and JSC currently create a fresh engine.
 pub(crate) fn build_realm(
     engine: &mut Engine,
     document: Rc<RefCell<BaseDocument>>,
@@ -50,12 +49,10 @@ fn build_context_inner(document: Rc<RefCell<BaseDocument>>) -> Result<Engine, St
 
 #[cfg(jsc_backend)]
 fn build_realm_inner(
-    engine: &mut Engine,
+    _engine: &mut Engine,
     document: Rc<RefCell<BaseDocument>>,
 ) -> Result<Engine, String> {
-    let mut child = engine.new_shared_realm();
-    setup_realm(&mut child, document)?;
-    Ok(child)
+    build_context_inner(document)
 }
 
 #[cfg(v8_backend)]
@@ -358,4 +355,47 @@ fn build_realm_inner(
     // Currently falls back to full build_context since Boa's
     // multi-realm support needs the host_hooks path.
     crate::js::bindings::html::build_context(_document)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{cell::RefCell, rc::Rc};
+
+    use blitz_dom::{BaseDocument, DocumentConfig};
+    use js_engine::ExecutionContext;
+    use url::Url;
+
+    use crate::html::EnvironmentSettingsObject;
+
+    fn new_document() -> Rc<RefCell<BaseDocument>> {
+        Rc::new(RefCell::new(BaseDocument::new(DocumentConfig::default())))
+    }
+
+    #[test]
+    fn realm_script_resolves_document_global() {
+        let creation_url = Url::parse("about:blank").expect("parse creation URL");
+        let mut parent_settings =
+            EnvironmentSettingsObject::new(new_document(), creation_url.clone(), None, None, None)
+                .expect("build parent settings object");
+        let mut child_settings = EnvironmentSettingsObject::new_in_realm(
+            Some(&mut parent_settings.realm_execution_context),
+            new_document(),
+            creation_url,
+            None,
+            None,
+            None,
+        )
+        .expect("build child settings object");
+
+        let document_type = child_settings
+            .realm_execution_context
+            .evaluate_script("typeof document")
+            .expect("evaluate document global");
+        let document_type = child_settings
+            .realm_execution_context
+            .to_rust_string(document_type)
+            .expect("convert document type");
+
+        assert_eq!(document_type, "object");
+    }
 }

--- a/content/src/js/build_context.rs
+++ b/content/src/js/build_context.rs
@@ -6,9 +6,7 @@ use crate::js::Engine;
 
 /// Build a JavaScript engine context with all native bindings installed.
 ///
-/// On the Boa backend, creates a `BoaContext` with full Web IDL bindings
-/// (DOM, HTML, Streams, WebAssembly).  On the JSC backend, creates a
-/// `JscEngine` with only the generic console namespace.
+/// Creates the selected engine with the generic Web IDL bindings installed.
 ///
 /// Returns a type implementing both [`js_engine::JsEngine<crate::js::Types>`] and
 /// [`js_engine::ExecutionContext<crate::js::Types>`].
@@ -20,8 +18,7 @@ pub(crate) fn build_context(document: Rc<RefCell<BaseDocument>>) -> Result<Engin
 /// JS context (same GC heap) but with its own global object, Window, Document,
 /// and prototype chain.
 ///
-/// On JSC, uses `JscEngine::new_shared_realm()` to create a child engine
-/// sharing the same `JSGlobalContextRef`.  On Boa, uses `create_realm()`.
+/// JSC and V8 share their engine heap. Boa currently creates a fresh engine.
 pub(crate) fn build_realm(
     engine: &mut Engine,
     document: Rc<RefCell<BaseDocument>>,
@@ -34,7 +31,7 @@ fn build_context_inner(document: Rc<RefCell<BaseDocument>>) -> Result<Engine, St
     crate::js::bindings::html::build_context(document)
 }
 
-#[cfg(not(boa_backend))]
+#[cfg(jsc_backend)]
 fn build_context_inner(document: Rc<RefCell<BaseDocument>>) -> Result<Engine, String> {
     use js_engine::jsc::JscEngine;
     let mut engine = JscEngine::new();
@@ -42,7 +39,15 @@ fn build_context_inner(document: Rc<RefCell<BaseDocument>>) -> Result<Engine, St
     Ok(engine)
 }
 
-#[cfg(not(boa_backend))]
+#[cfg(v8_backend)]
+fn build_context_inner(document: Rc<RefCell<BaseDocument>>) -> Result<Engine, String> {
+    use js_engine::v8::V8Engine;
+    let mut engine = V8Engine::new();
+    setup_realm(&mut engine, document)?;
+    Ok(engine)
+}
+
+#[cfg(jsc_backend)]
 fn build_realm_inner(
     engine: &mut Engine,
     document: Rc<RefCell<BaseDocument>>,
@@ -52,9 +57,19 @@ fn build_realm_inner(
     Ok(child)
 }
 
-/// Shared setup for both fresh engines and child realms (JSC backend).
+#[cfg(v8_backend)]
+fn build_realm_inner(
+    engine: &mut Engine,
+    document: Rc<RefCell<BaseDocument>>,
+) -> Result<Engine, String> {
+    let mut child = engine.new_child_realm();
+    setup_realm(&mut child, document)?;
+    Ok(child)
+}
+
+/// Shared setup for engines using the generic interface-registration path.
 /// Initializes the global object, Window, Document, prototypes, etc.
-#[cfg(not(boa_backend))]
+#[cfg(any(jsc_backend, v8_backend))]
 fn setup_realm(engine: &mut Engine, document: Rc<RefCell<BaseDocument>>) -> Result<(), String> {
     use crate::dom::{
         AbortController, AbortSignal, DOMException, Document, Element, Event, EventTarget, Node,
@@ -80,8 +95,7 @@ fn setup_realm(engine: &mut Engine, document: Rc<RefCell<BaseDocument>>) -> Resu
     // Step 1: Create the Window with GlobalScope and associate it with the
     // realm's global object so `global_scope_or_error` works.
     let global_scope = GlobalScope::new(crate::html::GlobalScopeKind::Window, Rc::clone(&document));
-    #[cfg_attr(jsc_backend, allow(unused_mut))]
-    let mut window = Window::new(global_scope);
+    let window = Window::new(global_scope);
     let global_obj = engine.realm_global_object();
     engine.associate_existing_object(&global_obj, Box::new(window));
     // Set the EventTarget reflector for the Window.
@@ -89,7 +103,7 @@ fn setup_realm(engine: &mut Engine, document: Rc<RefCell<BaseDocument>>) -> Resu
     crate::js::try_set_event_target_reflector(&global_value, engine);
 
     // Step 2: Store the global object in host_any.
-    crate::js::platform_objects::init_global_object_slot(engine, global_obj);
+    crate::js::platform_objects::init_global_object_slot(engine, global_obj.clone());
 
     // Step 3: Initialize the interface registry.
     initialize_registry::<crate::js::Types>(engine);
@@ -159,10 +173,20 @@ fn setup_realm(engine: &mut Engine, document: Rc<RefCell<BaseDocument>>) -> Resu
     // Step 7: Set the global object's prototype to Window.prototype so
     // `instanceof Window` etc. works.
     if let Some(window_proto) = get_registry_prototype::<crate::js::Types, Window>(engine) {
-        let _ = engine.set_prototype(global_obj, Some(window_proto));
+        #[cfg(v8_backend)]
+        engine
+            .set_prototype(global_obj.clone(), Some(window_proto.clone()))
+            .map_err(|error| format!("failed to install Window prototype: {error:?}"))?;
+
+        #[cfg(jsc_backend)]
+        if let Err(error) = engine.set_prototype(global_obj, Some(window_proto)) {
+            log::debug!("JSC global prototype remained immutable: {error:?}");
+        }
 
         // Step 7b: JSC's global object prototype is immutable.
         // Copy Window/EventTarget properties to the global object.
+        #[cfg(jsc_backend)]
+        {
         let prototypes = [
             get_registry_prototype::<crate::js::Types, EventTarget>(engine),
             Some(window_proto),
@@ -181,6 +205,7 @@ fn setup_realm(engine: &mut Engine, document: Rc<RefCell<BaseDocument>>) -> Resu
                     }
                 }
             }
+        }
         }
     }
 
@@ -232,18 +257,20 @@ fn setup_realm(engine: &mut Engine, document: Rc<RefCell<BaseDocument>>) -> Resu
         let values_value =
             <crate::js::Types as js_engine::JsTypes>::value_from_object(values_fn.clone());
         let values_desc = js_engine::records::PropertyDescriptor::<crate::js::Types> {
-            value: Some(values_value),
+            value: Some(values_value.clone()),
             writable: Some(true),
             enumerable: Some(true),
             configurable: Some(true),
             get: None,
             set: None,
         };
-        let _ = engine.define_property_or_throw(
-            rs_proto,
+        engine
+            .define_property_or_throw(
+            rs_proto.clone(),
             engine.property_key_from_str("values"),
             values_desc,
-        );
+        )
+            .map_err(|error| format!("failed to install ReadableStream.values: {error:?}"))?;
 
         // @@asyncIterator: same function as values (per spec
         // ReadableStream.prototype[@@asyncIterator] = ReadableStream.prototype.values)
@@ -256,7 +283,11 @@ fn setup_realm(engine: &mut Engine, document: Rc<RefCell<BaseDocument>>) -> Resu
             get: None,
             set: None,
         };
-        let _ = engine.define_property_or_throw(rs_proto, async_iter_key, async_iter_desc);
+        engine
+            .define_property_or_throw(rs_proto.clone(), async_iter_key, async_iter_desc)
+            .map_err(|error| {
+                format!("failed to install ReadableStream async iterator: {error:?}")
+            })?;
 
         // __formalWebReadableStreamPipeToNative (native backstop)
         let native_value =
@@ -269,11 +300,15 @@ fn setup_realm(engine: &mut Engine, document: Rc<RefCell<BaseDocument>>) -> Resu
             get: None,
             set: None,
         };
-        let _ = engine.define_property_or_throw(
-            rs_proto,
+        engine
+            .define_property_or_throw(
+            rs_proto.clone(),
             engine.property_key_from_str("__formalWebReadableStreamPipeToNative"),
             native_desc,
-        );
+        )
+            .map_err(|error| {
+                format!("failed to install ReadableStream pipeTo native function: {error:?}")
+            })?;
 
         // pipeTo: JS wrapper that calls the native backstop.
         let wrapper_source = "(function pipeTo(dest, opts) { return this.__formalWebReadableStreamPipeToNative(dest, opts); })";
@@ -291,11 +326,14 @@ fn setup_realm(engine: &mut Engine, document: Rc<RefCell<BaseDocument>>) -> Resu
                     get: None,
                     set: None,
                 };
-                let _ = engine.define_property_or_throw(
-                    rs_proto,
+                engine.define_property_or_throw(
+                    rs_proto.clone(),
                     engine.property_key_from_str("pipeTo"),
                     pipe_to_desc,
-                );
+                )
+                .map_err(|error| {
+                    format!("failed to install ReadableStream.pipeTo: {error:?}")
+                })?;
             }
         }
     }

--- a/content/src/js/build_context.rs
+++ b/content/src/js/build_context.rs
@@ -1,6 +1,8 @@
 use std::{cell::RefCell, rc::Rc};
 
 use blitz_dom::BaseDocument;
+#[cfg(jsc_backend)]
+use log::error;
 
 use crate::js::Engine;
 
@@ -14,9 +16,8 @@ pub(crate) fn build_context(document: Rc<RefCell<BaseDocument>>) -> Result<Engin
     build_context_inner(document)
 }
 
-/// Create a new realm within an existing engine, sharing the same underlying
-/// JS context (same GC heap) but with its own global object, Window, Document,
-/// and prototype chain.
+/// Create a new realm within an existing engine, sharing the same engine heap
+/// but with its own global object, Window, Document, and prototype chain.
 ///
 /// JSC and V8 share their engine heap. Boa currently creates a fresh engine.
 pub(crate) fn build_realm(
@@ -187,25 +188,31 @@ fn setup_realm(engine: &mut Engine, document: Rc<RefCell<BaseDocument>>) -> Resu
         // Copy Window/EventTarget properties to the global object.
         #[cfg(jsc_backend)]
         {
-        let prototypes = [
-            get_registry_prototype::<crate::js::Types, EventTarget>(engine),
-            Some(window_proto),
-        ];
-        for proto in prototypes.iter().flatten() {
-            if let Ok(keys) = engine.own_property_keys(*proto) {
-                for key in keys {
-                    let key_str = engine.property_key_to_rust_string(&key);
-                    if key_str == "constructor" || key_str == "__proto__" {
-                        continue;
-                    }
-                    if let Ok(Some(descriptor)) = engine.get_own_property(*proto, key.clone()) {
-                        if descriptor.value.is_some() || descriptor.get.is_some() {
-                            let _ = engine.define_property_or_throw(global_obj, key, descriptor);
+            let prototypes = [
+                get_registry_prototype::<crate::js::Types, EventTarget>(engine),
+                Some(window_proto),
+            ];
+            for proto in prototypes.iter().flatten() {
+                if let Ok(keys) = engine.own_property_keys(*proto) {
+                    for key in keys {
+                        let key_str = engine.property_key_to_rust_string(&key);
+                        if key_str == "constructor" || key_str == "__proto__" {
+                            continue;
+                        }
+                        if let Ok(Some(descriptor)) = engine.get_own_property(*proto, key.clone()) {
+                            if descriptor.value.is_some() || descriptor.get.is_some() {
+                                if let Err(error) =
+                                    engine.define_property_or_throw(global_obj, key, descriptor)
+                                {
+                                    error!(
+                                        "failed to copy a JSC Window prototype property to the global object: {error:?}"
+                                    );
+                                }
+                            }
                         }
                     }
                 }
             }
-        }
         }
     }
 
@@ -266,10 +273,10 @@ fn setup_realm(engine: &mut Engine, document: Rc<RefCell<BaseDocument>>) -> Resu
         };
         engine
             .define_property_or_throw(
-            rs_proto.clone(),
-            engine.property_key_from_str("values"),
-            values_desc,
-        )
+                rs_proto.clone(),
+                engine.property_key_from_str("values"),
+                values_desc,
+            )
             .map_err(|error| format!("failed to install ReadableStream.values: {error:?}"))?;
 
         // @@asyncIterator: same function as values (per spec
@@ -302,10 +309,10 @@ fn setup_realm(engine: &mut Engine, document: Rc<RefCell<BaseDocument>>) -> Resu
         };
         engine
             .define_property_or_throw(
-            rs_proto.clone(),
-            engine.property_key_from_str("__formalWebReadableStreamPipeToNative"),
-            native_desc,
-        )
+                rs_proto.clone(),
+                engine.property_key_from_str("__formalWebReadableStreamPipeToNative"),
+                native_desc,
+            )
             .map_err(|error| {
                 format!("failed to install ReadableStream pipeTo native function: {error:?}")
             })?;
@@ -326,14 +333,15 @@ fn setup_realm(engine: &mut Engine, document: Rc<RefCell<BaseDocument>>) -> Resu
                     get: None,
                     set: None,
                 };
-                engine.define_property_or_throw(
-                    rs_proto.clone(),
-                    engine.property_key_from_str("pipeTo"),
-                    pipe_to_desc,
-                )
-                .map_err(|error| {
-                    format!("failed to install ReadableStream.pipeTo: {error:?}")
-                })?;
+                engine
+                    .define_property_or_throw(
+                        rs_proto.clone(),
+                        engine.property_key_from_str("pipeTo"),
+                        pipe_to_desc,
+                    )
+                    .map_err(|error| {
+                        format!("failed to install ReadableStream.pipeTo: {error:?}")
+                    })?;
             }
         }
     }

--- a/content/src/js/build_context.rs
+++ b/content/src/js/build_context.rs
@@ -97,7 +97,7 @@ fn setup_realm(engine: &mut Engine, document: Rc<RefCell<BaseDocument>>) -> Resu
     let global_obj = engine.realm_global_object();
     engine.associate_existing_object(&global_obj, Box::new(window));
     // Set the EventTarget reflector for the Window.
-    let global_value = <crate::js::Types as js_engine::JsTypes>::value_from_object(global_obj);
+    let global_value = <crate::js::Types as js_engine::JsTypes>::value_from_object(global_obj.clone());
     crate::js::try_set_event_target_reflector(&global_value, engine);
 
     // Step 2: Store the global object in host_any.

--- a/content/src/js/builtin_fn.rs
+++ b/content/src/js/builtin_fn.rs
@@ -3,7 +3,7 @@ use js_engine::{Completion, ExecutionContext, JsTypes, JsTypesWithRealm};
 /// Create a builtin function with GC-traceable captures.
 /// Generic over `T` so Web IDL infrastructure (operation.rs, attribute.rs)
 /// can call it with their own type parameter.
-#[cfg(not(jsc_backend))]
+#[cfg(boa_backend)]
 pub(crate) fn create_builtin_fn_with_traced_captures<T, C>(
     ec: &mut dyn ExecutionContext<T>,
     captures: C,
@@ -22,6 +22,34 @@ where
     C: js_engine::gc::Trace + 'static,
 {
     js_engine::boa::create_builtin_fn_with_captures(
+        ec,
+        captures,
+        behaviour,
+        length,
+        name,
+        is_constructor,
+    )
+}
+
+#[cfg(v8_backend)]
+pub(crate) fn create_builtin_fn_with_traced_captures<T, C>(
+    ec: &mut dyn ExecutionContext<T>,
+    captures: C,
+    behaviour: fn(
+        &[T::JsValue],
+        T::JsValue,
+        &C,
+        &mut dyn ExecutionContext<T>,
+    ) -> Completion<T::JsValue, T>,
+    length: u32,
+    name: T::PropertyKey,
+    is_constructor: bool,
+) -> T::Function
+where
+    T: JsTypes + JsTypesWithRealm,
+    C: js_engine::gc::Trace + 'static,
+{
+    js_engine::v8::create_builtin_fn_with_captures(
         ec,
         captures,
         behaviour,

--- a/content/src/js/downcast.rs
+++ b/content/src/js/downcast.rs
@@ -3,7 +3,7 @@
 //! These use [`ExecutionContext::with_object_any`] / `with_object_any_mut`
 //! to extract native Rust data from JavaScript platform objects.
 
-use crate::dom::{AbortController, AbortSignal, Document, Element, Event, EventTarget, Node};
+use crate::dom::{AbortController, AbortSignal, Document, Element, Event, EventTarget, Node, UIEvent};
 use crate::html::{
     HTMLAnchorElement, HTMLElement, HTMLIFrameElement, HTMLInputElement, HTMLMediaElement,
     HTMLVideoElement, Window,
@@ -86,6 +86,8 @@ pub(crate) fn try_set_event_target_reflector(
                 signal.with_event_target_mut(|et| et.reflector = Some(obj_clone));
             } else if let Some(event) = data.downcast_mut::<Event>() {
                 event.reflector = Some(obj_clone);
+            } else if let Some(ui_event) = data.downcast_mut::<UIEvent>() {
+                ui_event.event.reflector = Some(obj_clone);
             }
         }
     }

--- a/content/src/js/mod.rs
+++ b/content/src/js/mod.rs
@@ -63,18 +63,23 @@ pub(crate) fn fn_capture_behaviour(
 }
 
 /// Content-level type alias for the concrete JS types in use.
-/// Set by the build script based on the target platform:
-/// `jsc_backend` on Apple platforms, `boa_backend` on others.
+/// Set by the build script from the selected engine feature.
 #[cfg(jsc_backend)]
 pub(crate) type Types = js_engine::jsc::JscTypes;
 
-#[cfg(not(jsc_backend))]
+#[cfg(boa_backend)]
 pub(crate) type Types = js_engine::boa::BoaTypes;
 
+#[cfg(v8_backend)]
+pub(crate) type Types = js_engine::v8::V8Types;
+
 /// Content-level type alias for the concrete JS engine in use.
-/// `BoaContext` on Boa, `JscEngine` on JSC.
+/// `BoaContext` on Boa, `JscEngine` on JSC, and `V8Engine` on V8.
 #[cfg(jsc_backend)]
 pub(crate) type Engine = js_engine::jsc::JscEngine;
 
-#[cfg(not(jsc_backend))]
+#[cfg(boa_backend)]
 pub(crate) type Engine = js_engine::boa::BoaContext;
+
+#[cfg(v8_backend)]
+pub(crate) type Engine = js_engine::v8::V8Engine;

--- a/content/src/main.rs
+++ b/content/src/main.rs
@@ -25,9 +25,8 @@ use crate::html::{
     parse_html_into_document, run_dom_post_connection_steps_for_document,
     run_dom_removing_steps_for_document, run_iframe_load_event_steps_for_traversable,
 };
-use crate::js::platform_objects::with_global_scope;
-#[cfg(v8_backend)]
 use crate::js::Engine;
+use crate::js::platform_objects::with_global_scope;
 use crate::ui_event::deserialize_ui_event;
 #[cfg(all(boa_backend, feature = "wasm"))]
 use crate::wasm::{WasmResult, compile_continuation, compile_rejection, instantiate_continuation};
@@ -421,8 +420,7 @@ pub(crate) struct ContentProcess {
     media_extension_sender: Option<ipc::IpcSender<ipc_messages::media::MediaCommand>>,
     /// This content process's own command sender, used by net for direct response routing.
     content_command_sender: ipc::IpcSender<Command>,
-    #[cfg(v8_backend)]
-    v8_realm_parent: Engine,
+    realm_parent: Engine,
 }
 
 impl ContentProcess {
@@ -457,12 +455,10 @@ impl ContentProcess {
             network_extension_sender,
             media_extension_sender,
             content_command_sender,
-            #[cfg(v8_backend)]
-            v8_realm_parent: Engine::new(),
+            realm_parent: Engine::new(),
         }
     }
 
-    #[cfg(v8_backend)]
     fn create_environment_settings_object(
         &mut self,
         document: Rc<RefCell<BaseDocument>>,
@@ -472,27 +468,10 @@ impl ContentProcess {
     ) -> Result<EnvironmentSettingsObject, String> {
         let event_sender = self.event_sender.clone();
         EnvironmentSettingsObject::new_in_realm(
-            Some(&mut self.v8_realm_parent),
+            Some(&mut self.realm_parent),
             document,
             creation_url,
             Some(event_sender),
-            Some(traversable_id),
-            Some(document_id),
-        )
-    }
-
-    #[cfg(not(v8_backend))]
-    fn create_environment_settings_object(
-        &mut self,
-        document: Rc<RefCell<BaseDocument>>,
-        creation_url: Url,
-        traversable_id: NavigableId,
-        document_id: DocumentId,
-    ) -> Result<EnvironmentSettingsObject, String> {
-        EnvironmentSettingsObject::new(
-            document,
-            creation_url,
-            Some(self.event_sender.clone()),
             Some(traversable_id),
             Some(document_id),
         )

--- a/content/src/main.rs
+++ b/content/src/main.rs
@@ -26,6 +26,8 @@ use crate::html::{
     run_dom_removing_steps_for_document, run_iframe_load_event_steps_for_traversable,
 };
 use crate::js::platform_objects::with_global_scope;
+#[cfg(v8_backend)]
+use crate::js::Engine;
 use crate::ui_event::deserialize_ui_event;
 #[cfg(all(boa_backend, feature = "wasm"))]
 use crate::wasm::{WasmResult, compile_continuation, compile_rejection, instantiate_continuation};
@@ -419,6 +421,8 @@ pub(crate) struct ContentProcess {
     media_extension_sender: Option<ipc::IpcSender<ipc_messages::media::MediaCommand>>,
     /// This content process's own command sender, used by net for direct response routing.
     content_command_sender: ipc::IpcSender<Command>,
+    #[cfg(v8_backend)]
+    v8_realm_parent: Engine,
 }
 
 impl ContentProcess {
@@ -453,7 +457,45 @@ impl ContentProcess {
             network_extension_sender,
             media_extension_sender,
             content_command_sender,
+            #[cfg(v8_backend)]
+            v8_realm_parent: Engine::new(),
         }
+    }
+
+    #[cfg(v8_backend)]
+    fn create_environment_settings_object(
+        &mut self,
+        document: Rc<RefCell<BaseDocument>>,
+        creation_url: Url,
+        traversable_id: NavigableId,
+        document_id: DocumentId,
+    ) -> Result<EnvironmentSettingsObject, String> {
+        let event_sender = self.event_sender.clone();
+        EnvironmentSettingsObject::new_in_realm(
+            Some(&mut self.v8_realm_parent),
+            document,
+            creation_url,
+            Some(event_sender),
+            Some(traversable_id),
+            Some(document_id),
+        )
+    }
+
+    #[cfg(not(v8_backend))]
+    fn create_environment_settings_object(
+        &mut self,
+        document: Rc<RefCell<BaseDocument>>,
+        creation_url: Url,
+        traversable_id: NavigableId,
+        document_id: DocumentId,
+    ) -> Result<EnvironmentSettingsObject, String> {
+        EnvironmentSettingsObject::new(
+            document,
+            creation_url,
+            Some(self.event_sender.clone()),
+            Some(traversable_id),
+            Some(document_id),
+        )
     }
 
     /// Set the clipboard cache from a prefetched clipboard text.
@@ -911,12 +953,11 @@ impl ContentProcess {
             document_id,
             None,
         ))));
-        let mut settings = EnvironmentSettingsObject::new(
+        let mut settings = self.create_environment_settings_object(
             Rc::clone(&document),
             Url::parse("about:blank").map_err(|error| error.to_string())?,
-            Some(self.event_sender.clone()),
-            Some(traversable_id),
-            Some(document_id),
+            traversable_id,
+            document_id,
         )?;
 
         // Set the video-paint registry on GlobalScope so that
@@ -1014,12 +1055,11 @@ impl ContentProcess {
             document_id,
             Some(final_url.clone()),
         ))));
-        let mut settings = EnvironmentSettingsObject::new(
+        let mut settings = self.create_environment_settings_object(
             Rc::clone(&document),
             Url::parse(&final_url).map_err(|error| error.to_string())?,
-            Some(self.event_sender.clone()),
-            Some(traversable_id),
-            Some(document_id),
+            traversable_id,
+            document_id,
         )?;
 
         // Set the video-paint registry on GlobalScope so that

--- a/content/src/streams/readablebytestreamcontroller.rs
+++ b/content/src/streams/readablebytestreamcontroller.rs
@@ -5,9 +5,7 @@ type JsValue = <Types as JsTypes>::JsValue;
 type JsObject = <Types as JsTypes>::JsObject;
 type ArrayBuffer = <Types as JsTypes>::ArrayBuffer;
 
-use js_engine::{
-    Completion, ExecutionContext, JsTypes, SharedMemoryOrder, TypedArrayElementType,
-};
+use js_engine::{Completion, ExecutionContext, JsTypes, SharedMemoryOrder, TypedArrayElementType};
 
 use crate::webidl::bindings::create_interface_instance;
 use crate::webidl::{rejected_promise, resolved_promise};
@@ -1532,7 +1530,9 @@ fn pull_steps_on_rejected(
     ec: &mut dyn ExecutionContext<crate::js::Types>,
 ) -> Completion<JsValue, crate::js::Types> {
     captures.error_steps(
-        args.first().cloned().unwrap_or_else(|| ec.value_undefined()),
+        args.first()
+            .cloned()
+            .unwrap_or_else(|| ec.value_undefined()),
         ec,
     )?;
     Ok(ec.value_undefined())
@@ -1556,7 +1556,9 @@ fn setup_on_rejected(
     ec: &mut dyn ExecutionContext<crate::js::Types>,
 ) -> Completion<JsValue, crate::js::Types> {
     captures.error_steps(
-        args.first().cloned().unwrap_or_else(|| ec.value_undefined()),
+        args.first()
+            .cloned()
+            .unwrap_or_else(|| ec.value_undefined()),
         ec,
     )?;
     Ok(ec.value_undefined())

--- a/content/src/streams/readablebytestreamcontroller.rs
+++ b/content/src/streams/readablebytestreamcontroller.rs
@@ -5,7 +5,9 @@ type JsValue = <Types as JsTypes>::JsValue;
 type JsObject = <Types as JsTypes>::JsObject;
 type ArrayBuffer = <Types as JsTypes>::ArrayBuffer;
 
-use js_engine::{Completion, ExecutionContext, JsTypes, TypedArrayElementType};
+use js_engine::{
+    Completion, ExecutionContext, JsTypes, SharedMemoryOrder, TypedArrayElementType,
+};
 
 use crate::webidl::bindings::create_interface_instance;
 use crate::webidl::{rejected_promise, resolved_promise};
@@ -1224,7 +1226,7 @@ impl ReadableByteStreamController {
                 let to_take = remaining.min(entry.remaining_len());
                 let start = entry.remaining_byte_offset();
                 let bytes = {
-                    let data = entry.buffer.data().ok_or_else(|| {
+                    let data = ec.array_buffer_data(&entry.buffer).ok_or_else(|| {
                         ec.new_type_error("Readable byte stream queue entry buffer is detached")
                     })?;
                     data[start..start + to_take].to_vec()
@@ -1240,15 +1242,18 @@ impl ReadableByteStreamController {
 
         self.queue_total_size
             .set(self.queue_total_size.get().saturating_sub(copied.len()));
-        #[cfg_attr(jsc_backend, allow(unused_mut))]
-        let mut data = descriptor
-            .view
-            .buffer
-            .data_mut()
-            .ok_or_else(|| ec.new_type_error("BYOB request buffer is detached"))?;
         let start = descriptor.view.byte_offset() + descriptor.bytes_filled;
-        let end = start + copied.len();
-        data[start..end].copy_from_slice(&copied);
+        for (relative_index, byte) in copied.iter().copied().enumerate() {
+            let value = ec.value_from_number(f64::from(byte));
+            ec.set_value_in_buffer(
+                &descriptor.view.buffer,
+                (start + relative_index) as u64,
+                TypedArrayElementType::Uint8,
+                value,
+                true,
+                SharedMemoryOrder::Unordered,
+            )?;
+        }
         descriptor.bytes_filled += copied.len();
         Ok(())
     }
@@ -1526,7 +1531,10 @@ fn pull_steps_on_rejected(
     captures: &ReadableByteStreamController,
     ec: &mut dyn ExecutionContext<crate::js::Types>,
 ) -> Completion<JsValue, crate::js::Types> {
-    captures.error_steps(args.first().cloned().unwrap_or_default(), ec)?;
+    captures.error_steps(
+        args.first().cloned().unwrap_or_else(|| ec.value_undefined()),
+        ec,
+    )?;
     Ok(ec.value_undefined())
 }
 
@@ -1547,6 +1555,9 @@ fn setup_on_rejected(
     captures: &ReadableByteStreamController,
     ec: &mut dyn ExecutionContext<crate::js::Types>,
 ) -> Completion<JsValue, crate::js::Types> {
-    captures.error_steps(args.first().cloned().unwrap_or_default(), ec)?;
+    captures.error_steps(
+        args.first().cloned().unwrap_or_else(|| ec.value_undefined()),
+        ec,
+    )?;
     Ok(ec.value_undefined())
 }

--- a/content/src/streams/readablestreambyobreader.rs
+++ b/content/src/streams/readablestreambyobreader.rs
@@ -144,7 +144,7 @@ impl ReadableStreamGenericReader for ReadableStreamBYOBReader {
 
     fn set_closed_promise_slot_value(&self, promise: Option<JsObject>) {
         // JSC: protect new value from GC, unprotect old value
-        #[cfg(not(feature = "boa"))]
+        #[cfg(feature = "jsc")]
         {
             let old = self.closed_promise.borrow().clone();
             if let Some(ref old_obj) = old {

--- a/content/src/streams/readablestreamdefaultreader.rs
+++ b/content/src/streams/readablestreamdefaultreader.rs
@@ -355,7 +355,7 @@ impl ReadableStreamGenericReader for ReadableStreamDefaultReader {
 
     fn set_closed_promise_slot_value(&self, promise: Option<JsObject>) {
         // JSC: protect new value from GC, unprotect old value
-        #[cfg(not(feature = "boa"))]
+        #[cfg(feature = "jsc")]
         {
             let old = self.closed_promise.borrow().clone();
             if let Some(ref old_obj) = old {

--- a/content/src/streams/writablestreamdefaultwriter.rs
+++ b/content/src/streams/writablestreamdefaultwriter.rs
@@ -52,7 +52,7 @@ impl WritableStreamDefaultWriter {
     }
     pub(crate) fn set_ready_promise_value(&self, promise: Option<JsObject>) {
         // JSC: protect new value from GC, unprotect old value
-        #[cfg(not(feature = "boa"))]
+        #[cfg(feature = "jsc")]
         {
             let old = self.ready_promise.borrow().clone();
             if let Some(ref old_obj) = old {
@@ -79,7 +79,7 @@ impl WritableStreamDefaultWriter {
     }
     pub(crate) fn set_closed_promise_value(&self, promise: Option<JsObject>) {
         // JSC: protect new value from GC, unprotect old value
-        #[cfg(not(feature = "boa"))]
+        #[cfg(feature = "jsc")]
         {
             let old = self.closed_promise.borrow().clone();
             if let Some(ref old_obj) = old {

--- a/content/src/webidl/bindings/interface.rs
+++ b/content/src/webidl/bindings/interface.rs
@@ -136,7 +136,7 @@ pub(crate) fn create_interface_instance<Ty, T>(
     ec: &mut dyn ExecutionContext<Ty>,
 ) -> Completion<Ty::JsObject, Ty>
 where
-    Ty: JsTypes + JsTypesWithRealm,
+    Ty: JsTypes + JsTypesWithRealm + PostCreateReflector<Ty>,
     T: 'static,
 {
     // <https://webidl.spec.whatwg.org/#internally-create-a-new-object-implementing-the-interface>
@@ -165,6 +165,8 @@ where
     //   indexed properties, named properties, or both:"
     //   Not yet implemented.
     // Step 14: "Return instance."
+    <Ty as PostCreateReflector<Ty>>::set_reflector(&instance, ec);
+
     Ok(instance)
 }
 

--- a/ipc_messages/src/content.rs
+++ b/ipc_messages/src/content.rs
@@ -906,12 +906,15 @@ pub enum Event {
 #[cfg(test)]
 mod tests {
     use super::{
-        Command, DocumentFetchId, FetchResponse, FontTransportReceiver, FontTransportSender,
-        FrameCompositionMetadata, FrameId, LoadedDocumentResponse, NavigableId, PaintFrame,
-        PaintTransportSummary, SceneSummary, WebviewId,
+        Command, DocumentFetchId, DocumentId, FetchResponse, FontTransportReceiver,
+        FontTransportSender, FrameCompositionMetadata, FrameId, LoadedDocumentResponse,
+        NavigableId, PaintFrame, PaintTransportSummary, PreparedScene, SceneSummary, WebviewId,
     };
     use anyrender::{Glyph, PaintScene, Scene, recording::RenderCommand};
-    use peniko::{Color, Fill, FontData, kurbo::Affine};
+    use peniko::{
+        Color, Fill, FontData,
+        kurbo::{Affine, Vec2},
+    };
 
     fn scene_with_glyph(font: &FontData, glyph_id: u16, x: f32, y: f32) -> Scene {
         let mut scene = Scene::new();
@@ -920,6 +923,7 @@ mod tests {
             16.0,
             true,
             &[],
+            Vec2::ZERO,
             Fill::NonZero,
             Color::BLACK,
             1.0,
@@ -942,7 +946,7 @@ mod tests {
                 assert_eq!(command.font_data.data.data(), expected_bytes);
                 assert_eq!(command.font_data.index, 0);
                 assert_eq!(command.glyphs.len(), 1);
-                assert_eq!(command.glyphs[0].id, expected_glyph_id.into());
+                assert_eq!(command.glyphs[0].id, u32::from(expected_glyph_id));
             }
             other => panic!("expected glyph run, got {other:?}"),
         }
@@ -953,7 +957,8 @@ mod tests {
         let font = FontData::new(vec![1_u8, 2, 3, 4].into(), 0);
         let scene = scene_with_glyph(&font, 7, 12.0, 18.0);
         let mut sender = FontTransportSender::default();
-        let prepared = sender.prepare_scene(11, scene.clone());
+        let mut next_shmem_key = 0;
+        let prepared = sender.prepare_scene(11, scene.clone(), &mut next_shmem_key);
 
         assert_eq!(prepared.scene.font_ids.len(), 1);
         assert_eq!(prepared.registered_fonts.len(), 1);
@@ -977,9 +982,18 @@ mod tests {
             }
         );
 
+        let PreparedScene {
+            scene,
+            registered_fonts,
+            font_shmem,
+        } = prepared;
+        let font_data = font_shmem
+            .into_iter()
+            .map(|(key, region)| (key, region.as_slice().to_vec()))
+            .collect();
         let mut receiver = FontTransportReceiver::default();
-        receiver.register_fonts(prepared.registered_fonts);
-        let roundtripped = prepared.scene.into_scene(&receiver);
+        receiver.register_fonts(registered_fonts, &font_data);
+        let roundtripped = scene.into_scene(&receiver);
         assert_single_glyph_run_font(&roundtripped, &[1, 2, 3, 4], 7);
     }
 
@@ -992,6 +1006,7 @@ mod tests {
             16.0,
             true,
             &[],
+            Vec2::ZERO,
             Fill::NonZero,
             Color::BLACK,
             1.0,
@@ -1006,14 +1021,24 @@ mod tests {
         );
 
         let mut sender = FontTransportSender::default();
-        let prepared = sender.prepare_scene(17, scene.clone());
+        let mut next_shmem_key = 0;
+        let prepared = sender.prepare_scene(17, scene.clone(), &mut next_shmem_key);
         assert_eq!(prepared.scene.font_ids.len(), 1);
         assert_eq!(prepared.registered_fonts.len(), 1);
         assert_eq!(prepared.scene.summary().font_refs, 1);
 
+        let PreparedScene {
+            scene,
+            registered_fonts,
+            font_shmem,
+        } = prepared;
+        let font_data = font_shmem
+            .into_iter()
+            .map(|(key, region)| (key, region.as_slice().to_vec()))
+            .collect();
         let mut receiver = FontTransportReceiver::default();
-        receiver.register_fonts(prepared.registered_fonts);
-        let roundtripped = prepared.scene.into_scene(&receiver);
+        receiver.register_fonts(registered_fonts, &font_data);
+        let roundtripped = scene.into_scene(&receiver);
         assert_eq!(roundtripped.commands.len(), 2);
     }
 
@@ -1022,21 +1047,23 @@ mod tests {
         let font = FontData::new(vec![1_u8, 2, 3, 4].into(), 0);
         let scene = scene_with_glyph(&font, 7, 12.0, 18.0);
         let mut sender = FontTransportSender::default();
-        let prepared = sender.prepare_scene(23, scene);
+        let mut next_shmem_key = 0;
+        let prepared = sender.prepare_scene(23, scene, &mut next_shmem_key);
         let expected_recorded = prepared.scene.clone();
-        let paint_frame = PaintFrame::new(
+        let (paint_frame, shmem_regions) = PaintFrame::new(
             WebviewId(NavigableId::from_u128(7)),
             FrameId::from_u128(7),
             320,
             240,
             FrameCompositionMetadata::default(),
             prepared,
+            &mut next_shmem_key,
         )
         .expect("paint frame should serialize into shared memory");
 
         let mut receiver = FontTransportReceiver::default();
         let roundtripped = paint_frame
-            .into_recorded_scene(&mut receiver)
+            .into_recorded_scene(&mut receiver, &shmem_regions)
             .expect("paint frame should deserialize scene bytes");
 
         assert_eq!(roundtripped, expected_recorded);
@@ -1047,52 +1074,64 @@ mod tests {
         let font = FontData::new(vec![1_u8, 2, 3, 4].into(), 0);
         let mut sender = FontTransportSender::default();
         let mut receiver = FontTransportReceiver::default();
+        let mut next_shmem_key = 0;
 
-        let first_frame = PaintFrame::new(
+        let first_prepared = sender.prepare_scene(
+            29,
+            scene_with_glyph(&font, 7, 12.0, 18.0),
+            &mut next_shmem_key,
+        );
+        let (first_frame, first_shmem_regions) = PaintFrame::new(
             WebviewId(NavigableId::from_u128(7)),
             FrameId::from_u128(7),
             320,
             240,
             FrameCompositionMetadata::default(),
-            sender.prepare_scene(29, scene_with_glyph(&font, 7, 12.0, 18.0)),
+            first_prepared,
+            &mut next_shmem_key,
         )
         .expect("first frame should serialize");
-        let first_summary = first_frame.transport_summary();
+        let first_summary = first_frame.transport_summary(&first_shmem_regions);
         assert_eq!(
             first_summary,
             PaintTransportSummary {
                 scene_bytes: first_summary.scene_bytes,
                 registered_fonts: 1,
-                registered_font_bytes: 4,
             }
         );
 
         let first_scene = first_frame
-            .into_recorded_scene(&mut receiver)
+            .into_recorded_scene(&mut receiver, &first_shmem_regions)
             .expect("first frame should decode")
             .into_scene(&receiver);
         assert_single_glyph_run_font(&first_scene, &[1, 2, 3, 4], 7);
 
-        let second_frame = PaintFrame::new(
+        let second_prepared = sender.prepare_scene(
+            29,
+            scene_with_glyph(&font, 8, 28.0, 18.0),
+            &mut next_shmem_key,
+        );
+        let (second_frame, second_shmem_regions) = PaintFrame::new(
             WebviewId(NavigableId::from_u128(7)),
             FrameId::from_u128(7),
             320,
             240,
             FrameCompositionMetadata::default(),
-            sender.prepare_scene(29, scene_with_glyph(&font, 8, 28.0, 18.0)),
+            second_prepared,
+            &mut next_shmem_key,
         )
         .expect("second frame should serialize");
+        let second_summary = second_frame.transport_summary(&second_shmem_regions);
         assert_eq!(
-            second_frame.transport_summary(),
+            second_summary,
             PaintTransportSummary {
-                scene_bytes: second_frame.transport_summary().scene_bytes,
+                scene_bytes: second_summary.scene_bytes,
                 registered_fonts: 0,
-                registered_font_bytes: 0,
             }
         );
 
         let second_scene = second_frame
-            .into_recorded_scene(&mut receiver)
+            .into_recorded_scene(&mut receiver, &second_shmem_regions)
             .expect("second frame should decode")
             .into_scene(&receiver);
         assert_single_glyph_run_font(&second_scene, &[1, 2, 3, 4], 8);
@@ -1102,7 +1141,7 @@ mod tests {
     fn create_loaded_document_command_round_trips_response_metadata() {
         let encoded = postcard::to_allocvec(&Command::CreateLoadedDocument {
             traversable_id: NavigableId::from_u128(3),
-            document_id: 7,
+            document_id: DocumentId::from_u128(7),
             frame_id: None,
             response: LoadedDocumentResponse {
                 final_url: String::from("https://example.test/final"),
@@ -1127,7 +1166,7 @@ mod tests {
                 top_level_traversable_id,
             } => {
                 assert_eq!(traversable_id, NavigableId::from_u128(3));
-                assert_eq!(document_id, 7);
+                assert_eq!(document_id, DocumentId::from_u128(7));
                 assert_eq!(frame_id, None);
                 assert_eq!(parent_traversable_id, Some(NavigableId::from_u128(2)));
                 assert_eq!(top_level_traversable_id, NavigableId::from_u128(1));

--- a/js_engine/Cargo.toml
+++ b/js_engine/Cargo.toml
@@ -6,13 +6,14 @@ publish = false
 description = "ECMA-262 abstract operation trait — pure type vocabulary and engine abstraction."
 
 [lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(boa_backend)', 'cfg(jsc_backend)'] }
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(boa_backend)', 'cfg(jsc_backend)', 'cfg(v8_backend)'] }
 
 [features]
 default = ["boa"]
 boa = ["dep:boa_engine", "dep:boa_gc", "dep:serde_json"]
 float16 = ["boa_engine/float16"]
 jsc = []
+v8 = ["dep:rusty_v8"]
 
 [dependencies]
 log = "0.4"
@@ -20,3 +21,4 @@ serde_json = { version = "1", optional = true }
 boa_engine = { git = "https://github.com/boa-dev/boa", rev = "7ce9cae84ac9bf54fe528bb05b997ac24af808a4", default-features = false, optional = true }
 boa_gc = { git = "https://github.com/boa-dev/boa", rev = "7ce9cae84ac9bf54fe528bb05b997ac24af808a4", features = ["thin-vec", "boa_string"], optional = true }
 js_engine_macros = { path = "../js_engine_macros" }
+rusty_v8 = { package = "v8", version = "=150.1.0", optional = true }

--- a/js_engine/README.md
+++ b/js_engine/README.md
@@ -126,6 +126,20 @@ strategies, transform, writable), formal gc-protection.
 
 ## Remaining work
 
+### V8 platform-object tracing through cppgc
+
+V8 currently stores generic `GcCell<T>` values in `Rc<RefCell<T>>` and keeps
+reflectors through V8 weak handles. Migrate platform-object ownership to a
+`cppgc::Heap` attached to each shared isolate. Objects allocated on that heap
+must trace every `Member`, `WeakMember`, and `TracedReference` edge, while
+off-heap owners use `Persistent` handles only when they are genuine roots.
+
+The generic cell API must change as part of this work: cppgc allocation needs
+the isolate heap, and cppgc cell access requires isolate-scoped proof instead
+of the current context-free `gc_cell_new`, `borrow`, and `borrow_mut` calls.
+Add forced-collection tests covering reflector cycles, platform-object cycles,
+weak edges, finalization, and isolate destruction.
+
 ### JSC microtask drain during nested C API calls
 
 `promise_state()` uses `eval_script_raw("void 0")` to drain microtasks, but

--- a/js_engine/README.md
+++ b/js_engine/README.md
@@ -2,7 +2,7 @@
 
 <https://tc39.es/ecma262/>
 
-Bridges between ECMAScript engines (Boa, JSC) and formal-web's
+Bridges between ECMAScript engines (Boa, JavaScriptCore, and V8) and formal-web's
 HTML/DOM/WebIDL layers.  Migration to a fully generic `JsEngine<T>` /
 `ExecutionContext<T>` trait architecture is complete — content code
 never depends on backend-specific APIs.
@@ -12,9 +12,9 @@ never depends on backend-specific APIs.
 Two categories of abstraction:
 
 1. **Standard** — `JsEngine<T>` and `ExecutionContext<T>` mirror ECMA-262
-   abstract operations (§7–§27).  `ExecutionContext<T>` is the runtime
-   handle threaded through every binding function and domain method — it
-   IS the HTML spec's realm execution context.
+   abstract operations (§7–§27). `ExecutionContext<T>` is threaded through
+   every binding function and domain method as the HTML specification's realm
+   execution context.
 2. **Engine-specific** — `gc.rs` abstracts GC (`Trace`, `Finalize`,
    `GcRootHandle`, `GcCell`) which has no ECMA-262 equivalent.
 
@@ -24,7 +24,7 @@ Two categories of abstraction:
 |---|---|
 | `JsTypes` | Associated types for a backend's value/object/string/realm/etc. |
 | `JsEngine<T>` | Factory operations: realm creation, script evaluation, builtin functions |
-| `ExecutionContext<T>` | Runtime handle for all ECMA-262 operations that reference the surrounding agent's running execution context |
+| `ExecutionContext<T>` | Interface for ECMA-262 operations that reference the surrounding agent's running execution context |
 | `JsTypesGcExt` | Cycle-safe reflector link between Rust domain objects and their JS wrappers |
 
 ### Module layout
@@ -38,6 +38,7 @@ Two categories of abstraction:
 | `gc` | `Trace`, `Finalize`, `GcRootHandle`, `GcCell` (backend-abstracted) |
 | `boa/` | Boa backend implementation |
 | `jsc/` | JSC backend implementation (macOS only) |
+| `v8/` | V8 backend implementation through `rusty_v8` (macOS arm64 only) |
 
 ## Feature flags
 
@@ -45,8 +46,10 @@ Two categories of abstraction:
 |---|---|---|
 | `boa` | Boa (git dep) | **default** |
 | `jsc` | JavaScriptCore (macOS, experimental) | opt-in |
+| `v8` | V8 150.1.0 through `rusty_v8` (macOS arm64) | opt-in |
 
-At most one engine feature can be active.
+Exactly one engine feature must be active. V8 and WebAssembly cannot be
+enabled together.
 
 ## Build commands
 
@@ -78,6 +81,30 @@ rustup run 1.94.0 cargo build --release --no-default-features --features jsc -p 
 # Run a single WPT test via JSC
 target/release/formal-web wpt dom/nodes/Element-hasAttribute.html
 ```
+
+### V8 (macOS arm64, opt-in)
+
+```bash
+# Build every process with V8 and media support
+rustup run 1.94.0 cargo build --release \
+  --no-default-features --features v8,media
+
+# Run the browser after the complete build
+rustup run 1.94.0 cargo run --release \
+  --no-default-features --features v8,media
+
+# Run the generic engine tests
+rustup run 1.94.0 cargo test --no-default-features \
+  --features v8 -p content generic_js_test
+```
+
+The first build downloads the pinned V8 150.1.0 archive. Set
+`RUSTY_V8_ARCHIVE=/absolute/path/to/librusty_v8_release_aarch64-apple-darwin.a.gz`
+to use a local archive, or set `RUSTY_V8_MIRROR` to an alternate releases base
+URL. Cargo also caches downloaded archives under `.cargo/.rusty_v8` in the
+Cargo home directory.
+
+WebAssembly support is deferred for V8; use Boa with the `wasm` feature.
 
 ## WPT test results
 

--- a/js_engine/build.rs
+++ b/js_engine/build.rs
@@ -1,7 +1,28 @@
 fn main() {
+    let has_boa = std::env::var("CARGO_FEATURE_BOA").is_ok();
+    let has_jsc = std::env::var("CARGO_FEATURE_JSC").is_ok();
+    let has_v8 = std::env::var("CARGO_FEATURE_V8").is_ok();
+    let enabled_backend_count = [has_boa, has_jsc, has_v8]
+        .into_iter()
+        .filter(|enabled| *enabled)
+        .count();
+
+    if enabled_backend_count != 1 {
+        panic!("exactly one of `boa`, `jsc`, or `v8` must be enabled");
+    }
+
     // When the "jsc" feature is enabled, link JavaScriptCore framework
-    #[cfg(feature = "jsc")]
-    {
+    if has_jsc {
         println!("cargo::rustc-link-lib=framework=JavaScriptCore");
+    }
+
+    if has_v8 {
+        let target_arch = std::env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_default();
+        let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
+        if target_arch != "aarch64" || target_os != "macos" {
+            panic!(
+                "v8 backend currently supports only aarch64-apple-darwin; selected target is {target_arch}-{target_os}"
+            );
+        }
     }
 }

--- a/js_engine/src/boa/engine.rs
+++ b/js_engine/src/boa/engine.rs
@@ -1495,7 +1495,7 @@ impl ExecutionContext<BoaTypes> for BoaContext {
     }
 
     fn get_value_from_buffer(
-        &self,
+        &mut self,
         _array_buffer: &JsArrayBuffer,
         _byte_index: u64,
         _element_type: TypedArrayElementType,
@@ -1917,6 +1917,10 @@ impl ExecutionContext<BoaTypes> for BoaContext {
 
     fn property_key_from_symbol(&self, sym: &JsSymbol) -> PropertyKey {
         PropertyKey::from(sym.clone())
+    }
+
+    fn value_from_property_key(&mut self, key: PropertyKey) -> JsValue {
+        JsValue::from(key)
     }
 
     fn property_key_from_well_known_symbol(&mut self, name: &str) -> PropertyKey {

--- a/js_engine/src/engine.rs
+++ b/js_engine/src/engine.rs
@@ -410,7 +410,7 @@ pub trait ExecutionContext<T: JsTypes + JsTypesWithRealm>: EcmascriptHost<T> {
 
     /// <https://tc39.es/ecma262/#sec-getvaluefrombuffer>
     fn get_value_from_buffer(
-        &self,
+        &mut self,
         array_buffer: &T::ArrayBuffer,
         byte_index: u64,
         element_type: TypedArrayElementType,
@@ -629,6 +629,9 @@ pub trait ExecutionContext<T: JsTypes + JsTypesWithRealm>: EcmascriptHost<T> {
     /// Used for accessing well-known symbol properties (e.g. `@@asyncIterator`,
     /// `@@iterator`) in iterable and async-iterable algorithms.
     fn property_key_from_symbol(&self, sym: &T::JsSymbol) -> T::PropertyKey;
+
+    /// Convert a property key to the corresponding ECMAScript value.
+    fn value_from_property_key(&mut self, key: T::PropertyKey) -> T::JsValue;
 
     /// Create a `PropertyKey` from a well-known Symbol name (e.g. "asyncIterator",
     /// "iterator", "hasInstance", "toPrimitive").

--- a/js_engine/src/engine.rs
+++ b/js_engine/src/engine.rs
@@ -8,12 +8,30 @@ use crate::enums::{
     IntegrityLevel, IteratorKind, PromiseRejectionOperation, SharedMemoryOrder,
     TypedArrayElementType,
 };
-use crate::records::{IteratorRecord, PromiseCapability, PromiseResolvers, RealmIntrinsics};
+use crate::records::{
+    IteratorRecord, ModuleRequest, PromiseCapability, PromiseResolvers, RealmIntrinsics,
+};
 use crate::types::{JsTypes, JsTypesWithRealm};
 use crate::{Numeric, PreferredType, PropertyDescriptor, RootedPromiseCapability};
 
 /// <https://tc39.es/ecma262/#sec-completion-record-specification-type>
 pub type Completion<T, Ty> = Result<T, <Ty as JsTypes>::JsValue>;
+pub type RealmJob<T> = Box<dyn FnOnce(&mut dyn ExecutionContext<T>)>;
+pub type MapEntries<T> = Vec<(<T as JsTypes>::JsValue, <T as JsTypes>::JsValue)>;
+pub type ObjectDataMutation<'a, T> =
+    Box<dyn FnOnce(&mut dyn std::any::Any, &mut dyn ExecutionContext<T>) + 'a>;
+pub type BuiltinFunction<T> = fn(
+    &[<T as JsTypes>::JsValue],
+    <T as JsTypes>::JsValue,
+    &mut dyn ExecutionContext<T>,
+) -> Completion<<T as JsTypes>::JsValue, T>;
+pub type BuiltinClosure<T> = Box<
+    dyn Fn(
+        &[<T as JsTypes>::JsValue],
+        <T as JsTypes>::JsValue,
+        &mut dyn ExecutionContext<T>,
+    ) -> Completion<<T as JsTypes>::JsValue, T>,
+>;
 
 /// <https://webidl.spec.whatwg.org/#call-a-user-objects-operation>
 /// <https://webidl.spec.whatwg.org/#invoke-a-callback-function>
@@ -339,7 +357,7 @@ pub trait ExecutionContext<T: JsTypes + JsTypesWithRealm>: EcmascriptHost<T> {
     ) -> Completion<T::JsValue, T>;
 
     // ────────────────────────────────────────────────────────────────────────
-    // §9.3 Realm — runtime access
+    // §9.3 Realm access
     // ────────────────────────────────────────────────────────────────────────
 
     /// <https://tc39.es/ecma262/#sec-execution-contexts>
@@ -365,17 +383,13 @@ pub trait ExecutionContext<T: JsTypes + JsTypesWithRealm>: EcmascriptHost<T> {
     /// Like `enqueue_job` but the job receives access to the execution context.
     /// The closure runs with the given realm restored as the current realm.
     /// <https://tc39.es/ecma262/#sec-enqueuejob>
-    fn enqueue_job_with_realm(
-        &mut self,
-        realm: T::Realm,
-        job: Box<dyn FnOnce(&mut dyn ExecutionContext<T>)>,
-    );
+    fn enqueue_job_with_realm(&mut self, realm: T::Realm, job: RealmJob<T>);
 
     /// <https://tc39.es/ecma262/#sec-runjobs>
     fn run_jobs(&mut self);
 
     // ────────────────────────────────────────────────────────────────────────
-    // §25.1 ArrayBuffer Abstract Operations — runtime queries
+    // §25.1 ArrayBuffer Abstract Operations — queries
     // ────────────────────────────────────────────────────────────────────────
 
     /// <https://tc39.es/ecma262/#sec-isdetachedbuffer>
@@ -521,7 +535,7 @@ pub trait ExecutionContext<T: JsTypes + JsTypesWithRealm>: EcmascriptHost<T> {
 
     /// <https://tc39.es/ecma262/#sec-map-objects>
     /// Get all entries from a Map as a Vec of (key, value) pairs.
-    fn map_get_entries(&mut self, map: &T::Map) -> Completion<Vec<(T::JsValue, T::JsValue)>, T>;
+    fn map_get_entries(&mut self, map: &T::Map) -> Completion<MapEntries<T>, T>;
 
     /// <https://tc39.es/ecma262/#sec-map.prototype.set>
     /// Add a (key, value) entry to a Map.
@@ -681,11 +695,7 @@ pub trait ExecutionContext<T: JsTypes + JsTypesWithRealm>: EcmascriptHost<T> {
     /// during mutation.  This is the canonical API for patterns like
     /// `set_onload`, `play()`, `pause()`, `set_src()` where the mutation
     /// needs to call back into ECMA-262 operations.
-    fn with_object_any_mut_with(
-        &mut self,
-        object: &T::JsObject,
-        f: Box<dyn FnOnce(&mut dyn std::any::Any, &mut dyn ExecutionContext<T>) + '_>,
-    );
+    fn with_object_any_mut_with(&mut self, object: &T::JsObject, f: ObjectDataMutation<'_, T>);
 
     // ── Error Construction ──────────────────────────────────────────────
 
@@ -814,11 +824,7 @@ pub trait ExecutionContext<T: JsTypes + JsTypesWithRealm>: EcmascriptHost<T> {
     /// The function pointer has no captures, so it is always GC-safe.
     fn create_builtin_fn_static(
         &mut self,
-        behaviour: fn(
-            &[T::JsValue],
-            T::JsValue,
-            &mut dyn ExecutionContext<T>,
-        ) -> Completion<T::JsValue, T>,
+        behaviour: BuiltinFunction<T>,
         length: u32,
         name: T::PropertyKey,
     ) -> T::Function;
@@ -832,13 +838,7 @@ pub trait ExecutionContext<T: JsTypes + JsTypesWithRealm>: EcmascriptHost<T> {
     #[doc(hidden)]
     fn create_builtin_fn(
         &mut self,
-        behaviour: Box<
-            dyn Fn(
-                &[T::JsValue],
-                T::JsValue,
-                &mut dyn ExecutionContext<T>,
-            ) -> Completion<T::JsValue, T>,
-        >,
+        behaviour: BuiltinClosure<T>,
         length: u32,
         name: T::PropertyKey,
     ) -> T::Function;
@@ -849,13 +849,7 @@ pub trait ExecutionContext<T: JsTypes + JsTypesWithRealm>: EcmascriptHost<T> {
     #[doc(hidden)]
     fn create_builtin_function(
         &mut self,
-        behaviour: Box<
-            dyn Fn(
-                &[T::JsValue],
-                T::JsValue,
-                &mut dyn ExecutionContext<T>,
-            ) -> Completion<T::JsValue, T>,
-        >,
+        behaviour: BuiltinClosure<T>,
         length: u32,
         name: T::PropertyKey,
         is_constructor: bool,
@@ -975,19 +969,27 @@ pub trait JsEngine<T: JsTypes> {
 // HostHooks
 // ────────────────────────────────────────────────────────────────────────────
 
+pub type EnsureCanCompileStringsHook<T> =
+    Box<dyn Fn(&<T as JsTypesWithRealm>::Realm) -> Completion<(), T>>;
+pub type PromiseRejectionTrackerHook<T> =
+    Box<dyn Fn(<T as JsTypes>::Promise, PromiseRejectionOperation)>;
+pub type EnqueuePromiseJobHook<T> =
+    Box<dyn Fn(Box<dyn FnOnce()>, Option<<T as JsTypesWithRealm>::Realm>)>;
+pub type LoadImportedModuleHook<T> = Box<dyn Fn(ModuleRequest<T>, PromiseCapability<T>)>;
+
 /// <https://html.spec.whatwg.org/#javascript-specification-host-hooks>
 pub struct HostHooks<T: JsTypesWithRealm> {
     /// <https://html.spec.whatwg.org/#hostensurecancompilestrings>
-    pub ensure_can_compile_strings: Option<Box<dyn Fn(&T::Realm) -> Completion<(), T>>>,
+    pub ensure_can_compile_strings: Option<EnsureCanCompileStringsHook<T>>,
 
     /// <https://html.spec.whatwg.org/#hostpromiserejectiontracker>
-    pub promise_rejection_tracker: Option<Box<dyn Fn(T::Promise, PromiseRejectionOperation)>>,
+    pub promise_rejection_tracker: Option<PromiseRejectionTrackerHook<T>>,
 
     /// <https://html.spec.whatwg.org/#hostenqueuepromisejob>
-    pub enqueue_promise_job: Option<Box<dyn Fn(Box<dyn FnOnce()>, Option<T::Realm>)>>,
+    pub enqueue_promise_job: Option<EnqueuePromiseJobHook<T>>,
 
     /// <https://html.spec.whatwg.org/#hostloadimportedmodule>
-    pub load_imported_module: Option<Box<dyn Fn(ModuleRequest<T>, PromiseCapability<T>)>>,
+    pub load_imported_module: Option<LoadImportedModuleHook<T>>,
 }
 
 impl<T: JsTypesWithRealm> HostHooks<T> {
@@ -1000,6 +1002,3 @@ impl<T: JsTypesWithRealm> HostHooks<T> {
         }
     }
 }
-
-// Needed for HostHooks field type resolution
-use crate::records::ModuleRequest;

--- a/js_engine/src/gc.rs
+++ b/js_engine/src/gc.rs
@@ -439,7 +439,14 @@ mod v8_cells {
 #[cfg(feature = "boa")]
 pub type GcCell<T> = boa_gc::Gc<boa_gc::GcRefCell<T>>;
 
-#[cfg(any(feature = "jsc", feature = "v8"))]
+#[cfg(feature = "jsc")]
+pub type GcCell<T> = std::rc::Rc<std::cell::RefCell<T>>;
+
+// TODO(v8): Move platform-object ownership to a per-isolate `cppgc::Heap` and
+// replace off-heap roots with traced `Member`/`WeakMember` edges. This requires
+// changing context-free cell construction and borrowing before this alias can
+// use rusty_v8's cppgc types safely.
+#[cfg(feature = "v8")]
 pub type GcCell<T> = std::rc::Rc<std::cell::RefCell<T>>;
 
 /// Construct a [`GcCell`] with the given value.

--- a/js_engine/src/gc.rs
+++ b/js_engine/src/gc.rs
@@ -17,7 +17,7 @@
 //! Each backend provides its own implementations inside `#[cfg]`-gated
 //! sub-modules below.
 
-use crate::JsTypes;
+use crate::{ExecutionContext, JsTypes, JsTypesWithRealm};
 
 // ============================================================================
 // SECTION I: SPEC-ANNOTATION TRAITS
@@ -54,12 +54,16 @@ pub trait Finalize {
 /// The `Reflector` is a structural twin link that lets a Rust domain object
 /// reference its associated JS wrapper object without creating fatal cycles.
 /// The concrete representation is engine-specific.
-pub trait JsTypesGcExt: JsTypes + Sized + 'static {
+pub trait JsTypesGcExt: JsTypes + JsTypesWithRealm + Sized + 'static {
     /// The cycle-safe structural twin link.
     type Reflector: Clone + 'static;
+    type Context: ExecutionContext<Self>;
 
-    fn create_reflector(obj: &Self::JsObject) -> Self::Reflector;
-    fn upgrade_reflector(reflector: &Self::Reflector) -> Option<Self::JsObject>;
+    fn create_reflector(context: &mut Self::Context, obj: &Self::JsObject) -> Self::Reflector;
+    fn upgrade_reflector(
+        context: &mut Self::Context,
+        reflector: &Self::Reflector,
+    ) -> Option<Self::JsObject>;
 }
 
 /// Internal guard that executes the unroot action when dropped.
@@ -194,10 +198,10 @@ mod boa_cells {
 }
 
 // JSC: actual struct with auto-protect/unprotect
-#[cfg(not(feature = "boa"))]
+#[cfg(feature = "jsc")]
 pub use jsc_cells::*;
 
-#[cfg(not(feature = "boa"))]
+#[cfg(feature = "jsc")]
 mod jsc_cells {
     use crate::jsc::{JscObject, JscValue};
     use crate::jsc_sys;
@@ -360,17 +364,80 @@ mod jsc_cells {
     }
 }
 
+#[cfg(feature = "v8")]
+pub use v8_cells::*;
+
+#[cfg(feature = "v8")]
+mod v8_cells {
+    use std::cell::{Ref, RefCell, RefMut};
+    use std::rc::Rc;
+
+    use crate::v8::{V8Object, V8Value};
+
+    pub struct JsValueCell(Rc<RefCell<V8Value>>);
+
+    pub struct JsObjectCell(Rc<RefCell<Option<V8Object>>>);
+
+    impl JsValueCell {
+        pub fn new(value: V8Value) -> Self {
+            Self(Rc::new(RefCell::new(value)))
+        }
+
+        pub fn set(&self, value: V8Value) {
+            *self.0.borrow_mut() = value;
+        }
+
+        pub fn borrow(&self) -> Ref<'_, V8Value> {
+            self.0.borrow()
+        }
+
+        pub fn borrow_mut(&self) -> RefMut<'_, V8Value> {
+            self.0.borrow_mut()
+        }
+    }
+
+    impl Clone for JsValueCell {
+        fn clone(&self) -> Self {
+            Self(self.0.clone())
+        }
+    }
+
+    impl JsObjectCell {
+        pub fn new(value: Option<V8Object>) -> Self {
+            Self(Rc::new(RefCell::new(value)))
+        }
+
+        pub fn set(&self, value: Option<V8Object>) {
+            *self.0.borrow_mut() = value;
+        }
+
+        pub fn borrow(&self) -> Ref<'_, Option<V8Object>> {
+            self.0.borrow()
+        }
+
+        pub fn borrow_mut(&self) -> RefMut<'_, Option<V8Object>> {
+            self.0.borrow_mut()
+        }
+    }
+
+    impl Clone for JsObjectCell {
+        fn clone(&self) -> Self {
+            Self(self.0.clone())
+        }
+    }
+}
+
 /// A backend-abstracted GC-managed cell providing interior mutability.
 ///
 /// On Boa this is a type alias for `boa_gc::Gc<boa_gc::GcRefCell<T>>` so
-/// the GC traces through the reference.  On JSC it is `Rc<RefCell<T>>`.
+/// the GC traces through the reference. On JSC and V8 it is `Rc<RefCell<T>>`.
 ///
 /// Use `gc_cell_new(val)` to construct, `.borrow()` / `.borrow_mut()` to
 /// access the inner value.
 #[cfg(feature = "boa")]
 pub type GcCell<T> = boa_gc::Gc<boa_gc::GcRefCell<T>>;
 
-#[cfg(not(feature = "boa"))]
+#[cfg(any(feature = "jsc", feature = "v8"))]
 pub type GcCell<T> = std::rc::Rc<std::cell::RefCell<T>>;
 
 /// Construct a [`GcCell`] with the given value.
@@ -380,7 +447,7 @@ pub fn gc_cell_new<T: boa_gc::Trace>(val: T) -> GcCell<T> {
 }
 
 /// Construct a [`GcCell`] with the given value.
-#[cfg(not(feature = "boa"))]
+#[cfg(any(feature = "jsc", feature = "v8"))]
 pub fn gc_cell_new<T>(val: T) -> GcCell<T> {
     std::rc::Rc::new(std::cell::RefCell::new(val))
 }
@@ -388,14 +455,14 @@ pub fn gc_cell_new<T>(val: T) -> GcCell<T> {
 /// Compare two [`GcCell`] references for pointer equality.
 ///
 /// Returns `true` if both references point to the same GC-managed allocation.
-/// On Boa this uses `Gc::ptr_eq`; on JSC it uses `Rc::ptr_eq`.
+/// On Boa this uses `Gc::ptr_eq`; on JSC and V8 it uses `Rc::ptr_eq`.
 #[cfg(feature = "boa")]
 pub fn gc_cell_ptr_eq<T: boa_gc::Trace + ?Sized>(a: &GcCell<T>, b: &GcCell<T>) -> bool {
     boa_gc::Gc::ptr_eq(a, b)
 }
 
 /// Compare two [`GcCell`] references for pointer equality.
-#[cfg(not(feature = "boa"))]
+#[cfg(any(feature = "jsc", feature = "v8"))]
 pub fn gc_cell_ptr_eq<T>(a: &GcCell<T>, b: &GcCell<T>) -> bool {
     std::rc::Rc::ptr_eq(a, b)
 }
@@ -493,11 +560,15 @@ mod boa_gc_impl {
 
     impl JsTypesGcExt for BoaTypes {
         type Reflector = boa_engine::object::JsObject;
+        type Context = crate::boa::BoaContext;
 
-        fn create_reflector(obj: &Self::JsObject) -> Self::Reflector {
+        fn create_reflector(_context: &mut Self::Context, obj: &Self::JsObject) -> Self::Reflector {
             obj.clone()
         }
-        fn upgrade_reflector(reflector: &Self::Reflector) -> Option<Self::JsObject> {
+        fn upgrade_reflector(
+            _context: &mut Self::Context,
+            reflector: &Self::Reflector,
+        ) -> Option<Self::JsObject> {
             Some(reflector.clone())
         }
     }
@@ -525,7 +596,7 @@ mod boa_gc_impl {
 }
 
 // ── JSC backend ───────────────────────────────────────────────────────────
-#[cfg(not(feature = "boa"))]
+#[cfg(feature = "jsc")]
 mod jsc_gc_impl {
     use super::*;
     use crate::jsc::JscTypes;
@@ -534,12 +605,16 @@ mod jsc_gc_impl {
         /// A (raw_object_ptr, context) pair so that `upgrade_reflector` can
         /// reconstruct a fully-valid `JscObject` with a non-null context.
         type Reflector = (*mut std::ffi::c_void, *mut crate::jsc_sys::JSContextRef);
+        type Context = crate::jsc::JscEngine;
 
-        fn create_reflector(obj: &Self::JsObject) -> Self::Reflector {
+        fn create_reflector(_context: &mut Self::Context, obj: &Self::JsObject) -> Self::Reflector {
             (obj.as_raw() as *mut std::ffi::c_void, obj.ctx())
         }
 
-        fn upgrade_reflector(reflector: &Self::Reflector) -> Option<Self::JsObject> {
+        fn upgrade_reflector(
+            _context: &mut Self::Context,
+            reflector: &Self::Reflector,
+        ) -> Option<Self::JsObject> {
             let (raw_ptr, ctx) = *reflector;
             if raw_ptr.is_null() || ctx.is_null() {
                 None
@@ -553,6 +628,24 @@ mod jsc_gc_impl {
             }
         }
     }
+
+    #[allow(dead_code)]
+    pub extern "C" fn jsc_generic_finalizer<V>(object: *mut std::ffi::c_void) {
+        unsafe {
+            let private_data =
+                crate::jsc_sys::JSObjectGetPrivate(object as *mut crate::jsc_sys::JSObjectRef);
+            if !private_data.is_null() {
+                drop(std::sync::Arc::from_raw(
+                    private_data as *const std::cell::RefCell<V>,
+                ));
+            }
+        }
+    }
+}
+
+#[cfg(any(feature = "jsc", feature = "v8"))]
+mod persistent_handle_trace_impls {
+    use super::Trace;
 
     // Blanket Trace impls for common types used as captures with
     // `create_builtin_function`.
@@ -574,17 +667,4 @@ mod jsc_gc_impl {
     unsafe impl<A: Trace, B: Trace, C: Trace> Trace for (A, B, C) {}
     unsafe impl<A: Trace, B: Trace, C: Trace, D: Trace> Trace for (A, B, C, D) {}
     unsafe impl<A: Trace, B: Trace, C: Trace, D: Trace, E: Trace> Trace for (A, B, C, D, E) {}
-
-    #[allow(dead_code)]
-    pub extern "C" fn jsc_generic_finalizer<V>(object: *mut std::ffi::c_void) {
-        unsafe {
-            let private_data =
-                crate::jsc_sys::JSObjectGetPrivate(object as *mut crate::jsc_sys::JSObjectRef);
-            if !private_data.is_null() {
-                drop(std::sync::Arc::from_raw(
-                    private_data as *const std::cell::RefCell<V>,
-                ));
-            }
-        }
-    }
 }

--- a/js_engine/src/gc.rs
+++ b/js_engine/src/gc.rs
@@ -19,6 +19,8 @@
 
 use crate::{ExecutionContext, JsTypes, JsTypesWithRealm};
 
+pub type UnrootAction<T> = Box<dyn FnOnce(&<T as JsTypes>::JsValue)>;
+
 // ============================================================================
 // SECTION I: SPEC-ANNOTATION TRAITS
 // ============================================================================
@@ -70,7 +72,7 @@ pub trait JsTypesGcExt: JsTypes + JsTypesWithRealm + Sized + 'static {
 /// Shared across all clones of a GcRootHandle via Rc.
 pub(crate) struct SharedUnroot<T: JsTypes> {
     value: T::JsValue,
-    action: Option<Box<dyn FnOnce(&T::JsValue)>>,
+    action: Option<UnrootAction<T>>,
 }
 
 impl<T: JsTypes> Drop for SharedUnroot<T> {
@@ -93,7 +95,7 @@ pub struct GcRootHandle<T: JsTypes> {
 
 impl<T: JsTypes> GcRootHandle<T> {
     /// Creates a new root handle.
-    pub fn new(value: T::JsValue, unroot_action: Option<Box<dyn FnOnce(&T::JsValue)>>) -> Self {
+    pub fn new(value: T::JsValue, unroot_action: Option<UnrootAction<T>>) -> Self {
         let guard = unroot_action.map(|action| {
             std::rc::Rc::new(SharedUnroot {
                 value: value.clone(),

--- a/js_engine/src/jsc/engine.rs
+++ b/js_engine/src/jsc/engine.rs
@@ -1612,7 +1612,7 @@ impl JscEngine {
     }
 
     fn descriptor_field_value(
-        &self,
+        &mut self,
         descriptor_object: *mut JSObjectRef,
         field_name: &str,
     ) -> Result<Option<JscValue>, JscValue> {
@@ -3656,7 +3656,7 @@ impl ExecutionContext<JscTypes> for JscEngine {
         true
     }
     fn get_value_from_buffer(
-        &self,
+        &mut self,
         array_buffer: &JscArrayBuffer,
         byte_index: u64,
         element_type: TypedArrayElementType,
@@ -4845,6 +4845,10 @@ impl ExecutionContext<JscTypes> for JscEngine {
 
     fn property_key_from_symbol(&self, sym: &JscSymbol) -> JscPropertyKey {
         JscPropertyKey::Symbol(*sym)
+    }
+
+    fn value_from_property_key(&mut self, key: JscPropertyKey) -> JscValue {
+        key.into()
     }
 
     fn property_key_from_well_known_symbol(&mut self, name: &str) -> JscPropertyKey {

--- a/js_engine/src/lib.rs
+++ b/js_engine/src/lib.rs
@@ -17,6 +17,7 @@
 //! | [`gc`] | `Trace`, `Finalize`, `GcRootHandle` (engine-specific) |
 //! | [`boa`] | Boa backend (feature = "boa") |
 //! | [`jsc`] | JSC backend (feature = "jsc") |
+//! | [`v8`] | V8 backend (feature = "v8") |
 //!
 //! ## Feature flags
 //!
@@ -24,6 +25,7 @@
 //! |---|---|---|
 //! | `boa` | Boa (git dep) | **default** |
 //! | `jsc` | JavaScriptCore (macOS) | opt-in |
+//! | `v8` | V8 (macOS arm64) | opt-in |
 //!
 //! At most one engine feature can be active.
 
@@ -42,6 +44,9 @@ pub mod jsc_sys;
 #[cfg(feature = "jsc")]
 pub mod jsc;
 
+#[cfg(feature = "v8")]
+pub mod v8;
+
 pub use engine::{Completion, EcmascriptHost, ExecutionContext, HostHooks, JsEngine};
 pub use enums::{
     IntegrityLevel, IteratorKind, Numeric, PreferredType, PromiseRejectionOperation, PromiseState,
@@ -51,7 +56,7 @@ pub use gc::{Finalize, GcCell, GcRootHandle, JsTypesGcExt, Trace, gc_cell_new};
 #[cfg(feature = "boa")]
 pub use js_engine_macros::gc_struct_boa as gc_struct;
 
-#[cfg(not(feature = "boa"))]
+#[cfg(any(feature = "jsc", feature = "v8"))]
 pub use js_engine_macros::gc_struct_jsc as gc_struct;
 
 pub use js_engine_macros::ignore_trace;

--- a/js_engine/src/records.rs
+++ b/js_engine/src/records.rs
@@ -120,11 +120,14 @@ pub struct PromiseResolvers<T: JsTypes> {
     // alive across Clone/Drop cycles.
     #[cfg(not(feature = "boa"))]
     #[allow(dead_code)]
-    root: Option<(
-        std::rc::Rc<crate::gc::GcRootHandle<T>>,
-        std::rc::Rc<crate::gc::GcRootHandle<T>>,
-    )>,
+    root: Option<PromiseResolverRoots<T>>,
 }
+
+#[cfg(not(feature = "boa"))]
+type PromiseResolverRoots<T> = (
+    std::rc::Rc<crate::gc::GcRootHandle<T>>,
+    std::rc::Rc<crate::gc::GcRootHandle<T>>,
+);
 
 impl<T: JsTypes> std::fmt::Debug for PromiseResolvers<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/js_engine/src/v8/engine.rs
+++ b/js_engine/src/v8/engine.rs
@@ -3,12 +3,11 @@ use std::cell::{Cell, RefCell, RefMut};
 use std::collections::{HashMap, VecDeque};
 use std::convert::TryFrom;
 use std::ffi::c_void;
-use std::ops::{Deref, DerefMut};
 use std::panic::{AssertUnwindSafe, catch_unwind};
 use std::ptr::NonNull;
 use std::rc::Rc;
-use std::sync::{Arc, Once};
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Once};
 
 use log::error;
 use rusty_v8 as v8;
@@ -19,33 +18,31 @@ use crate::enums::{
 use crate::gc::{JsTypesGcExt, Trace};
 use crate::records::{IteratorRecord, PromiseCapability, PromiseResolvers, RealmIntrinsics};
 use crate::{
-    Completion, EcmascriptHost, ExecutionContext, HostHooks, JsEngine, JsTypes, Numeric,
-    JsTypesWithRealm, PreferredType, PropertyDescriptor,
+    Completion, EcmascriptHost, ExecutionContext, HostHooks, JsEngine, JsTypes, JsTypesWithRealm,
+    Numeric, PreferredType, PropertyDescriptor,
 };
 
 use super::types::{CachedPrimitive, ObjectProfile, V8ArrayBufferState};
-use super::{
-    V8BigInt, V8Object, V8PropertyKey, V8Realm, V8String, V8Symbol, V8Types, V8Value,
-};
+use super::{V8BigInt, V8Object, V8PropertyKey, V8Realm, V8String, V8Symbol, V8Types, V8Value};
 
 const HOST_OBJECT_TAG: u16 = 1;
 static HOST_OBJECT_MARKER: u8 = 0;
 static NEXT_ISOLATE_ID: AtomicU64 = AtomicU64::new(1);
 
 type StoredBehaviour = Box<
-    dyn Fn(
-        &[V8Value],
-        V8Value,
-        &mut dyn ExecutionContext<V8Types>,
-    ) -> Completion<V8Value, V8Types>,
+    dyn Fn(&[V8Value], V8Value, &mut dyn ExecutionContext<V8Types>) -> Completion<V8Value, V8Types>,
 >;
+type RealmJob = Box<dyn FnOnce(&mut dyn ExecutionContext<V8Types>)>;
+type CaptureBehaviour<T, C> = fn(
+    &[<T as JsTypes>::JsValue],
+    <T as JsTypes>::JsValue,
+    &C,
+    &mut dyn ExecutionContext<T>,
+) -> Completion<<T as JsTypes>::JsValue, T>;
 
 enum QueuedJob {
     Plain(Box<dyn FnOnce()>),
-    WithRealm(
-        V8Realm,
-        Box<dyn FnOnce(&mut dyn ExecutionContext<V8Types>)>,
-    ),
+    WithRealm(V8Realm, RealmJob),
 }
 
 struct CallbackRecord {
@@ -57,53 +54,17 @@ struct HostObjectRecord {
     data: Box<dyn Any>,
 }
 
+type StoredCallbackScope = v8::PinScope<'static, 'static>;
+
 thread_local! {
     static CURRENT_ENGINE: Cell<*mut V8Engine> = const { Cell::new(std::ptr::null_mut()) };
-    static CURRENT_CALLBACK_ISOLATE: Cell<*mut v8::Isolate> = const { Cell::new(std::ptr::null_mut()) };
+    static CURRENT_CALLBACK_SCOPE: Cell<*mut StoredCallbackScope> = const { Cell::new(std::ptr::null_mut()) };
     static CURRENT_CALLBACK_ISOLATE_ID: Cell<u64> = const { Cell::new(0) };
 }
 
 struct SharedIsolate {
     isolate_id: u64,
     isolate: RefCell<v8::OwnedIsolate>,
-}
-
-enum IsolateAccess<'a> {
-    Owned(RefMut<'a, v8::OwnedIsolate>),
-    Callback(NonNull<v8::Isolate>),
-}
-
-impl Deref for IsolateAccess<'_> {
-    type Target = v8::Isolate;
-
-    fn deref(&self) -> &Self::Target {
-        match self {
-            Self::Owned(isolate) => isolate,
-            Self::Callback(isolate) => {
-                // SAFETY: This pointer is installed only by `native_callback`
-                // from V8's pinned callback scope. Callback execution is
-                // synchronous on the isolate thread, and the guard clears the
-                // pointer before that scope ends. The isolate id is checked by
-                // `SharedIsolate::borrow` before this variant is constructed.
-                unsafe { isolate.as_ref() }
-            }
-        }
-    }
-}
-
-impl DerefMut for IsolateAccess<'_> {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        match self {
-            Self::Owned(isolate) => isolate,
-            Self::Callback(isolate) => {
-                // SAFETY: The callback-scope, thread, lifetime, and isolate
-                // identity invariants are established in the `Deref` block.
-                // Native callbacks are the only reentrant path while the
-                // outer `RefMut` is live.
-                unsafe { isolate.as_mut() }
-            }
-        }
-    }
 }
 
 impl SharedIsolate {
@@ -117,69 +78,132 @@ impl SharedIsolate {
         })
     }
 
-    fn borrow(&self, expected_isolate_id: u64) -> IsolateAccess<'_> {
+    fn borrow(&self, expected_isolate_id: u64) -> RefMut<'_, v8::OwnedIsolate> {
         assert_eq!(
             self.isolate_id, expected_isolate_id,
             "V8 engine and shared isolate identities differ"
         );
-        match self.isolate.try_borrow_mut() {
-            Ok(isolate) => IsolateAccess::Owned(isolate),
-            Err(_) => {
-                let callback_isolate_id = CURRENT_CALLBACK_ISOLATE_ID.get();
-                let callback_isolate = CURRENT_CALLBACK_ISOLATE.get();
-                assert_eq!(
-                    callback_isolate_id, expected_isolate_id,
-                    "reentrant V8 isolate access occurred outside its native callback"
-                );
-                let callback_isolate = NonNull::new(callback_isolate).expect(
-                    "reentrant V8 isolate access occurred without a native callback scope",
-                );
-                IsolateAccess::Callback(callback_isolate)
-            }
-        }
+        self.isolate.borrow_mut()
     }
 }
 
 macro_rules! v8_engine_scope_with_context {
-    (let $scope:ident, $engine:expr, $context:expr) => {
-        let shared_isolate_for_scope = Rc::clone(&$engine.shared_isolate);
-        let mut isolate_for_scope = shared_isolate_for_scope.borrow($engine.isolate_id);
-        v8::scope_with_context!(let $scope, &mut *isolate_for_scope, $context);
-    };
+    ($scope:ident, $engine:expr, $context:expr, $body:block) => {{
+        let callback_scope_pointer = CURRENT_CALLBACK_SCOPE.get();
+        if callback_scope_pointer.is_null() {
+            let shared_isolate_for_scope = Rc::clone(&$engine.shared_isolate);
+            let mut isolate_for_scope = shared_isolate_for_scope.borrow($engine.isolate_id);
+            v8::scope_with_context!(let $scope, &mut *isolate_for_scope, $context);
+            $body
+        } else {
+            assert_eq!(
+                CURRENT_CALLBACK_ISOLATE_ID.get(),
+                $engine.isolate_id,
+                "reentrant V8 scope belongs to another isolate"
+            );
+            // SAFETY: `native_callback` installs this pointer from the pinned
+            // scope V8 supplied for the synchronous callback. The guard clears
+            // it before that scope ends, and the isolate identity is checked
+            // above. Reusing the callback scope avoids creating a second
+            // mutable reference to the isolate owned by the outer V8 call.
+            let callback_scope = unsafe { &mut *callback_scope_pointer };
+            let local_context = v8::Local::new(callback_scope, $context);
+            let $scope = &mut v8::ContextScope::new(callback_scope, local_context);
+            $body
+        }
+    }};
 }
 
 macro_rules! v8_engine_scope {
-    (let $scope:ident, $engine:expr) => {
-        let shared_isolate_for_scope = Rc::clone(&$engine.shared_isolate);
-        let mut isolate_for_scope = shared_isolate_for_scope.borrow($engine.isolate_id);
-        v8::scope!(let $scope, &mut *isolate_for_scope);
-    };
+    ($scope:ident, $engine:expr, $body:block) => {{
+        let callback_scope_pointer = CURRENT_CALLBACK_SCOPE.get();
+        if callback_scope_pointer.is_null() {
+            let shared_isolate_for_scope = Rc::clone(&$engine.shared_isolate);
+            let mut isolate_for_scope = shared_isolate_for_scope.borrow($engine.isolate_id);
+            v8::scope!(let $scope, &mut *isolate_for_scope);
+            $body
+        } else {
+            assert_eq!(
+                CURRENT_CALLBACK_ISOLATE_ID.get(),
+                $engine.isolate_id,
+                "reentrant V8 scope belongs to another isolate"
+            );
+            // SAFETY: The pointer and lifetime invariants are established by
+            // `CurrentCallbackScopeGuard` and checked above.
+            let $scope = unsafe { &mut *callback_scope_pointer };
+            $body
+        }
+    }};
+}
+
+macro_rules! v8_shared_scope {
+    ($scope:ident, $shared_isolate:expr, $isolate_id:expr, $body:block) => {{
+        let callback_scope_pointer = CURRENT_CALLBACK_SCOPE.get();
+        if callback_scope_pointer.is_null() {
+            let mut isolate_for_scope = $shared_isolate.borrow($isolate_id);
+            v8::scope!(let $scope, &mut *isolate_for_scope);
+            $body
+        } else {
+            assert_eq!(
+                CURRENT_CALLBACK_ISOLATE_ID.get(),
+                $isolate_id,
+                "reentrant V8 scope belongs to another isolate"
+            );
+            // SAFETY: The pointer and lifetime invariants are established by
+            // `CurrentCallbackScopeGuard` and checked above.
+            let $scope = unsafe { &mut *callback_scope_pointer };
+            $body
+        }
+    }};
+}
+
+macro_rules! v8_shared_isolate {
+    ($isolate:ident, $shared_isolate:expr, $isolate_id:expr, $body:block) => {{
+        let callback_scope_pointer = CURRENT_CALLBACK_SCOPE.get();
+        if callback_scope_pointer.is_null() {
+            let mut isolate_for_operation = $shared_isolate.borrow($isolate_id);
+            let $isolate = &mut *isolate_for_operation;
+            $body
+        } else {
+            assert_eq!(
+                CURRENT_CALLBACK_ISOLATE_ID.get(),
+                $isolate_id,
+                "reentrant V8 scope belongs to another isolate"
+            );
+            // SAFETY: The pointer and lifetime invariants are established by
+            // `CurrentCallbackScopeGuard` and checked above. The isolate
+            // reference is reborrowed from V8's active callback scope.
+            let callback_scope = unsafe { &mut *callback_scope_pointer };
+            let $isolate = &mut ***callback_scope;
+            $body
+        }
+    }};
 }
 
 struct CurrentEngineGuard {
     previous: *mut V8Engine,
 }
 
-struct CurrentCallbackIsolateGuard {
-    previous_isolate: *mut v8::Isolate,
+struct CurrentCallbackScopeGuard {
+    previous_scope: *mut StoredCallbackScope,
     previous_isolate_id: u64,
 }
 
-impl CurrentCallbackIsolateGuard {
+impl CurrentCallbackScopeGuard {
     fn enter(scope: &mut v8::PinScope<'_, '_>, isolate_id: u64) -> Self {
-        let isolate = &mut ***scope as *mut v8::Isolate;
-        let previous_isolate = CURRENT_CALLBACK_ISOLATE.replace(isolate);
+        let scope_pointer = (scope as *mut v8::PinScope<'_, '_>).cast::<StoredCallbackScope>();
+        let previous_scope = CURRENT_CALLBACK_SCOPE.replace(scope_pointer);
         let previous_isolate_id = CURRENT_CALLBACK_ISOLATE_ID.replace(isolate_id);
         Self {
-            previous_isolate,
+            previous_scope,
             previous_isolate_id,
         }
     }
 }
 
-impl Drop for CurrentCallbackIsolateGuard {
+impl Drop for CurrentCallbackScopeGuard {
     fn drop(&mut self) {
-        CURRENT_CALLBACK_ISOLATE.set(self.previous_isolate);
+        CURRENT_CALLBACK_SCOPE.set(self.previous_scope);
         CURRENT_CALLBACK_ISOLATE_ID.set(self.previous_isolate_id);
     }
 }
@@ -244,9 +268,8 @@ fn host_data_pointer<'scope>(
     // created by `create_object_with_any`. That constructor stores an aligned
     // `HostObjectRecord` pointer in field 1 with this exact tag. The weak
     // handle keeps the record alive for at least as long as the JS object.
-    let pointer = unsafe {
-        object.get_aligned_pointer_from_internal_field(1, HOST_OBJECT_TAG)
-    } as *mut c_void;
+    let pointer = unsafe { object.get_aligned_pointer_from_internal_field(1, HOST_OBJECT_TAG) }
+        as *mut c_void;
     NonNull::new(pointer)
 }
 
@@ -319,7 +342,7 @@ fn wrap_local_value(
         } else {
             None
         };
-        Some(ObjectProfile {
+        Some(Box::new(ObjectProfile {
             is_array_buffer: value.is_array_buffer(),
             is_shared_array_buffer: value.is_shared_array_buffer(),
             is_typed_array: value.is_typed_array(),
@@ -342,7 +365,7 @@ fn wrap_local_value(
             wrapper_primitive: None,
             array_buffer_state,
             typed_array_element_type,
-        })
+        }))
     } else {
         None
     };
@@ -394,12 +417,9 @@ fn local_property_key<'scope>(
             if let Some(value) = &string.value {
                 local_value(scope, isolate_id, value)
             } else {
-                let string = v8::String::new_from_two_byte(
-                    scope,
-                    &string.utf16,
-                    v8::NewStringType::Normal,
-                )
-                .expect("V8 property name allocation failed");
+                let string =
+                    v8::String::new_from_two_byte(scope, &string.utf16, v8::NewStringType::Normal)
+                        .expect("V8 property name allocation failed");
                 Ok(string.into())
             }
         }
@@ -436,8 +456,8 @@ fn caught_exception(
     fallback: &str,
 ) -> V8Value {
     let exception = exception.unwrap_or_else(|| {
-        let message = v8::String::new(scope, fallback)
-            .expect("static V8 exception string allocation failed");
+        let message =
+            v8::String::new(scope, fallback).expect("static V8 exception string allocation failed");
         v8::Exception::error(scope, message)
     });
     wrap_local_value(scope, isolate_id, exception)
@@ -488,14 +508,14 @@ fn native_callback(
     // restricted to the isolate thread. The isolate id check below prevents a
     // record from being used by another isolate. `catch_unwind` prevents Rust
     // unwinding from crossing V8's callback boundary.
-    let result = unsafe {
+    let (result, callback_isolate_id) = unsafe {
         let record = &*record_pointer;
         let engine = &mut *engine_pointer;
-        if record.isolate_id != engine.isolate_id {
+        let result = if record.isolate_id != engine.isolate_id {
             Err(engine.new_type_error("native callback belongs to a different V8 isolate"))
         } else {
-            let _current_callback_isolate =
-                CurrentCallbackIsolateGuard::enter(scope, record.isolate_id);
+            let _current_callback_scope =
+                CurrentCallbackScopeGuard::enter(scope, record.isolate_id);
             let callback_arguments: Vec<_> = (0..arguments.length())
                 .map(|index| wrap_local_value(scope, record.isolate_id, arguments.get(index)))
                 .collect();
@@ -506,11 +526,12 @@ fn native_callback(
                 Ok(completion) => completion,
                 Err(_) => Err(engine.new_type_error("Rust panic in native callback")),
             }
-        }
+        };
+        (result, record.isolate_id)
     };
 
     match result {
-        Ok(value) => match local_value(scope, unsafe { (*record_pointer).isolate_id }, &value) {
+        Ok(value) => match local_value(scope, callback_isolate_id, &value) {
             Ok(value) => return_value.set(value),
             Err(exception) => {
                 let exception = v8::Local::new(scope, &exception.handle);
@@ -518,7 +539,7 @@ fn native_callback(
             }
         },
         Err(exception) => {
-            if exception.isolate_id == unsafe { (*record_pointer).isolate_id } {
+            if exception.isolate_id == callback_isolate_id {
                 let exception = v8::Local::new(scope, &exception.handle);
                 scope.throw_exception(exception);
             } else {
@@ -556,17 +577,14 @@ impl V8Engine {
     fn new_with_shared_isolate(shared_isolate: Rc<SharedIsolate>) -> Self {
         let isolate_id = shared_isolate.isolate_id;
 
-        let (context_handle, realm_global) = {
-            let mut isolate = shared_isolate.borrow(isolate_id);
-            v8::scope!(let scope, &mut *isolate);
+        let (context_handle, realm_global) = v8_shared_scope!(scope, shared_isolate, isolate_id, {
             let context = v8::Context::new(scope, v8::ContextOptions::default());
             let context_handle = v8::Global::new(scope, context);
             let context_scope = &mut v8::ContextScope::new(scope, context);
             let global = context.global(context_scope);
-            let realm_global =
-                V8Object(wrap_local_value(context_scope, isolate_id, global.into()));
+            let realm_global = V8Object(wrap_local_value(context_scope, isolate_id, global.into()));
             (context_handle, realm_global)
-        };
+        });
 
         let realm = V8Realm {
             isolate_id,
@@ -599,26 +617,27 @@ impl V8Engine {
 
     pub(crate) fn create_weak_object(&mut self, object: &V8Object) -> Rc<v8::Weak<v8::Object>> {
         let isolate_id = self.isolate_id;
-        v8_engine_scope_with_context!(let scope, self, &self.realm.context);
-        let local = local_object(scope, isolate_id, object)
-            .expect("reflector creation received a non-object or cross-isolate handle");
-        Rc::new(v8::Weak::new(scope, local))
+        v8_engine_scope_with_context!(scope, self, &self.realm.context, {
+            let local = local_object(scope, isolate_id, object)
+                .expect("reflector creation received a non-object or cross-isolate handle");
+            Rc::new(v8::Weak::new(scope, local))
+        })
     }
 
-    pub(crate) fn upgrade_weak_object(
-        &mut self,
-        weak: &v8::Weak<v8::Object>,
-    ) -> Option<V8Object> {
+    pub(crate) fn upgrade_weak_object(&mut self, weak: &v8::Weak<v8::Object>) -> Option<V8Object> {
         let isolate_id = self.isolate_id;
-        let shared_isolate = Rc::clone(&self.shared_isolate);
-        let mut isolate = shared_isolate.borrow(isolate_id);
-        let global = weak.to_global(&mut *isolate)?;
-        v8::scope_with_context!(let scope, &mut *isolate, &self.realm.context);
-        let local = v8::Local::new(scope, global);
-        Some(V8Object(wrap_local_value(scope, isolate_id, local.into())))
+        v8_engine_scope_with_context!(scope, self, &self.realm.context, {
+            let global = weak.to_global(scope)?;
+            let local = v8::Local::new(scope, global);
+            Some(V8Object(wrap_local_value(scope, isolate_id, local.into())))
+        })
     }
 
-    fn call_js_helper(&mut self, source: &str, arguments: &[V8Value]) -> Completion<V8Value, V8Types> {
+    fn call_js_helper(
+        &mut self,
+        source: &str,
+        arguments: &[V8Value],
+    ) -> Completion<V8Value, V8Types> {
         for argument in arguments {
             if argument.isolate_id != self.isolate_id {
                 return Err(self.new_type_error("value belongs to a different V8 isolate"));
@@ -626,30 +645,41 @@ impl V8Engine {
         }
         let _current_engine = CurrentEngineGuard::enter(self);
         let isolate_id = self.isolate_id;
-        v8_engine_scope_with_context!(let scope, self, &self.realm.context);
-        v8::tc_scope!(let try_catch, scope);
-        let Some(source) = v8::String::new(try_catch, source) else {
-            return Err(caught_exception(try_catch, isolate_id, None, "failed to allocate helper source"));
-        };
-        let Some(script) = v8::Script::compile(try_catch, source, None) else {
-            return Err(caught!(try_catch, isolate_id, "failed to compile helper"));
-        };
-        let Some(function_value) = script.run(try_catch) else {
-            return Err(caught!(try_catch, isolate_id, "failed to evaluate helper"));
-        };
-        let Ok(function) = v8::Local::<v8::Function>::try_from(function_value) else {
-            return Err(caught_exception(try_catch, isolate_id, None, "helper is not callable"));
-        };
-        let local_arguments: Result<Vec<_>, _> = arguments
-            .iter()
-            .map(|argument| local_value(try_catch, isolate_id, argument))
-            .collect();
-        let local_arguments = local_arguments?;
-        let receiver = v8::undefined(try_catch).into();
-        let Some(result) = function.call(try_catch, receiver, &local_arguments) else {
-            return Err(caught!(try_catch, isolate_id, "helper call failed"));
-        };
-        Ok(wrap_local_value(try_catch, isolate_id, result))
+        v8_engine_scope_with_context!(scope, self, &self.realm.context, {
+            v8::tc_scope!(let try_catch, scope);
+            let Some(source) = v8::String::new(try_catch, source) else {
+                return Err(caught_exception(
+                    try_catch,
+                    isolate_id,
+                    None,
+                    "failed to allocate helper source",
+                ));
+            };
+            let Some(script) = v8::Script::compile(try_catch, source, None) else {
+                return Err(caught!(try_catch, isolate_id, "failed to compile helper"));
+            };
+            let Some(function_value) = script.run(try_catch) else {
+                return Err(caught!(try_catch, isolate_id, "failed to evaluate helper"));
+            };
+            let Ok(function) = v8::Local::<v8::Function>::try_from(function_value) else {
+                return Err(caught_exception(
+                    try_catch,
+                    isolate_id,
+                    None,
+                    "helper is not callable",
+                ));
+            };
+            let local_arguments: Result<Vec<_>, _> = arguments
+                .iter()
+                .map(|argument| local_value(try_catch, isolate_id, argument))
+                .collect();
+            let local_arguments = local_arguments?;
+            let receiver = v8::undefined(try_catch).into();
+            let Some(result) = function.call(try_catch, receiver, &local_arguments) else {
+                return Err(caught!(try_catch, isolate_id, "helper call failed"));
+            };
+            Ok(wrap_local_value(try_catch, isolate_id, result))
+        })
     }
 
     fn intrinsic_object(&mut self, source: &str) -> V8Object {
@@ -722,41 +752,42 @@ impl V8Engine {
         let isolate_id = self.isolate_id;
         let function_name = self.property_key_to_rust_string(&name);
 
-        v8_engine_scope_with_context!(let scope, self, &self.realm.context);
-        let external = v8::External::new(scope, record_pointer.cast());
-        let constructor_behavior = if is_constructor {
-            v8::ConstructorBehavior::Allow
-        } else {
-            v8::ConstructorBehavior::Throw
-        };
-        let function = v8::Function::builder(native_callback)
-            .data(external.into())
-            .length(length as i32)
-            .constructor_behavior(constructor_behavior)
-            .build(scope)
-            .expect("V8 failed to create native function");
-        if let Some(name) = v8::String::new(scope, &function_name) {
-            function.set_name(name);
-        }
-        let function_value = wrap_local_value(scope, isolate_id, function.into());
+        v8_engine_scope_with_context!(scope, self, &self.realm.context, {
+            let external = v8::External::new(scope, record_pointer.cast());
+            let constructor_behavior = if is_constructor {
+                v8::ConstructorBehavior::Allow
+            } else {
+                v8::ConstructorBehavior::Throw
+            };
+            let function = v8::Function::builder(native_callback)
+                .data(external.into())
+                .length(length as i32)
+                .constructor_behavior(constructor_behavior)
+                .build(scope)
+                .expect("V8 failed to create native function");
+            if let Some(name) = v8::String::new(scope, &function_name) {
+                function.set_name(name);
+            }
+            let function_value = wrap_local_value(scope, isolate_id, function.into());
 
-        // The weak handle is retained by the engine. The finalizer owns the
-        // callback record and is guaranteed to release it before isolate
-        // destruction, even if no collection happens first.
-        let callback_handle = v8::Weak::with_guaranteed_finalizer(
-            scope,
-            function,
-            Box::new(move || {
-                // SAFETY: `record_pointer` came from one Box::into_raw above
-                // and this guaranteed finalizer is its sole owner. The weak
-                // handle invokes this closure at most once.
-                unsafe {
-                    drop(Box::from_raw(record_pointer));
-                }
-            }),
-        );
-        self.callback_handles.push(callback_handle);
-        V8Object(function_value)
+            // The weak handle is retained by the engine. The finalizer owns the
+            // callback record and is guaranteed to release it before isolate
+            // destruction, even if no collection happens first.
+            let callback_handle = v8::Weak::with_guaranteed_finalizer(
+                scope,
+                function,
+                Box::new(move || {
+                    // SAFETY: `record_pointer` came from one Box::into_raw above
+                    // and this guaranteed finalizer is its sole owner. The weak
+                    // handle invokes this closure at most once.
+                    unsafe {
+                        drop(Box::from_raw(record_pointer));
+                    }
+                }),
+            );
+            self.callback_handles.push(callback_handle);
+            V8Object(function_value)
+        })
     }
 }
 
@@ -769,12 +800,13 @@ impl Default for V8Engine {
 impl JsEngine<V8Types> for V8Engine {
     fn create_realm(&mut self) -> V8Realm {
         let isolate_id = self.isolate_id;
-        v8_engine_scope!(let scope, self);
-        let context = v8::Context::new(scope, v8::ContextOptions::default());
-        V8Realm {
-            isolate_id,
-            context: v8::Global::new(scope, context),
-        }
+        v8_engine_scope!(scope, self, {
+            let context = v8::Context::new(scope, v8::ContextOptions::default());
+            V8Realm {
+                isolate_id,
+                context: v8::Global::new(scope, context),
+            }
+        })
     }
 
     fn set_realm_global_object(
@@ -799,59 +831,73 @@ impl JsEngine<V8Types> for V8Engine {
         }
     }
 
-    fn evaluate_script(
-        &mut self,
-        source: &str,
-        realm: &V8Realm,
-    ) -> Completion<V8Value, V8Types> {
+    fn evaluate_script(&mut self, source: &str, realm: &V8Realm) -> Completion<V8Value, V8Types> {
         if realm.isolate_id != self.isolate_id {
             return Err(self.new_type_error("realm belongs to a different V8 isolate"));
         }
         let _current_engine = CurrentEngineGuard::enter(self);
         let isolate_id = self.isolate_id;
-        v8_engine_scope_with_context!(let scope, self, &realm.context);
-        v8::tc_scope!(let try_catch, scope);
-        let Some(source) = v8::String::new(try_catch, source) else {
-            return Err(caught_exception(try_catch, isolate_id, None, "script source allocation failed"));
-        };
-        let Some(script) = v8::Script::compile(try_catch, source, None) else {
-            return Err(caught!(try_catch, isolate_id, "script compilation failed"));
-        };
-        let Some(value) = script.run(try_catch) else {
-            return Err(caught!(try_catch, isolate_id, "script evaluation failed"));
-        };
-        Ok(wrap_local_value(try_catch, isolate_id, value))
+        v8_engine_scope_with_context!(scope, self, &realm.context, {
+            v8::tc_scope!(let try_catch, scope);
+            let Some(source) = v8::String::new(try_catch, source) else {
+                return Err(caught_exception(
+                    try_catch,
+                    isolate_id,
+                    None,
+                    "script source allocation failed",
+                ));
+            };
+            let Some(script) = v8::Script::compile(try_catch, source, None) else {
+                return Err(caught!(try_catch, isolate_id, "script compilation failed"));
+            };
+            let Some(value) = script.run(try_catch) else {
+                return Err(caught!(try_catch, isolate_id, "script evaluation failed"));
+            };
+            Ok(wrap_local_value(try_catch, isolate_id, value))
+        })
     }
 
-    fn evaluate_module(
-        &mut self,
-        source: &str,
-        realm: &V8Realm,
-    ) -> Completion<V8Object, V8Types> {
+    fn evaluate_module(&mut self, source: &str, realm: &V8Realm) -> Completion<V8Object, V8Types> {
         if realm.isolate_id != self.isolate_id {
             return Err(self.new_type_error("realm belongs to a different V8 isolate"));
         }
         let _current_engine = CurrentEngineGuard::enter(self);
         let isolate_id = self.isolate_id;
-        v8_engine_scope_with_context!(let scope, self, &realm.context);
-        v8::tc_scope!(let try_catch, scope);
-        let Some(source_string) = v8::String::new(try_catch, source) else {
-            return Err(caught_exception(try_catch, isolate_id, None, "module source allocation failed"));
-        };
-        let mut source = v8::script_compiler::Source::new(source_string, None);
-        let Some(module) = v8::script_compiler::compile_module(try_catch, &mut source) else {
-            return Err(caught!(try_catch, isolate_id, "module compilation failed"));
-        };
-        if module.instantiate_module(try_catch, reject_module_import) != Some(true) {
-            return Err(caught!(try_catch, isolate_id, "module instantiation failed"));
-        }
-        if module.evaluate(try_catch).is_none() {
-            return Err(caught!(try_catch, isolate_id, "module evaluation failed"));
-        }
-        let namespace = module.get_module_namespace();
-        let namespace = wrap_local_value(try_catch, isolate_id, namespace);
-        V8Types::value_as_object(&namespace)
-            .ok_or_else(|| caught_exception(try_catch, isolate_id, None, "module namespace is not an object"))
+        v8_engine_scope_with_context!(scope, self, &realm.context, {
+            v8::tc_scope!(let try_catch, scope);
+            let Some(source_string) = v8::String::new(try_catch, source) else {
+                return Err(caught_exception(
+                    try_catch,
+                    isolate_id,
+                    None,
+                    "module source allocation failed",
+                ));
+            };
+            let mut source = v8::script_compiler::Source::new(source_string, None);
+            let Some(module) = v8::script_compiler::compile_module(try_catch, &mut source) else {
+                return Err(caught!(try_catch, isolate_id, "module compilation failed"));
+            };
+            if module.instantiate_module(try_catch, reject_module_import) != Some(true) {
+                return Err(caught!(
+                    try_catch,
+                    isolate_id,
+                    "module instantiation failed"
+                ));
+            }
+            if module.evaluate(try_catch).is_none() {
+                return Err(caught!(try_catch, isolate_id, "module evaluation failed"));
+            }
+            let namespace = module.get_module_namespace();
+            let namespace = wrap_local_value(try_catch, isolate_id, namespace);
+            V8Types::value_as_object(&namespace).ok_or_else(|| {
+                caught_exception(
+                    try_catch,
+                    isolate_id,
+                    None,
+                    "module namespace is not an object",
+                )
+            })
+        })
     }
 
     fn allocate_array_buffer(
@@ -893,7 +939,8 @@ impl JsEngine<V8Types> for V8Engine {
         byte_length: u64,
     ) -> Completion<V8Object, V8Types> {
         let byte_length = self.value_from_number(byte_length as f64);
-        let value = self.call_js_helper("length => new SharedArrayBuffer(length)", &[byte_length])?;
+        let value =
+            self.call_js_helper("length => new SharedArrayBuffer(length)", &[byte_length])?;
         V8Types::value_as_object(&value)
             .ok_or_else(|| self.new_type_error("SharedArrayBuffer allocation failed"))
     }
@@ -919,6 +966,9 @@ impl JsTypesGcExt for V8Types {
     }
 }
 
+// SAFETY: Each V8 wrapper owns a `v8::Global` handle, so its JavaScript value
+// remains rooted independently of Rust-side tracing. The marker implementation
+// therefore cannot hide an unrooted V8 reference from the collector.
 unsafe impl Trace for V8Value {}
 unsafe impl Trace for V8Object {}
 unsafe impl Trace for V8String {}
@@ -928,12 +978,7 @@ unsafe impl Trace for V8BigInt {}
 pub fn create_builtin_fn_with_captures<T, C>(
     execution_context: &mut dyn ExecutionContext<T>,
     captures: C,
-    behaviour: fn(
-        &[T::JsValue],
-        T::JsValue,
-        &C,
-        &mut dyn ExecutionContext<T>,
-    ) -> Completion<T::JsValue, T>,
+    behaviour: CaptureBehaviour<T, C>,
     length: u32,
     name: T::PropertyKey,
     is_constructor: bool,
@@ -951,12 +996,7 @@ where
     // build, where T is V8Types. Function pointers have identical pointer
     // representation; the callback trampoline validates the active isolate
     // before invoking the converted behaviour.
-    let behaviour: fn(
-        &[V8Value],
-        V8Value,
-        &C,
-        &mut dyn ExecutionContext<V8Types>,
-    ) -> Completion<V8Value, V8Types> = unsafe { std::mem::transmute_copy(&behaviour) };
+    let behaviour: CaptureBehaviour<V8Types, C> = unsafe { std::mem::transmute_copy(&behaviour) };
 
     // SAFETY: In a V8-selected build T::PropertyKey is V8PropertyKey. Moving
     // through MaybeUninit preserves ownership without creating a second drop.
@@ -970,9 +1010,13 @@ where
         std::mem::forget(name);
         destination.assume_init()
     };
-    let stored = Box::new(move |arguments: &[V8Value], this_value, execution_context: &mut dyn ExecutionContext<V8Types>| {
-        behaviour(arguments, this_value, &captures, execution_context)
-    });
+    let stored = Box::new(
+        move |arguments: &[V8Value],
+              this_value,
+              execution_context: &mut dyn ExecutionContext<V8Types>| {
+            behaviour(arguments, this_value, &captures, execution_context)
+        },
+    );
     let result = engine.make_builtin_function(stored, length, name, is_constructor);
 
     // SAFETY: In a V8-selected build T::Function is V8Object. The result is
@@ -1010,27 +1054,30 @@ impl EcmascriptHost<V8Types> for V8Engine {
     ) -> Completion<V8Value, V8Types> {
         if callable.0.isolate_id != self.isolate_id
             || this_argument.isolate_id != self.isolate_id
-            || arguments.iter().any(|value| value.isolate_id != self.isolate_id)
+            || arguments
+                .iter()
+                .any(|value| value.isolate_id != self.isolate_id)
         {
             return Err(self.new_type_error("value belongs to a different V8 isolate"));
         }
         let _current_engine = CurrentEngineGuard::enter(self);
         let isolate_id = self.isolate_id;
-        v8_engine_scope_with_context!(let scope, self, &self.realm.context);
-        v8::tc_scope!(let try_catch, scope);
-        let callable = local_value(try_catch, isolate_id, &callable.0)?;
-        let function = v8::Local::<v8::Function>::try_from(callable).map_err(|_| {
-            caught_exception(try_catch, isolate_id, None, "callback is not callable")
-        })?;
-        let this_argument = local_value(try_catch, isolate_id, this_argument)?;
-        let local_arguments: Result<Vec<_>, _> = arguments
-            .iter()
-            .map(|argument| local_value(try_catch, isolate_id, argument))
-            .collect();
-        let Some(result) = function.call(try_catch, this_argument, &local_arguments?) else {
-            return Err(caught!(try_catch, isolate_id, "callback call failed"));
-        };
-        Ok(wrap_local_value(try_catch, isolate_id, result))
+        v8_engine_scope_with_context!(scope, self, &self.realm.context, {
+            v8::tc_scope!(let try_catch, scope);
+            let callable = local_value(try_catch, isolate_id, &callable.0)?;
+            let function = v8::Local::<v8::Function>::try_from(callable).map_err(|_| {
+                caught_exception(try_catch, isolate_id, None, "callback is not callable")
+            })?;
+            let this_argument = local_value(try_catch, isolate_id, this_argument)?;
+            let local_arguments: Result<Vec<_>, _> = arguments
+                .iter()
+                .map(|argument| local_value(try_catch, isolate_id, argument))
+                .collect();
+            let Some(result) = function.call(try_catch, this_argument, &local_arguments?) else {
+                return Err(caught!(try_catch, isolate_id, "callback call failed"));
+            };
+            Ok(wrap_local_value(try_catch, isolate_id, result))
+        })
     }
 
     fn perform_a_microtask_checkpoint(&mut self) -> Completion<(), V8Types> {
@@ -1041,7 +1088,9 @@ impl EcmascriptHost<V8Types> for V8Engine {
                     QueuedJob::Plain(job) => job(),
                     QueuedJob::WithRealm(realm, job) => {
                         if realm.isolate_id != self.isolate_id {
-                            return Err(self.new_type_error("job realm belongs to a different V8 isolate"));
+                            return Err(
+                                self.new_type_error("job realm belongs to a different V8 isolate")
+                            );
                         }
                         job(self);
                     }
@@ -1049,8 +1098,9 @@ impl EcmascriptHost<V8Types> for V8Engine {
             }
             let queued_before_checkpoint = self.queued_jobs.len();
             let shared_isolate = Rc::clone(&self.shared_isolate);
-            let mut isolate = shared_isolate.borrow(self.isolate_id);
-            isolate.perform_microtask_checkpoint();
+            v8_shared_isolate!(isolate, shared_isolate, self.isolate_id, {
+                isolate.perform_microtask_checkpoint();
+            });
             if self.queued_jobs.len() == queued_before_checkpoint {
                 break;
             }
@@ -1067,36 +1117,41 @@ impl EcmascriptHost<V8Types> for V8Engine {
 
     fn gc(&mut self) {
         let shared_isolate = Rc::clone(&self.shared_isolate);
-        let mut isolate = shared_isolate.borrow(self.isolate_id);
-        isolate.request_garbage_collection_for_testing(v8::GarbageCollectionType::Full);
+        v8_shared_isolate!(isolate, shared_isolate, self.isolate_id, {
+            isolate.request_garbage_collection_for_testing(v8::GarbageCollectionType::Full);
+        });
     }
 
     fn value_undefined(&mut self) -> V8Value {
         let isolate_id = self.isolate_id;
-        v8_engine_scope_with_context!(let scope, self, &self.realm.context);
-        let value = v8::undefined(scope).into();
-        wrap_local_value(scope, isolate_id, value)
+        v8_engine_scope_with_context!(scope, self, &self.realm.context, {
+            let value = v8::undefined(scope).into();
+            wrap_local_value(scope, isolate_id, value)
+        })
     }
 
     fn value_null(&mut self) -> V8Value {
         let isolate_id = self.isolate_id;
-        v8_engine_scope_with_context!(let scope, self, &self.realm.context);
-        let value = v8::null(scope).into();
-        wrap_local_value(scope, isolate_id, value)
+        v8_engine_scope_with_context!(scope, self, &self.realm.context, {
+            let value = v8::null(scope).into();
+            wrap_local_value(scope, isolate_id, value)
+        })
     }
 
     fn value_from_bool(&mut self, boolean: bool) -> V8Value {
         let isolate_id = self.isolate_id;
-        v8_engine_scope_with_context!(let scope, self, &self.realm.context);
-        let value = v8::Boolean::new(scope, boolean).into();
-        wrap_local_value(scope, isolate_id, value)
+        v8_engine_scope_with_context!(scope, self, &self.realm.context, {
+            let value = v8::Boolean::new(scope, boolean).into();
+            wrap_local_value(scope, isolate_id, value)
+        })
     }
 
     fn value_from_number(&mut self, number: f64) -> V8Value {
         let isolate_id = self.isolate_id;
-        v8_engine_scope_with_context!(let scope, self, &self.realm.context);
-        let value = v8::Number::new(scope, number).into();
-        wrap_local_value(scope, isolate_id, value)
+        v8_engine_scope_with_context!(scope, self, &self.realm.context, {
+            let value = v8::Number::new(scope, number).into();
+            wrap_local_value(scope, isolate_id, value)
+        })
     }
 
     fn value_from_string(&mut self, string: V8String) -> V8Value {
@@ -1104,14 +1159,12 @@ impl EcmascriptHost<V8Types> for V8Engine {
             return value;
         }
         let isolate_id = self.isolate_id;
-        v8_engine_scope_with_context!(let scope, self, &self.realm.context);
-        let local = v8::String::new_from_two_byte(
-            scope,
-            &string.utf16,
-            v8::NewStringType::Normal,
-        )
-        .expect("V8 string allocation failed");
-        wrap_local_value(scope, isolate_id, local.into())
+        v8_engine_scope_with_context!(scope, self, &self.realm.context, {
+            let local =
+                v8::String::new_from_two_byte(scope, &string.utf16, v8::NewStringType::Normal)
+                    .expect("V8 string allocation failed");
+            wrap_local_value(scope, isolate_id, local.into())
+        })
     }
 
     fn js_string_from_str(&self, string: &str) -> V8String {
@@ -1289,7 +1342,8 @@ impl ExecutionContext<V8Types> for V8Engine {
     }
 
     fn is_array(&mut self, value: &V8Value) -> Completion<bool, V8Types> {
-        let result = self.call_js_helper("value => Array.isArray(value)", &[value.clone()])?;
+        let result =
+            self.call_js_helper("value => Array.isArray(value)", std::slice::from_ref(value))?;
         Ok(V8Types::value_as_bool(&result).unwrap_or(false))
     }
 
@@ -1301,12 +1355,16 @@ impl ExecutionContext<V8Types> for V8Engine {
     }
 
     fn is_extensible(&mut self, object: &V8Object) -> Completion<bool, V8Types> {
-        let result = self.call_js_helper("value => Object.isExtensible(value)", &[object.0.clone()])?;
+        let result = self.call_js_helper(
+            "value => Object.isExtensible(value)",
+            std::slice::from_ref(&object.0),
+        )?;
         Ok(V8Types::value_as_bool(&result).unwrap_or(false))
     }
 
     fn is_integral_number(&self, value: &V8Value) -> bool {
-        V8Types::value_as_number(value).is_some_and(|number| number.is_finite() && number.fract() == 0.0)
+        V8Types::value_as_number(value)
+            .is_some_and(|number| number.is_finite() && number.fract() == 0.0)
     }
 
     fn is_property_key(&self, value: &V8Value) -> bool {
@@ -1323,7 +1381,8 @@ impl ExecutionContext<V8Types> for V8Engine {
             (CachedPrimitive::Boolean(left), CachedPrimitive::Boolean(right)) => left == right,
             (CachedPrimitive::Number(left), CachedPrimitive::Number(right)) => {
                 (left.is_nan() && right.is_nan())
-                    || (left == right && (left != &0.0 || left.is_sign_positive() == right.is_sign_positive()))
+                    || (left == right
+                        && (left != &0.0 || left.is_sign_positive() == right.is_sign_positive()))
             }
             (CachedPrimitive::String(left), CachedPrimitive::String(right)) => left == right,
             (CachedPrimitive::BigInt(left), CachedPrimitive::BigInt(right)) => left == right,
@@ -1366,14 +1425,15 @@ impl ExecutionContext<V8Types> for V8Engine {
     ) -> Completion<V8Value, V8Types> {
         let _current_engine = CurrentEngineGuard::enter(self);
         let isolate_id = self.isolate_id;
-        v8_engine_scope_with_context!(let scope, self, &self.realm.context);
-        v8::tc_scope!(let try_catch, scope);
-        let object = local_object(try_catch, isolate_id, &object)?;
-        let key = local_property_key(try_catch, isolate_id, &property_key)?;
-        let Some(value) = object.get(try_catch, key) else {
-            return Err(caught!(try_catch, isolate_id, "property get failed"));
-        };
-        Ok(wrap_local_value(try_catch, isolate_id, value))
+        v8_engine_scope_with_context!(scope, self, &self.realm.context, {
+            v8::tc_scope!(let try_catch, scope);
+            let object = local_object(try_catch, isolate_id, &object)?;
+            let key = local_property_key(try_catch, isolate_id, &property_key)?;
+            let Some(value) = object.get(try_catch, key) else {
+                return Err(caught!(try_catch, isolate_id, "property get failed"));
+            };
+            Ok(wrap_local_value(try_catch, isolate_id, value))
+        })
     }
 
     fn get_v(
@@ -1394,22 +1454,23 @@ impl ExecutionContext<V8Types> for V8Engine {
     ) -> Completion<(), V8Types> {
         let _current_engine = CurrentEngineGuard::enter(self);
         let isolate_id = self.isolate_id;
-        v8_engine_scope_with_context!(let scope, self, &self.realm.context);
-        v8::tc_scope!(let try_catch, scope);
-        let object = local_object(try_catch, isolate_id, &object)?;
-        let key = local_property_key(try_catch, isolate_id, &property_key)?;
-        let value = local_value(try_catch, isolate_id, &value)?;
-        match object.set(try_catch, key, value) {
-            Some(true) => Ok(()),
-            Some(false) if !throw => Ok(()),
-            Some(false) => Err(caught_exception(
-                try_catch,
-                isolate_id,
-                None,
-                "property assignment was rejected",
-            )),
-            None => Err(caught!(try_catch, isolate_id, "property assignment failed")),
-        }
+        v8_engine_scope_with_context!(scope, self, &self.realm.context, {
+            v8::tc_scope!(let try_catch, scope);
+            let object = local_object(try_catch, isolate_id, &object)?;
+            let key = local_property_key(try_catch, isolate_id, &property_key)?;
+            let value = local_value(try_catch, isolate_id, &value)?;
+            match object.set(try_catch, key, value) {
+                Some(true) => Ok(()),
+                Some(false) if !throw => Ok(()),
+                Some(false) => Err(caught_exception(
+                    try_catch,
+                    isolate_id,
+                    None,
+                    "property assignment was rejected",
+                )),
+                None => Err(caught!(try_catch, isolate_id, "property assignment failed")),
+            }
+        })
     }
 
     fn create_data_property(
@@ -1420,14 +1481,15 @@ impl ExecutionContext<V8Types> for V8Engine {
     ) -> Completion<bool, V8Types> {
         let _current_engine = CurrentEngineGuard::enter(self);
         let isolate_id = self.isolate_id;
-        v8_engine_scope_with_context!(let scope, self, &self.realm.context);
-        v8::tc_scope!(let try_catch, scope);
-        let object = local_object(try_catch, isolate_id, &object)?;
-        let key = local_name(try_catch, isolate_id, &property_key)?;
-        let value = local_value(try_catch, isolate_id, &value)?;
-        object
-            .create_data_property(try_catch, key, value)
-            .ok_or_else(|| caught!(try_catch, isolate_id, "CreateDataProperty failed"))
+        v8_engine_scope_with_context!(scope, self, &self.realm.context, {
+            v8::tc_scope!(let try_catch, scope);
+            let object = local_object(try_catch, isolate_id, &object)?;
+            let key = local_name(try_catch, isolate_id, &property_key)?;
+            let value = local_value(try_catch, isolate_id, &value)?;
+            object
+                .create_data_property(try_catch, key, value)
+                .ok_or_else(|| caught!(try_catch, isolate_id, "CreateDataProperty failed"))
+        })
     }
 
     fn to_property_descriptor(
@@ -1442,7 +1504,14 @@ impl ExecutionContext<V8Types> for V8Engine {
             enumerable: None,
             configurable: None,
         };
-        for property in ["enumerable", "configurable", "value", "writable", "get", "set"] {
+        for property in [
+            "enumerable",
+            "configurable",
+            "value",
+            "writable",
+            "get",
+            "set",
+        ] {
             let key = self.property_key_from_str(property);
             if !self.has_property(descriptor_object.clone(), key.clone())? {
                 continue;
@@ -1457,7 +1526,9 @@ impl ExecutionContext<V8Types> for V8Engine {
                     if !V8Types::value_is_undefined(&value) {
                         let object = V8Types::value_as_object(&value)
                             .and_then(|object| V8Types::object_as_function(&object))
-                            .ok_or_else(|| self.new_type_error("descriptor getter is not callable"))?;
+                            .ok_or_else(|| {
+                                self.new_type_error("descriptor getter is not callable")
+                            })?;
                         descriptor.get = Some(object);
                     }
                 }
@@ -1465,7 +1536,9 @@ impl ExecutionContext<V8Types> for V8Engine {
                     if !V8Types::value_is_undefined(&value) {
                         let object = V8Types::value_as_object(&value)
                             .and_then(|object| V8Types::object_as_function(&object))
-                            .ok_or_else(|| self.new_type_error("descriptor setter is not callable"))?;
+                            .ok_or_else(|| {
+                                self.new_type_error("descriptor setter is not callable")
+                            })?;
                         descriptor.set = Some(object);
                     }
                 }
@@ -1488,48 +1561,53 @@ impl ExecutionContext<V8Types> for V8Engine {
     ) -> Completion<(), V8Types> {
         let _current_engine = CurrentEngineGuard::enter(self);
         let isolate_id = self.isolate_id;
-        v8_engine_scope_with_context!(let scope, self, &self.realm.context);
-        v8::tc_scope!(let try_catch, scope);
-        let object = local_object(try_catch, isolate_id, &object)?;
-        let key = local_name(try_catch, isolate_id, &property_key)?;
+        v8_engine_scope_with_context!(scope, self, &self.realm.context, {
+            v8::tc_scope!(let try_catch, scope);
+            let object = local_object(try_catch, isolate_id, &object)?;
+            let key = local_name(try_catch, isolate_id, &property_key)?;
 
-        let undefined = v8::undefined(try_catch).into();
-        let mut v8_descriptor = if descriptor.get.is_some() || descriptor.set.is_some() {
-            let getter = match &descriptor.get {
-                Some(getter) => local_value(try_catch, isolate_id, &getter.0)?,
-                None => undefined,
+            let undefined = v8::undefined(try_catch).into();
+            let mut v8_descriptor = if descriptor.get.is_some() || descriptor.set.is_some() {
+                let getter = match &descriptor.get {
+                    Some(getter) => local_value(try_catch, isolate_id, &getter.0)?,
+                    None => undefined,
+                };
+                let setter = match &descriptor.set {
+                    Some(setter) => local_value(try_catch, isolate_id, &setter.0)?,
+                    None => undefined,
+                };
+                v8::PropertyDescriptor::new_from_get_set(getter, setter)
+            } else {
+                let value = match &descriptor.value {
+                    Some(value) => local_value(try_catch, isolate_id, value)?,
+                    None => undefined,
+                };
+                v8::PropertyDescriptor::new_from_value_writable(
+                    value,
+                    descriptor.writable.unwrap_or(false),
+                )
             };
-            let setter = match &descriptor.set {
-                Some(setter) => local_value(try_catch, isolate_id, &setter.0)?,
-                None => undefined,
-            };
-            v8::PropertyDescriptor::new_from_get_set(getter, setter)
-        } else {
-            let value = match &descriptor.value {
-                Some(value) => local_value(try_catch, isolate_id, value)?,
-                None => undefined,
-            };
-            v8::PropertyDescriptor::new_from_value_writable(
-                value,
-                descriptor.writable.unwrap_or(false),
-            )
-        };
-        if let Some(enumerable) = descriptor.enumerable {
-            v8_descriptor.set_enumerable(enumerable);
-        }
-        if let Some(configurable) = descriptor.configurable {
-            v8_descriptor.set_configurable(configurable);
-        }
-        match object.define_property(try_catch, key, &v8_descriptor) {
-            Some(true) => Ok(()),
-            Some(false) => Err(caught_exception(
-                try_catch,
-                isolate_id,
-                None,
-                "DefinePropertyOrThrow was rejected",
-            )),
-            None => Err(caught!(try_catch, isolate_id, "DefinePropertyOrThrow failed")),
-        }
+            if let Some(enumerable) = descriptor.enumerable {
+                v8_descriptor.set_enumerable(enumerable);
+            }
+            if let Some(configurable) = descriptor.configurable {
+                v8_descriptor.set_configurable(configurable);
+            }
+            match object.define_property(try_catch, key, &v8_descriptor) {
+                Some(true) => Ok(()),
+                Some(false) => Err(caught_exception(
+                    try_catch,
+                    isolate_id,
+                    None,
+                    "DefinePropertyOrThrow was rejected",
+                )),
+                None => Err(caught!(
+                    try_catch,
+                    isolate_id,
+                    "DefinePropertyOrThrow failed"
+                )),
+            }
+        })
     }
 
     fn delete_property_or_throw(
@@ -1539,33 +1617,36 @@ impl ExecutionContext<V8Types> for V8Engine {
     ) -> Completion<(), V8Types> {
         let _current_engine = CurrentEngineGuard::enter(self);
         let isolate_id = self.isolate_id;
-        v8_engine_scope_with_context!(let scope, self, &self.realm.context);
-        v8::tc_scope!(let try_catch, scope);
-        let object = local_object(try_catch, isolate_id, &object)?;
-        let key = local_property_key(try_catch, isolate_id, &property_key)?;
-        match object.delete(try_catch, key) {
-            Some(true) => Ok(()),
-            Some(false) => Err(caught_exception(
-                try_catch,
-                isolate_id,
-                None,
-                "DeletePropertyOrThrow was rejected",
-            )),
-            None => Err(caught!(try_catch, isolate_id, "DeletePropertyOrThrow failed")),
-        }
+        v8_engine_scope_with_context!(scope, self, &self.realm.context, {
+            v8::tc_scope!(let try_catch, scope);
+            let object = local_object(try_catch, isolate_id, &object)?;
+            let key = local_property_key(try_catch, isolate_id, &property_key)?;
+            match object.delete(try_catch, key) {
+                Some(true) => Ok(()),
+                Some(false) => Err(caught_exception(
+                    try_catch,
+                    isolate_id,
+                    None,
+                    "DeletePropertyOrThrow was rejected",
+                )),
+                None => Err(caught!(
+                    try_catch,
+                    isolate_id,
+                    "DeletePropertyOrThrow failed"
+                )),
+            }
+        })
     }
 
     fn get_prototype_of(&mut self, object: V8Object) -> Completion<Option<V8Object>, V8Types> {
-        let isolate_id = self.isolate_id;
-        v8_engine_scope_with_context!(let scope, self, &self.realm.context);
-        let object = local_object(scope, isolate_id, &object)?;
-        let prototype = object
-            .get_prototype(scope)
-            .ok_or_else(|| caught_exception(scope, isolate_id, None, "GetPrototypeOf failed"))?;
-        if prototype.is_null() {
+        let prototype =
+            self.call_js_helper("object => Object.getPrototypeOf(object)", &[object.0])?;
+        if V8Types::value_is_null(&prototype) {
             Ok(None)
         } else {
-            Ok(Some(V8Object(wrap_local_value(scope, isolate_id, prototype))))
+            V8Types::value_as_object(&prototype)
+                .map(Some)
+                .ok_or_else(|| self.new_type_error("GetPrototypeOf did not return an object"))
         }
     }
 
@@ -1574,16 +1655,13 @@ impl ExecutionContext<V8Types> for V8Engine {
         object: V8Object,
         prototype: Option<V8Object>,
     ) -> Completion<bool, V8Types> {
-        let isolate_id = self.isolate_id;
-        v8_engine_scope_with_context!(let scope, self, &self.realm.context);
-        let object = local_object(scope, isolate_id, &object)?;
-        let prototype = match &prototype {
-            Some(prototype) => local_value(scope, isolate_id, &prototype.0)?,
-            None => v8::null(scope).into(),
-        };
-        object
-            .set_prototype(scope, prototype)
-            .ok_or_else(|| caught_exception(scope, isolate_id, None, "SetPrototypeOf failed"))
+        let prototype = prototype.map_or_else(|| self.value_null(), |prototype| prototype.0);
+        let result = self.call_js_helper(
+            "(object, prototype) => Reflect.setPrototypeOf(object, prototype)",
+            &[object.0, prototype],
+        )?;
+        V8Types::value_as_bool(&result)
+            .ok_or_else(|| self.new_type_error("SetPrototypeOf did not return a boolean"))
     }
 
     fn get_method(
@@ -1608,13 +1686,14 @@ impl ExecutionContext<V8Types> for V8Engine {
     ) -> Completion<bool, V8Types> {
         let _current_engine = CurrentEngineGuard::enter(self);
         let isolate_id = self.isolate_id;
-        v8_engine_scope_with_context!(let scope, self, &self.realm.context);
-        v8::tc_scope!(let try_catch, scope);
-        let object = local_object(try_catch, isolate_id, &object)?;
-        let key = local_property_key(try_catch, isolate_id, &property_key)?;
-        object
-            .has(try_catch, key)
-            .ok_or_else(|| caught!(try_catch, isolate_id, "HasProperty failed"))
+        v8_engine_scope_with_context!(scope, self, &self.realm.context, {
+            v8::tc_scope!(let try_catch, scope);
+            let object = local_object(try_catch, isolate_id, &object)?;
+            let key = local_property_key(try_catch, isolate_id, &property_key)?;
+            object
+                .has(try_catch, key)
+                .ok_or_else(|| caught!(try_catch, isolate_id, "HasProperty failed"))
+        })
     }
 
     fn has_own_property(
@@ -1624,20 +1703,22 @@ impl ExecutionContext<V8Types> for V8Engine {
     ) -> Completion<bool, V8Types> {
         let _current_engine = CurrentEngineGuard::enter(self);
         let isolate_id = self.isolate_id;
-        v8_engine_scope_with_context!(let scope, self, &self.realm.context);
-        v8::tc_scope!(let try_catch, scope);
-        let object = local_object(try_catch, isolate_id, &object)?;
-        let key = local_name(try_catch, isolate_id, &property_key)?;
-        object
-            .has_own_property(try_catch, key)
-            .ok_or_else(|| caught!(try_catch, isolate_id, "HasOwnProperty failed"))
+        v8_engine_scope_with_context!(scope, self, &self.realm.context, {
+            v8::tc_scope!(let try_catch, scope);
+            let object = local_object(try_catch, isolate_id, &object)?;
+            let key = local_name(try_catch, isolate_id, &property_key)?;
+            object
+                .has_own_property(try_catch, key)
+                .ok_or_else(|| caught!(try_catch, isolate_id, "HasOwnProperty failed"))
+        })
     }
 
     fn own_property_keys(&mut self, object: V8Object) -> Completion<Vec<V8PropertyKey>, V8Types> {
         let array = self.call_js_helper("object => Reflect.ownKeys(object)", &[object.0])?;
         let array = V8Types::value_as_object(&array)
             .ok_or_else(|| self.new_type_error("Reflect.ownKeys did not return an array"))?;
-        let length_value = ExecutionContext::get(self, array.clone(), self.property_key_from_str("length"))?;
+        let length_value =
+            ExecutionContext::get(self, array.clone(), self.property_key_from_str("length"))?;
         let length = V8Types::value_as_number(&length_value).unwrap_or(0.0) as u32;
         let mut keys = Vec::with_capacity(length as usize);
         for index in 0..length {
@@ -1655,33 +1736,29 @@ impl ExecutionContext<V8Types> for V8Engine {
         let descriptor = {
             let _current_engine = CurrentEngineGuard::enter(self);
             let isolate_id = self.isolate_id;
-        v8_engine_scope_with_context!(let scope, self, &self.realm.context);
-            v8::tc_scope!(let try_catch, scope);
-            let object = local_object(try_catch, isolate_id, &object)?;
-            let key = local_name(try_catch, isolate_id, &property_key)?;
-            let Some(descriptor) = object.get_own_property_descriptor(try_catch, key) else {
-                if let Some(exception) = try_catch.exception() {
-                    return Err(caught_exception(
-                        try_catch,
-                        isolate_id,
-                        Some(exception),
-                        "GetOwnProperty failed",
-                    ));
+            v8_engine_scope_with_context!(scope, self, &self.realm.context, {
+                v8::tc_scope!(let try_catch, scope);
+                let object = local_object(try_catch, isolate_id, &object)?;
+                let key = local_name(try_catch, isolate_id, &property_key)?;
+                let Some(descriptor) = object.get_own_property_descriptor(try_catch, key) else {
+                    if let Some(exception) = try_catch.exception() {
+                        return Err(caught_exception(
+                            try_catch,
+                            isolate_id,
+                            Some(exception),
+                            "GetOwnProperty failed",
+                        ));
+                    }
+                    return Ok(None);
+                };
+                if descriptor.is_undefined() {
+                    return Ok(None);
                 }
-                return Ok(None);
-            };
-            if descriptor.is_undefined() {
-                return Ok(None);
-            }
-            V8Types::value_as_object(&wrap_local_value(try_catch, isolate_id, descriptor))
-                .ok_or_else(|| {
-                    caught_exception(
-                        try_catch,
-                        isolate_id,
-                        None,
-                        "invalid property descriptor",
-                    )
-                })?
+                V8Types::value_as_object(&wrap_local_value(try_catch, isolate_id, descriptor))
+                    .ok_or_else(|| {
+                        caught_exception(try_catch, isolate_id, None, "invalid property descriptor")
+                    })
+            })?
         };
         self.to_property_descriptor(descriptor).map(Some)
     }
@@ -1692,9 +1769,9 @@ impl ExecutionContext<V8Types> for V8Engine {
         arguments: &[V8Value],
         new_target: Option<V8Object>,
     ) -> Completion<V8Object, V8Types> {
-        if new_target.is_some() {
+        if let Some(new_target) = new_target {
             let mut helper_arguments = vec![function.0];
-            helper_arguments.push(new_target.expect("new target checked above").0);
+            helper_arguments.push(new_target.0);
             helper_arguments.extend_from_slice(arguments);
             let result = self.call_js_helper(
                 "(constructor, newTarget, ...args) => Reflect.construct(constructor, args, newTarget)",
@@ -1720,25 +1797,27 @@ impl ExecutionContext<V8Types> for V8Engine {
         });
         let _current_engine = CurrentEngineGuard::enter(self);
         let isolate_id = self.isolate_id;
-        v8_engine_scope_with_context!(let scope, self, &self.realm.context);
-        v8::tc_scope!(let try_catch, scope);
-        let function = local_value(try_catch, isolate_id, &function.0)?;
-        let function = v8::Local::<v8::Function>::try_from(function)
-            .map_err(|_| caught_exception(try_catch, isolate_id, None, "value is not a constructor"))?;
-        let local_arguments: Result<Vec<_>, _> = arguments
-            .iter()
-            .map(|argument| local_value(try_catch, isolate_id, argument))
-            .collect();
-        let Some(object) = function.new_instance(try_catch, &local_arguments?) else {
-            return Err(caught!(try_catch, isolate_id, "constructor call failed"));
-        };
-        let mut object = V8Object(wrap_local_value(try_catch, isolate_id, object.into()));
-        if let Some(wrapper_primitive) = wrapper_primitive {
-            if let Some(profile) = object.0.object_profile.as_mut() {
+        v8_engine_scope_with_context!(scope, self, &self.realm.context, {
+            v8::tc_scope!(let try_catch, scope);
+            let function = local_value(try_catch, isolate_id, &function.0)?;
+            let function = v8::Local::<v8::Function>::try_from(function).map_err(|_| {
+                caught_exception(try_catch, isolate_id, None, "value is not a constructor")
+            })?;
+            let local_arguments: Result<Vec<_>, _> = arguments
+                .iter()
+                .map(|argument| local_value(try_catch, isolate_id, argument))
+                .collect();
+            let Some(object) = function.new_instance(try_catch, &local_arguments?) else {
+                return Err(caught!(try_catch, isolate_id, "constructor call failed"));
+            };
+            let mut object = V8Object(wrap_local_value(try_catch, isolate_id, object.into()));
+            if let Some(wrapper_primitive) = wrapper_primitive
+                && let Some(profile) = object.0.object_profile.as_mut()
+            {
                 profile.wrapper_primitive = Some(wrapper_primitive);
             }
-        }
-        Ok(object)
+            Ok(object)
+        })
     }
 
     fn set_integrity_level(
@@ -1746,16 +1825,19 @@ impl ExecutionContext<V8Types> for V8Engine {
         object: V8Object,
         level: IntegrityLevel,
     ) -> Completion<bool, V8Types> {
+        let _current_engine = CurrentEngineGuard::enter(self);
         let isolate_id = self.isolate_id;
-        v8_engine_scope_with_context!(let scope, self, &self.realm.context);
-        let object = local_object(scope, isolate_id, &object)?;
-        let level = match level {
-            IntegrityLevel::Sealed => v8::IntegrityLevel::Sealed,
-            IntegrityLevel::Frozen => v8::IntegrityLevel::Frozen,
-        };
-        object
-            .set_integrity_level(scope, level)
-            .ok_or_else(|| caught_exception(scope, isolate_id, None, "SetIntegrityLevel failed"))
+        v8_engine_scope_with_context!(scope, self, &self.realm.context, {
+            v8::tc_scope!(let try_catch, scope);
+            let object = local_object(try_catch, isolate_id, &object)?;
+            let level = match level {
+                IntegrityLevel::Sealed => v8::IntegrityLevel::Sealed,
+                IntegrityLevel::Frozen => v8::IntegrityLevel::Frozen,
+            };
+            object
+                .set_integrity_level(try_catch, level)
+                .ok_or_else(|| caught!(try_catch, isolate_id, "SetIntegrityLevel failed"))
+        })
     }
 
     fn test_integrity_level(
@@ -1786,10 +1868,19 @@ impl ExecutionContext<V8Types> for V8Engine {
 
     fn get_function_realm(&mut self, function: &V8Object) -> Completion<V8Realm, V8Types> {
         if function.0.isolate_id != self.isolate_id {
-            Err(self.new_type_error("function belongs to a different V8 isolate"))
-        } else {
-            Ok(self.realm.clone())
+            return Err(self.new_type_error("function belongs to a different V8 isolate"));
         }
+        let isolate_id = self.isolate_id;
+        v8_engine_scope_with_context!(scope, self, &self.realm.context, {
+            let function = local_object(scope, isolate_id, function)?;
+            let context = function.get_creation_context(scope).ok_or_else(|| {
+                caught_exception(scope, isolate_id, None, "function has no creation context")
+            })?;
+            Ok(V8Realm {
+                isolate_id,
+                context: v8::Global::new(scope, context),
+            })
+        })
     }
 
     fn get_iterator(
@@ -1814,10 +1905,7 @@ impl ExecutionContext<V8Types> for V8Engine {
         let iterator = V8Types::value_as_object(&iterator_value)
             .ok_or_else(|| self.new_type_error("iterator method did not return an object"))?;
         let next = self
-            .get_method(
-                iterator_value,
-                self.property_key_from_str("next"),
-            )?
+            .get_method(iterator_value, self.property_key_from_str("next"))?
             .ok_or_else(|| self.new_type_error("iterator has no next method"))?;
         Ok(IteratorRecord {
             iterator,
@@ -1852,10 +1940,9 @@ impl ExecutionContext<V8Types> for V8Engine {
         completion: Completion<V8Value, V8Types>,
     ) -> Completion<V8Value, V8Types> {
         let iterator_value = iterator.iterator.0.clone();
-        if let Some(return_method) = self.get_method(
-            iterator_value.clone(),
-            self.property_key_from_str("return"),
-        )? {
+        if let Some(return_method) =
+            self.get_method(iterator_value.clone(), self.property_key_from_str("return"))?
+        {
             let close_result = EcmascriptHost::call(self, &return_method, &iterator_value, &[])?;
             if V8Types::value_as_object(&close_result).is_none() {
                 return Err(self.new_type_error("iterator return method did not return an object"));
@@ -1881,7 +1968,10 @@ impl ExecutionContext<V8Types> for V8Engine {
     }
 
     fn realm_intrinsics(&self, realm: &V8Realm) -> RealmIntrinsics<V8Types> {
-        assert_eq!(realm.isolate_id, self.isolate_id, "realm belongs to a different V8 isolate");
+        assert_eq!(
+            realm.isolate_id, self.isolate_id,
+            "realm belongs to a different V8 isolate"
+        );
         self.intrinsics
             .as_ref()
             .expect("V8 intrinsics are not initialized")
@@ -1943,9 +2033,14 @@ impl ExecutionContext<V8Types> for V8Engine {
         let isolate_id = self.isolate_id;
         let byte_length = usize::try_from(byte_length)
             .map_err(|_| self.new_range_error("ArrayBuffer length is too large"))?;
-        v8_engine_scope_with_context!(let scope, self, &self.realm.context);
-        let array_buffer = v8::ArrayBuffer::new(scope, byte_length);
-        Ok(V8Object(wrap_local_value(scope, isolate_id, array_buffer.into())))
+        v8_engine_scope_with_context!(scope, self, &self.realm.context, {
+            let array_buffer = v8::ArrayBuffer::new(scope, byte_length);
+            Ok(V8Object(wrap_local_value(
+                scope,
+                isolate_id,
+                array_buffer.into(),
+            )))
+        })
     }
 
     fn clone_array_buffer(
@@ -1966,12 +2061,8 @@ impl ExecutionContext<V8Types> for V8Engine {
             .checked_add(length)
             .filter(|end| *end <= bytes.len())
             .ok_or_else(|| self.new_range_error("ArrayBuffer clone range is out of bounds"))?;
-        let clone = ExecutionContext::allocate_array_buffer(
-            self,
-            constructor,
-            source_length,
-            None,
-        )?;
+        let clone =
+            ExecutionContext::allocate_array_buffer(self, constructor, source_length, None)?;
         let state = clone
             .0
             .object_profile
@@ -1990,33 +2081,35 @@ impl ExecutionContext<V8Types> for V8Engine {
         key: Option<V8Value>,
     ) -> Completion<(), V8Types> {
         let isolate_id = self.isolate_id;
-        v8_engine_scope_with_context!(let scope, self, &self.realm.context);
-        let value = local_value(scope, isolate_id, &array_buffer.0)?;
-        let local = v8::Local::<v8::ArrayBuffer>::try_from(value)
-            .map_err(|_| caught_exception(scope, isolate_id, None, "value is not an ArrayBuffer"))?;
-        let key = key
-            .as_ref()
-            .map(|key| local_value(scope, isolate_id, key))
-            .transpose()?;
-        match local.detach(key) {
-            Some(true) => {
-                if let Some(state) = array_buffer
-                    .0
-                    .object_profile
-                    .as_ref()
-                    .and_then(|profile| profile.array_buffer_state.as_ref())
-                {
-                    state.detached.set(true);
+        v8_engine_scope_with_context!(scope, self, &self.realm.context, {
+            let value = local_value(scope, isolate_id, &array_buffer.0)?;
+            let local = v8::Local::<v8::ArrayBuffer>::try_from(value).map_err(|_| {
+                caught_exception(scope, isolate_id, None, "value is not an ArrayBuffer")
+            })?;
+            let key = key
+                .as_ref()
+                .map(|key| local_value(scope, isolate_id, key))
+                .transpose()?;
+            match local.detach(key) {
+                Some(true) => {
+                    if let Some(state) = array_buffer
+                        .0
+                        .object_profile
+                        .as_ref()
+                        .and_then(|profile| profile.array_buffer_state.as_ref())
+                    {
+                        state.detached.set(true);
+                    }
+                    Ok(())
                 }
-                Ok(())
+                Some(false) | None => Err(caught_exception(
+                    scope,
+                    isolate_id,
+                    None,
+                    "ArrayBuffer detach key did not match",
+                )),
             }
-            Some(false) | None => Err(caught_exception(
-                scope,
-                isolate_id,
-                None,
-                "ArrayBuffer detach key did not match",
-            )),
-        }
+        })
     }
 
     fn get_value_from_buffer(
@@ -2074,25 +2167,34 @@ impl ExecutionContext<V8Types> for V8Engine {
         };
         let byte_index = self.value_from_number(byte_index as f64);
         self.call_js_helper(
-            &format!("(buffer, offset, value) => {{ new {constructor}(buffer, offset, 1)[0] = value; }}"),
+            &format!(
+                "(buffer, offset, value) => {{ new {constructor}(buffer, offset, 1)[0] = value; }}"
+            ),
             &[array_buffer.0.clone(), byte_index, value],
         )?;
         Ok(())
     }
 
     fn typed_array_buffer(&mut self, typed_array: &V8Object) -> Completion<V8Object, V8Types> {
-        let value = self.call_js_helper("view => view.buffer", &[typed_array.0.clone()])?;
+        let value =
+            self.call_js_helper("view => view.buffer", std::slice::from_ref(&typed_array.0))?;
         V8Types::value_as_object(&value)
             .ok_or_else(|| self.new_type_error("typed array has no ArrayBuffer"))
     }
 
     fn typed_array_byte_offset(&mut self, typed_array: &V8Object) -> Completion<u64, V8Types> {
-        let value = self.call_js_helper("view => view.byteOffset", &[typed_array.0.clone()])?;
+        let value = self.call_js_helper(
+            "view => view.byteOffset",
+            std::slice::from_ref(&typed_array.0),
+        )?;
         Ok(V8Types::value_as_number(&value).unwrap_or(0.0) as u64)
     }
 
     fn typed_array_byte_length(&mut self, typed_array: &V8Object) -> Completion<u64, V8Types> {
-        let value = self.call_js_helper("view => view.byteLength", &[typed_array.0.clone()])?;
+        let value = self.call_js_helper(
+            "view => view.byteLength",
+            std::slice::from_ref(&typed_array.0),
+        )?;
         Ok(V8Types::value_as_number(&value).unwrap_or(0.0) as u64)
     }
 
@@ -2128,54 +2230,87 @@ impl ExecutionContext<V8Types> for V8Engine {
             | TypedArrayElementType::BigInt64
             | TypedArrayElementType::BigUint64 => 8,
         };
-        if byte_length % element_size != 0 {
+        if !byte_length.is_multiple_of(element_size) {
             return Err(self.new_range_error("typed array byte length is not element-aligned"));
         }
         let length = usize::try_from(byte_length / element_size)
             .map_err(|_| self.new_range_error("typed array length is too large"))?;
-        v8_engine_scope_with_context!(let scope, self, &self.realm.context);
-        let buffer_value = local_value(scope, isolate_id, &buffer.0)?;
-        let buffer = v8::Local::<v8::ArrayBuffer>::try_from(buffer_value)
-            .map_err(|_| caught_exception(scope, isolate_id, None, "value is not an ArrayBuffer"))?;
-        if element_type == TypedArrayElementType::Float16 {
-            return Err(caught_exception(
-                scope,
-                isolate_id,
-                None,
-                "Float16Array is not exposed by this rusty_v8 build",
-            ));
-        }
-        let view: Option<v8::Local<v8::Value>> = match element_type {
-            TypedArrayElementType::Int8 => v8::Int8Array::new(scope, buffer, byte_offset, length).map(Into::into),
-            TypedArrayElementType::Uint8 => v8::Uint8Array::new(scope, buffer, byte_offset, length).map(Into::into),
-            TypedArrayElementType::Uint8Clamped => v8::Uint8ClampedArray::new(scope, buffer, byte_offset, length).map(Into::into),
-            TypedArrayElementType::Int16 => v8::Int16Array::new(scope, buffer, byte_offset, length).map(Into::into),
-            TypedArrayElementType::Uint16 => v8::Uint16Array::new(scope, buffer, byte_offset, length).map(Into::into),
-            TypedArrayElementType::Int32 => v8::Int32Array::new(scope, buffer, byte_offset, length).map(Into::into),
-            TypedArrayElementType::Uint32 => v8::Uint32Array::new(scope, buffer, byte_offset, length).map(Into::into),
-            TypedArrayElementType::Float16 => unreachable!(),
-            TypedArrayElementType::Float32 => v8::Float32Array::new(scope, buffer, byte_offset, length).map(Into::into),
-            TypedArrayElementType::Float64 => v8::Float64Array::new(scope, buffer, byte_offset, length).map(Into::into),
-            TypedArrayElementType::BigInt64 => v8::BigInt64Array::new(scope, buffer, byte_offset, length).map(Into::into),
-            TypedArrayElementType::BigUint64 => v8::BigUint64Array::new(scope, buffer, byte_offset, length).map(Into::into),
-        };
-        let view = view.ok_or_else(|| caught_exception(scope, isolate_id, None, "typed array construction failed"))?;
-        Ok(V8Object(wrap_local_value(scope, isolate_id, view)))
+        v8_engine_scope_with_context!(scope, self, &self.realm.context, {
+            let buffer_value = local_value(scope, isolate_id, &buffer.0)?;
+            let buffer = v8::Local::<v8::ArrayBuffer>::try_from(buffer_value).map_err(|_| {
+                caught_exception(scope, isolate_id, None, "value is not an ArrayBuffer")
+            })?;
+            if element_type == TypedArrayElementType::Float16 {
+                return Err(caught_exception(
+                    scope,
+                    isolate_id,
+                    None,
+                    "Float16Array is not exposed by this rusty_v8 build",
+                ));
+            }
+            let view: Option<v8::Local<v8::Value>> = match element_type {
+                TypedArrayElementType::Int8 => {
+                    v8::Int8Array::new(scope, buffer, byte_offset, length).map(Into::into)
+                }
+                TypedArrayElementType::Uint8 => {
+                    v8::Uint8Array::new(scope, buffer, byte_offset, length).map(Into::into)
+                }
+                TypedArrayElementType::Uint8Clamped => {
+                    v8::Uint8ClampedArray::new(scope, buffer, byte_offset, length).map(Into::into)
+                }
+                TypedArrayElementType::Int16 => {
+                    v8::Int16Array::new(scope, buffer, byte_offset, length).map(Into::into)
+                }
+                TypedArrayElementType::Uint16 => {
+                    v8::Uint16Array::new(scope, buffer, byte_offset, length).map(Into::into)
+                }
+                TypedArrayElementType::Int32 => {
+                    v8::Int32Array::new(scope, buffer, byte_offset, length).map(Into::into)
+                }
+                TypedArrayElementType::Uint32 => {
+                    v8::Uint32Array::new(scope, buffer, byte_offset, length).map(Into::into)
+                }
+                TypedArrayElementType::Float16 => unreachable!(),
+                TypedArrayElementType::Float32 => {
+                    v8::Float32Array::new(scope, buffer, byte_offset, length).map(Into::into)
+                }
+                TypedArrayElementType::Float64 => {
+                    v8::Float64Array::new(scope, buffer, byte_offset, length).map(Into::into)
+                }
+                TypedArrayElementType::BigInt64 => {
+                    v8::BigInt64Array::new(scope, buffer, byte_offset, length).map(Into::into)
+                }
+                TypedArrayElementType::BigUint64 => {
+                    v8::BigUint64Array::new(scope, buffer, byte_offset, length).map(Into::into)
+                }
+            };
+            let view = view.ok_or_else(|| {
+                caught_exception(scope, isolate_id, None, "typed array construction failed")
+            })?;
+            Ok(V8Object(wrap_local_value(scope, isolate_id, view)))
+        })
     }
 
     fn data_view_buffer(&mut self, data_view: &V8Object) -> Completion<V8Object, V8Types> {
-        let value = self.call_js_helper("view => view.buffer", &[data_view.0.clone()])?;
+        let value =
+            self.call_js_helper("view => view.buffer", std::slice::from_ref(&data_view.0))?;
         V8Types::value_as_object(&value)
             .ok_or_else(|| self.new_type_error("DataView has no ArrayBuffer"))
     }
 
     fn data_view_byte_offset(&mut self, data_view: &V8Object) -> Completion<u64, V8Types> {
-        let value = self.call_js_helper("view => view.byteOffset", &[data_view.0.clone()])?;
+        let value = self.call_js_helper(
+            "view => view.byteOffset",
+            std::slice::from_ref(&data_view.0),
+        )?;
         Ok(V8Types::value_as_number(&value).unwrap_or(0.0) as u64)
     }
 
     fn data_view_byte_length(&mut self, data_view: &V8Object) -> Completion<u64, V8Types> {
-        let value = self.call_js_helper("view => view.byteLength", &[data_view.0.clone()])?;
+        let value = self.call_js_helper(
+            "view => view.byteLength",
+            std::slice::from_ref(&data_view.0),
+        )?;
         Ok(V8Types::value_as_number(&value).unwrap_or(0.0) as u64)
     }
 
@@ -2190,12 +2325,18 @@ impl ExecutionContext<V8Types> for V8Engine {
             .map_err(|_| self.new_range_error("DataView byte offset is too large"))?;
         let byte_length = usize::try_from(byte_length)
             .map_err(|_| self.new_range_error("DataView byte length is too large"))?;
-        v8_engine_scope_with_context!(let scope, self, &self.realm.context);
-        let buffer = local_value(scope, isolate_id, &buffer.0)?;
-        let buffer = v8::Local::<v8::ArrayBuffer>::try_from(buffer)
-            .map_err(|_| caught_exception(scope, isolate_id, None, "value is not an ArrayBuffer"))?;
-        let data_view = v8::DataView::new(scope, buffer, byte_offset, byte_length);
-        Ok(V8Object(wrap_local_value(scope, isolate_id, data_view.into())))
+        v8_engine_scope_with_context!(scope, self, &self.realm.context, {
+            let buffer = local_value(scope, isolate_id, &buffer.0)?;
+            let buffer = v8::Local::<v8::ArrayBuffer>::try_from(buffer).map_err(|_| {
+                caught_exception(scope, isolate_id, None, "value is not an ArrayBuffer")
+            })?;
+            let data_view = v8::DataView::new(scope, buffer, byte_offset, byte_length);
+            Ok(V8Object(wrap_local_value(
+                scope,
+                isolate_id,
+                data_view.into(),
+            )))
+        })
     }
 
     fn array_buffer_data(&self, array_buffer: &V8Object) -> Option<Vec<u8>> {
@@ -2212,31 +2353,41 @@ impl ExecutionContext<V8Types> for V8Engine {
     }
 
     fn get_date_value(&mut self, date: &V8Object) -> Completion<f64, V8Types> {
-        let value = self.call_js_helper("date => Date.prototype.getTime.call(date)", &[date.0.clone()])?;
+        let value = self.call_js_helper(
+            "date => Date.prototype.getTime.call(date)",
+            std::slice::from_ref(&date.0),
+        )?;
         V8Types::value_as_number(&value)
             .ok_or_else(|| self.new_type_error("Date value is not a number"))
     }
 
     fn get_regexp_source(&mut self, regexp: &V8Object) -> Completion<String, V8Types> {
-        let value = self.call_js_helper("regexp => regexp.source", &[regexp.0.clone()])?;
+        let value =
+            self.call_js_helper("regexp => regexp.source", std::slice::from_ref(&regexp.0))?;
         self.to_rust_string(value)
     }
 
     fn get_regexp_flags(&mut self, regexp: &V8Object) -> Completion<String, V8Types> {
-        let value = self.call_js_helper("regexp => regexp.flags", &[regexp.0.clone()])?;
+        let value =
+            self.call_js_helper("regexp => regexp.flags", std::slice::from_ref(&regexp.0))?;
         self.to_rust_string(value)
     }
 
     fn map_get_entries(&mut self, map: &V8Object) -> Completion<Vec<(V8Value, V8Value)>, V8Types> {
-        let entries = self.call_js_helper("map => Array.from(map.entries()).flat()", &[map.0.clone()])?;
+        let entries = self.call_js_helper(
+            "map => Array.from(map.entries()).flat()",
+            std::slice::from_ref(&map.0),
+        )?;
         let entries = V8Types::value_as_object(&entries)
             .ok_or_else(|| self.new_type_error("Map entries did not produce an array"))?;
-        let length = ExecutionContext::get(self, entries.clone(), self.property_key_from_str("length"))?;
+        let length =
+            ExecutionContext::get(self, entries.clone(), self.property_key_from_str("length"))?;
         let length = V8Types::value_as_number(&length).unwrap_or(0.0) as u32;
         let mut result = Vec::with_capacity((length / 2) as usize);
         for index in (0..length).step_by(2) {
             let key = ExecutionContext::get(self, entries.clone(), V8PropertyKey::Index(index))?;
-            let value = ExecutionContext::get(self, entries.clone(), V8PropertyKey::Index(index + 1))?;
+            let value =
+                ExecutionContext::get(self, entries.clone(), V8PropertyKey::Index(index + 1))?;
             result.push((key, value));
         }
         Ok(result)
@@ -2248,25 +2399,39 @@ impl ExecutionContext<V8Types> for V8Engine {
         key: V8Value,
         value: V8Value,
     ) -> Completion<(), V8Types> {
-        self.call_js_helper("(map, key, value) => { map.set(key, value); }", &[map.0.clone(), key, value])?;
+        self.call_js_helper(
+            "(map, key, value) => { map.set(key, value); }",
+            &[map.0.clone(), key, value],
+        )?;
         Ok(())
     }
 
     fn set_get_values(&mut self, set: &V8Object) -> Completion<Vec<V8Value>, V8Types> {
-        let values = self.call_js_helper("set => Array.from(set.values())", &[set.0.clone()])?;
+        let values = self.call_js_helper(
+            "set => Array.from(set.values())",
+            std::slice::from_ref(&set.0),
+        )?;
         let values = V8Types::value_as_object(&values)
             .ok_or_else(|| self.new_type_error("Set values did not produce an array"))?;
-        let length = ExecutionContext::get(self, values.clone(), self.property_key_from_str("length"))?;
+        let length =
+            ExecutionContext::get(self, values.clone(), self.property_key_from_str("length"))?;
         let length = V8Types::value_as_number(&length).unwrap_or(0.0) as u32;
         let mut result = Vec::with_capacity(length as usize);
         for index in 0..length {
-            result.push(ExecutionContext::get(self, values.clone(), V8PropertyKey::Index(index))?);
+            result.push(ExecutionContext::get(
+                self,
+                values.clone(),
+                V8PropertyKey::Index(index),
+            )?);
         }
         Ok(result)
     }
 
     fn set_add_entry(&mut self, set: &V8Object, value: V8Value) -> Completion<(), V8Types> {
-        self.call_js_helper("(set, value) => { set.add(value); }", &[set.0.clone(), value])?;
+        self.call_js_helper(
+            "(set, value) => { set.add(value); }",
+            &[set.0.clone(), value],
+        )?;
         Ok(())
     }
 
@@ -2350,25 +2515,26 @@ impl ExecutionContext<V8Types> for V8Engine {
 
     fn promise_state(&mut self, promise: &V8Object) -> Completion<PromiseState<V8Types>, V8Types> {
         let isolate_id = self.isolate_id;
-        v8_engine_scope_with_context!(let scope, self, &self.realm.context);
-        let promise_value = local_value(scope, isolate_id, &promise.0)?;
-        let promise = v8::Local::<v8::Promise>::try_from(promise_value)
-            .map_err(|_| caught_exception(scope, isolate_id, None, "value is not a Promise"))?;
-        match promise.state() {
-            v8::PromiseState::Pending => Ok(PromiseState::Pending),
-            v8::PromiseState::Fulfilled => {
-                let result = promise.result(scope);
-                Ok(PromiseState::Fulfilled(wrap_local_value(
-                    scope, isolate_id, result,
-                )))
+        v8_engine_scope_with_context!(scope, self, &self.realm.context, {
+            let promise_value = local_value(scope, isolate_id, &promise.0)?;
+            let promise = v8::Local::<v8::Promise>::try_from(promise_value)
+                .map_err(|_| caught_exception(scope, isolate_id, None, "value is not a Promise"))?;
+            match promise.state() {
+                v8::PromiseState::Pending => Ok(PromiseState::Pending),
+                v8::PromiseState::Fulfilled => {
+                    let result = promise.result(scope);
+                    Ok(PromiseState::Fulfilled(wrap_local_value(
+                        scope, isolate_id, result,
+                    )))
+                }
+                v8::PromiseState::Rejected => {
+                    let result = promise.result(scope);
+                    Ok(PromiseState::Rejected(wrap_local_value(
+                        scope, isolate_id, result,
+                    )))
+                }
             }
-            v8::PromiseState::Rejected => {
-                let result = promise.result(scope);
-                Ok(PromiseState::Rejected(wrap_local_value(
-                    scope, isolate_id, result,
-                )))
-            }
-        }
+        })
     }
 
     fn generator_start(
@@ -2397,11 +2563,12 @@ impl ExecutionContext<V8Types> for V8Engine {
 
     fn value_from_property_key(&mut self, key: V8PropertyKey) -> V8Value {
         let isolate_id = self.isolate_id;
-        v8_engine_scope_with_context!(let scope, self, &self.realm.context);
-        match local_property_key(scope, isolate_id, &key) {
-            Ok(value) => wrap_local_value(scope, isolate_id, value),
-            Err(error) => error,
-        }
+        v8_engine_scope_with_context!(scope, self, &self.realm.context, {
+            match local_property_key(scope, isolate_id, &key) {
+                Ok(value) => wrap_local_value(scope, isolate_id, value),
+                Err(error) => error,
+            }
+        })
     }
 
     fn property_key_from_well_known_symbol(&mut self, name: &str) -> V8PropertyKey {
@@ -2443,47 +2610,44 @@ impl ExecutionContext<V8Types> for V8Engine {
         data: Box<dyn Any + 'static>,
     ) -> V8Object {
         let isolate_id = self.isolate_id;
-        v8_engine_scope_with_context!(let scope, self, &self.realm.context);
-        let object_template = v8::ObjectTemplate::new(scope);
-        object_template.set_internal_field_count(2);
-        let object = object_template
-            .new_instance(scope)
-            .expect("V8 failed to create a platform object");
-        let prototype = local_value(scope, isolate_id, &prototype.0)
-            .expect("platform-object prototype belongs to another isolate");
-        object
-            .set_prototype(scope, prototype)
-            .expect("V8 failed to set a platform-object prototype");
+        v8_engine_scope_with_context!(scope, self, &self.realm.context, {
+            let object_template = v8::ObjectTemplate::new(scope);
+            object_template.set_internal_field_count(2);
+            let object = object_template
+                .new_instance(scope)
+                .expect("V8 failed to create a platform object");
+            let prototype = local_value(scope, isolate_id, &prototype.0)
+                .expect("platform-object prototype belongs to another isolate");
+            object
+                .set_prototype(scope, prototype)
+                .expect("V8 failed to set a platform-object prototype");
 
-        let record = Box::new(HostObjectRecord { data });
-        let record_pointer = Box::into_raw(record);
-        let marker = v8::External::new(
-            scope,
-            std::ptr::addr_of!(HOST_OBJECT_MARKER).cast_mut().cast(),
-        );
-        assert!(object.set_internal_field(0, marker.into()));
-        object.set_aligned_pointer_in_internal_field(
-            1,
-            record_pointer.cast(),
-            HOST_OBJECT_TAG,
-        );
+            let record = Box::new(HostObjectRecord { data });
+            let record_pointer = Box::into_raw(record);
+            let marker = v8::External::new(
+                scope,
+                std::ptr::addr_of!(HOST_OBJECT_MARKER).cast_mut().cast(),
+            );
+            assert!(object.set_internal_field(0, marker.into()));
+            object.set_aligned_pointer_in_internal_field(1, record_pointer.cast(), HOST_OBJECT_TAG);
 
-        let value = V8Object(wrap_local_value(scope, isolate_id, object.into()));
-        let weak = v8::Weak::with_guaranteed_finalizer(
-            scope,
-            object,
-            Box::new(move || {
-                // SAFETY: `record_pointer` is created by the single
-                // Box::into_raw above. This guaranteed finalizer is its sole
-                // owner and V8 invokes it at most once after the JS object can
-                // no longer expose its internal field.
-                unsafe {
-                    drop(Box::from_raw(record_pointer));
-                }
-            }),
-        );
-        self.host_object_handles.push(weak);
-        value
+            let value = V8Object(wrap_local_value(scope, isolate_id, object.into()));
+            let weak = v8::Weak::with_guaranteed_finalizer(
+                scope,
+                object,
+                Box::new(move || {
+                    // SAFETY: `record_pointer` is created by the single
+                    // Box::into_raw above. This guaranteed finalizer is its sole
+                    // owner and V8 invokes it at most once after the JS object can
+                    // no longer expose its internal field.
+                    unsafe {
+                        drop(Box::from_raw(record_pointer));
+                    }
+                }),
+            );
+            self.host_object_handles.push(weak);
+            value
+        })
     }
 
     fn with_object_any(&self, object: &V8Object) -> Option<&dyn Any> {
@@ -2545,26 +2709,32 @@ impl ExecutionContext<V8Types> for V8Engine {
 
     fn new_type_error(&mut self, message: &str) -> V8Value {
         let isolate_id = self.isolate_id;
-        v8_engine_scope_with_context!(let scope, self, &self.realm.context);
-        let message = v8::String::new(scope, message).expect("V8 TypeError message allocation failed");
-        let exception = v8::Exception::type_error(scope, message);
-        wrap_local_value(scope, isolate_id, exception)
+        v8_engine_scope_with_context!(scope, self, &self.realm.context, {
+            let message =
+                v8::String::new(scope, message).expect("V8 TypeError message allocation failed");
+            let exception = v8::Exception::type_error(scope, message);
+            wrap_local_value(scope, isolate_id, exception)
+        })
     }
 
     fn new_range_error(&mut self, message: &str) -> V8Value {
         let isolate_id = self.isolate_id;
-        v8_engine_scope_with_context!(let scope, self, &self.realm.context);
-        let message = v8::String::new(scope, message).expect("V8 RangeError message allocation failed");
-        let exception = v8::Exception::range_error(scope, message);
-        wrap_local_value(scope, isolate_id, exception)
+        v8_engine_scope_with_context!(scope, self, &self.realm.context, {
+            let message =
+                v8::String::new(scope, message).expect("V8 RangeError message allocation failed");
+            let exception = v8::Exception::range_error(scope, message);
+            wrap_local_value(scope, isolate_id, exception)
+        })
     }
 
     fn new_syntax_error(&mut self, message: &str) -> V8Value {
         let isolate_id = self.isolate_id;
-        v8_engine_scope_with_context!(let scope, self, &self.realm.context);
-        let message = v8::String::new(scope, message).expect("V8 SyntaxError message allocation failed");
-        let exception = v8::Exception::syntax_error(scope, message);
-        wrap_local_value(scope, isolate_id, exception)
+        v8_engine_scope_with_context!(scope, self, &self.realm.context, {
+            let message =
+                v8::String::new(scope, message).expect("V8 SyntaxError message allocation failed");
+            let exception = v8::Exception::syntax_error(scope, message);
+            wrap_local_value(scope, isolate_id, exception)
+        })
     }
 
     fn create_proxy(
@@ -2573,12 +2743,14 @@ impl ExecutionContext<V8Types> for V8Engine {
         handler: V8Object,
     ) -> Completion<V8Object, V8Types> {
         let isolate_id = self.isolate_id;
-        v8_engine_scope_with_context!(let scope, self, &self.realm.context);
-        let target = local_object(scope, isolate_id, &target)?;
-        let handler = local_object(scope, isolate_id, &handler)?;
-        let proxy = v8::Proxy::new(scope, target, handler)
-            .ok_or_else(|| caught_exception(scope, isolate_id, None, "Proxy creation failed"))?;
-        Ok(V8Object(wrap_local_value(scope, isolate_id, proxy.into())))
+        v8_engine_scope_with_context!(scope, self, &self.realm.context, {
+            let target = local_object(scope, isolate_id, &target)?;
+            let handler = local_object(scope, isolate_id, &handler)?;
+            let proxy = v8::Proxy::new(scope, target, handler).ok_or_else(|| {
+                caught_exception(scope, isolate_id, None, "Proxy creation failed")
+            })?;
+            Ok(V8Object(wrap_local_value(scope, isolate_id, proxy.into())))
+        })
     }
 
     fn js_string_to_rust_string(&self, string: &V8String) -> String {
@@ -2587,28 +2759,33 @@ impl ExecutionContext<V8Types> for V8Engine {
 
     fn create_empty_array(&mut self) -> V8Object {
         let isolate_id = self.isolate_id;
-        v8_engine_scope_with_context!(let scope, self, &self.realm.context);
-        let array = v8::Array::new(scope, 0);
-        V8Object(wrap_local_value(scope, isolate_id, array.into()))
+        v8_engine_scope_with_context!(scope, self, &self.realm.context, {
+            let array = v8::Array::new(scope, 0);
+            V8Object(wrap_local_value(scope, isolate_id, array.into()))
+        })
     }
 
     fn array_push(&mut self, array: &V8Object, value: V8Value) -> Completion<(), V8Types> {
-        self.call_js_helper("(array, value) => { array.push(value); }", &[array.0.clone(), value])?;
+        self.call_js_helper(
+            "(array, value) => { array.push(value); }",
+            &[array.0.clone(), value],
+        )?;
         Ok(())
     }
 
     fn create_plain_object(&mut self, prototype: Option<&V8Object>) -> V8Object {
         let isolate_id = self.isolate_id;
-        v8_engine_scope_with_context!(let scope, self, &self.realm.context);
-        let object = v8::Object::new(scope);
-        if let Some(prototype) = prototype {
-            let prototype = local_value(scope, isolate_id, &prototype.0)
-                .expect("plain-object prototype belongs to another isolate");
-            object
-                .set_prototype(scope, prototype)
-                .expect("V8 failed to set plain-object prototype");
-        }
-        V8Object(wrap_local_value(scope, isolate_id, object.into()))
+        v8_engine_scope_with_context!(scope, self, &self.realm.context, {
+            let object = v8::Object::new(scope);
+            if let Some(prototype) = prototype {
+                let prototype = local_value(scope, isolate_id, &prototype.0)
+                    .expect("plain-object prototype belongs to another isolate");
+                object
+                    .set_prototype(scope, prototype)
+                    .expect("V8 failed to set plain-object prototype");
+            }
+            V8Object(wrap_local_value(scope, isolate_id, object.into()))
+        })
     }
 
     fn json_stringify(&mut self, value: V8Value) -> Completion<String, V8Types> {
@@ -2626,9 +2803,10 @@ impl ExecutionContext<V8Types> for V8Engine {
 
     fn value_from_bigint(&mut self, number: i64) -> V8Value {
         let isolate_id = self.isolate_id;
-        v8_engine_scope_with_context!(let scope, self, &self.realm.context);
-        let bigint = v8::BigInt::new_from_i64(scope, number);
-        wrap_local_value(scope, isolate_id, bigint.into())
+        v8_engine_scope_with_context!(scope, self, &self.realm.context, {
+            let bigint = v8::BigInt::new_from_i64(scope, number);
+            wrap_local_value(scope, isolate_id, bigint.into())
+        })
     }
 
     fn create_builtin_fn_static(
@@ -2710,11 +2888,8 @@ mod tests {
         let mut first_document_engine = parent_engine.new_child_realm();
         let mut second_document_engine = parent_engine.new_child_realm();
 
-        let first_value = ExecutionContext::evaluate_script(
-            &mut first_document_engine,
-            "21 * 2",
-        )
-        .expect("the first child realm must evaluate JavaScript");
+        let first_value = ExecutionContext::evaluate_script(&mut first_document_engine, "21 * 2")
+            .expect("the first child realm must evaluate JavaScript");
         assert_eq!(
             first_document_engine
                 .to_number(first_value)
@@ -2740,11 +2915,9 @@ mod tests {
             .create_data_property(global, callback_name, callback_value)
             .expect("the callback must be installed in the second child realm");
 
-        let second_value = ExecutionContext::evaluate_script(
-            &mut second_document_engine,
-            "sharedCallback()",
-        )
-        .expect("the remaining child realm must invoke native callbacks");
+        let second_value =
+            ExecutionContext::evaluate_script(&mut second_document_engine, "sharedCallback()")
+                .expect("the remaining child realm must invoke native callbacks");
         assert_eq!(
             second_document_engine
                 .to_number(second_value)
@@ -2787,6 +2960,69 @@ mod tests {
                 .expect("the callback result must be numeric"),
             42.0
         );
+    }
+
+    #[test]
+    fn prototype_proxy_traps_can_call_native_functions_and_throw() {
+        let mut engine = V8Engine::new();
+        let callback_called = Rc::new(Cell::new(false));
+        let callback_called_by_function = Rc::clone(&callback_called);
+        let callback_name = engine.property_key_from_str("prototypeTrap");
+        let callback = engine.create_builtin_function(
+            Box::new(move |_arguments, _this, execution_context| {
+                callback_called_by_function.set(true);
+                Ok(execution_context.value_undefined())
+            }),
+            0,
+            callback_name.clone(),
+            false,
+        );
+        let callback_value = V8Types::value_from_object(callback);
+        let global = engine.realm_global_object();
+        engine
+            .create_data_property(global, callback_name, callback_value)
+            .expect("the callback must be installed in the realm");
+
+        let proxy = ExecutionContext::evaluate_script(
+            &mut engine,
+            "new Proxy({}, { getPrototypeOf() { prototypeTrap(); throw new Error('prototype failure'); } })",
+        )
+        .expect("the proxy must be created");
+        let proxy = V8Types::value_as_object(&proxy).expect("the proxy must be an object");
+
+        assert!(engine.get_prototype_of(proxy).is_err());
+        assert!(callback_called.get());
+
+        callback_called.set(false);
+        let proxy = ExecutionContext::evaluate_script(
+            &mut engine,
+            "new Proxy({}, { setPrototypeOf() { prototypeTrap(); return true; } })",
+        )
+        .expect("the second proxy must be created");
+        let proxy = V8Types::value_as_object(&proxy).expect("the second proxy must be an object");
+
+        assert!(
+            engine
+                .set_prototype(proxy, None)
+                .expect("the setPrototypeOf trap must succeed")
+        );
+        assert!(callback_called.get());
+    }
+
+    #[test]
+    fn get_function_realm_returns_the_creation_realm() {
+        let mut parent_engine = V8Engine::new();
+        let mut child_engine = parent_engine.new_child_realm();
+        let function = ExecutionContext::evaluate_script(&mut child_engine, "(() => 42)")
+            .expect("the child realm must create a function");
+        let function = V8Types::value_as_object(&function).expect("the value must be a function");
+
+        let function_realm = parent_engine
+            .get_function_realm(&function)
+            .expect("the function realm must be found");
+
+        assert_eq!(function_realm.isolate_id, child_engine.realm.isolate_id);
+        assert_eq!(function_realm.context, child_engine.realm.context);
     }
 
     #[test]

--- a/js_engine/src/v8/engine.rs
+++ b/js_engine/src/v8/engine.rs
@@ -3,9 +3,10 @@ use std::cell::{Cell, RefCell, RefMut};
 use std::collections::{HashMap, VecDeque};
 use std::convert::TryFrom;
 use std::ffi::c_void;
+use std::mem::replace;
 use std::panic::{AssertUnwindSafe, catch_unwind};
-use std::ptr::NonNull;
-use std::rc::Rc;
+use std::ptr::{NonNull, from_ref};
+use std::rc::{Rc, Weak as RcWeak};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Once};
 
@@ -23,7 +24,11 @@ use crate::{
 };
 
 use super::types::{CachedPrimitive, ObjectProfile, V8ArrayBufferState};
-use super::{V8BigInt, V8Object, V8PropertyKey, V8Realm, V8String, V8Symbol, V8Types, V8Value};
+use super::{
+    V8ArrayBuffer, V8BigInt, V8Constructor, V8DataView, V8Function, V8Generator, V8Map, V8Object,
+    V8Promise, V8PropertyKey, V8Realm, V8Set, V8SharedArrayBuffer, V8String, V8Symbol,
+    V8TypedArray, V8Types, V8Value,
+};
 
 const HOST_OBJECT_TAG: u16 = 1;
 static HOST_OBJECT_MARKER: u8 = 0;
@@ -41,17 +46,32 @@ type CaptureBehaviour<T, C> = fn(
 ) -> Completion<<T as JsTypes>::JsValue, T>;
 
 enum QueuedJob {
-    Plain(Box<dyn FnOnce()>),
-    WithRealm(V8Realm, RealmJob),
+    Plain(Rc<V8RealmState>, Box<dyn FnOnce()>),
+    WithRealm(Rc<V8RealmState>, RealmJob),
 }
 
 struct CallbackRecord {
     isolate_id: u64,
+    creation_realm: RcWeak<V8RealmState>,
     behaviour: StoredBehaviour,
 }
 
 struct HostObjectRecord {
     data: Box<dyn Any>,
+}
+
+#[derive(Default)]
+struct RealmHostData {
+    values: HashMap<TypeId, Box<dyn Any>>,
+    associated_objects: Vec<(V8Object, Box<dyn Any>)>,
+}
+
+#[derive(Clone)]
+struct V8RealmState {
+    realm: V8Realm,
+    realm_global: RefCell<V8Object>,
+    intrinsics: Option<RealmIntrinsics<V8Types>>,
+    host_data_holder: Option<V8Object>,
 }
 
 type StoredCallbackScope = v8::PinScope<'static, 'static>;
@@ -64,7 +84,12 @@ thread_local! {
 
 struct SharedIsolate {
     isolate_id: u64,
+    realm_states: RefCell<Vec<RcWeak<V8RealmState>>>,
+    queued_jobs: RefCell<VecDeque<QueuedJob>>,
+    host_object_handles: RefCell<Vec<v8::Weak<v8::Object>>>,
+    callback_handles: RefCell<Vec<v8::Weak<v8::Function>>>,
     isolate: RefCell<v8::OwnedIsolate>,
+    microtask_queue: v8::UniqueRef<v8::MicrotaskQueue>,
 }
 
 impl SharedIsolate {
@@ -72,9 +97,15 @@ impl SharedIsolate {
         initialize_v8();
         let mut isolate = v8::Isolate::new(v8::CreateParams::default());
         isolate.set_microtasks_policy(v8::MicrotasksPolicy::Explicit);
+        let microtask_queue = v8::MicrotaskQueue::new(&mut isolate, v8::MicrotasksPolicy::Explicit);
         Rc::new(Self {
             isolate_id: NEXT_ISOLATE_ID.fetch_add(1, Ordering::Relaxed),
+            realm_states: RefCell::new(Vec::new()),
+            queued_jobs: RefCell::new(VecDeque::new()),
+            host_object_handles: RefCell::new(Vec::new()),
+            callback_handles: RefCell::new(Vec::new()),
             isolate: RefCell::new(isolate),
+            microtask_queue,
         })
     }
 
@@ -224,14 +255,7 @@ impl Drop for CurrentEngineGuard {
 
 pub struct V8Engine {
     isolate_id: u64,
-    realm: V8Realm,
-    realm_global: V8Object,
-    intrinsics: Option<RealmIntrinsics<V8Types>>,
-    host_data: HashMap<TypeId, Box<dyn Any>>,
-    associated_objects: Vec<(V8Object, Box<dyn Any>)>,
-    queued_jobs: VecDeque<QueuedJob>,
-    host_object_handles: Vec<v8::Weak<v8::Object>>,
-    callback_handles: Vec<v8::Weak<v8::Function>>,
+    realm_state: Rc<V8RealmState>,
     host_hooks: HostHooks<V8Types>,
     shared_isolate: Rc<SharedIsolate>,
 }
@@ -303,6 +327,30 @@ fn wrap_local_value(
     let object_profile = if value.is_object() {
         let object = v8::Local::<v8::Object>::try_from(value).expect("V8 object type check failed");
         host_data = host_data_pointer(scope, object);
+        let array_buffer_handle = v8::Local::<v8::ArrayBuffer>::try_from(value)
+            .ok()
+            .map(|handle| v8::Global::new(scope, handle));
+        let shared_array_buffer_handle = v8::Local::<v8::SharedArrayBuffer>::try_from(value)
+            .ok()
+            .map(|handle| v8::Global::new(scope, handle));
+        let typed_array_handle = v8::Local::<v8::TypedArray>::try_from(value)
+            .ok()
+            .map(|handle| v8::Global::new(scope, handle));
+        let data_view_handle = v8::Local::<v8::DataView>::try_from(value)
+            .ok()
+            .map(|handle| v8::Global::new(scope, handle));
+        let promise_handle = v8::Local::<v8::Promise>::try_from(value)
+            .ok()
+            .map(|handle| v8::Global::new(scope, handle));
+        let function_handle = v8::Local::<v8::Function>::try_from(value)
+            .ok()
+            .map(|handle| v8::Global::new(scope, handle));
+        let map_handle = v8::Local::<v8::Map>::try_from(value)
+            .ok()
+            .map(|handle| v8::Global::new(scope, handle));
+        let set_handle = v8::Local::<v8::Set>::try_from(value)
+            .ok()
+            .map(|handle| v8::Global::new(scope, handle));
         let array_buffer_state = if value.is_array_buffer() {
             let array_buffer = v8::Local::<v8::ArrayBuffer>::try_from(value)
                 .expect("V8 ArrayBuffer type check failed");
@@ -343,15 +391,15 @@ fn wrap_local_value(
             None
         };
         Some(Box::new(ObjectProfile {
-            is_array_buffer: value.is_array_buffer(),
-            is_shared_array_buffer: value.is_shared_array_buffer(),
-            is_typed_array: value.is_typed_array(),
-            is_data_view: value.is_data_view(),
-            is_promise: value.is_promise(),
-            is_function: value.is_function(),
-            is_constructor: value.is_function(),
-            is_map: value.is_map(),
-            is_set: value.is_set(),
+            object_handle: v8::Global::new(scope, object),
+            array_buffer_handle,
+            shared_array_buffer_handle,
+            typed_array_handle,
+            data_view_handle,
+            promise_handle,
+            function_handle,
+            map_handle,
+            set_handle,
             is_weak_map: value.is_weak_map(),
             is_weak_set: value.is_weak_set(),
             is_generator: value.is_generator_object(),
@@ -379,6 +427,10 @@ fn wrap_local_value(
     }
 }
 
+fn object_from_wrapped_value(value: V8Value) -> V8Object {
+    V8Object::from_value(value).expect("V8 object wrapper requires an object value")
+}
+
 fn local_value<'scope>(
     scope: &mut v8::PinScope<'scope, '_>,
     isolate_id: u64,
@@ -398,13 +450,28 @@ fn local_object<'scope>(
     isolate_id: u64,
     object: &V8Object,
 ) -> Result<v8::Local<'scope, v8::Object>, V8Value> {
-    let value = local_value(scope, isolate_id, &object.0)?;
-    v8::Local::<v8::Object>::try_from(value).map_err(|_| {
+    if object.0.isolate_id != isolate_id {
         let message = v8::String::new(scope, "value is not an object")
             .expect("static V8 error string allocation failed");
         let exception = v8::Exception::type_error(scope, message);
-        wrap_local_value(scope, isolate_id, exception)
-    })
+        return Err(wrap_local_value(scope, isolate_id, exception));
+    }
+    Ok(v8::Local::new(scope, &object.1))
+}
+
+fn local_typed_object<'scope, T>(
+    scope: &mut v8::PinScope<'scope, '_>,
+    isolate_id: u64,
+    object: &V8Object,
+    handle: &v8::Global<T>,
+) -> Result<v8::Local<'scope, T>, V8Value> {
+    if object.0.isolate_id != isolate_id {
+        let message = v8::String::new(scope, "value belongs to a different V8 isolate")
+            .expect("static V8 error string allocation failed");
+        let exception = v8::Exception::type_error(scope, message);
+        return Err(wrap_local_value(scope, isolate_id, exception));
+    }
+    Ok(v8::Local::new(scope, handle))
 }
 
 fn local_property_key<'scope>(
@@ -513,19 +580,27 @@ fn native_callback(
         let engine = &mut *engine_pointer;
         let result = if record.isolate_id != engine.isolate_id {
             Err(engine.new_type_error("native callback belongs to a different V8 isolate"))
+        } else if let Some(creation_realm) = record.creation_realm.upgrade() {
+            let previous_realm = replace(&mut engine.realm_state, creation_realm);
+            let completion = {
+                let _current_callback_scope =
+                    CurrentCallbackScopeGuard::enter(scope, record.isolate_id);
+                let callback_arguments: Vec<_> = (0..arguments.length())
+                    .map(|index| wrap_local_value(scope, record.isolate_id, arguments.get(index)))
+                    .collect();
+                let this_value =
+                    wrap_local_value(scope, record.isolate_id, arguments.this().into());
+                match catch_unwind(AssertUnwindSafe(|| {
+                    (record.behaviour)(&callback_arguments, this_value, engine)
+                })) {
+                    Ok(completion) => completion,
+                    Err(_) => Err(engine.new_type_error("Rust panic in native callback")),
+                }
+            };
+            engine.realm_state = previous_realm;
+            completion
         } else {
-            let _current_callback_scope =
-                CurrentCallbackScopeGuard::enter(scope, record.isolate_id);
-            let callback_arguments: Vec<_> = (0..arguments.length())
-                .map(|index| wrap_local_value(scope, record.isolate_id, arguments.get(index)))
-                .collect();
-            let this_value = wrap_local_value(scope, record.isolate_id, arguments.this().into());
-            match catch_unwind(AssertUnwindSafe(|| {
-                (record.behaviour)(&callback_arguments, this_value, engine)
-            })) {
-                Ok(completion) => completion,
-                Err(_) => Err(engine.new_type_error("Rust panic in native callback")),
-            }
+            Err(engine.new_type_error("native callback creation realm no longer exists"))
         };
         (result, record.isolate_id)
     };
@@ -578,11 +653,22 @@ impl V8Engine {
         let isolate_id = shared_isolate.isolate_id;
 
         let (context_handle, realm_global) = v8_shared_scope!(scope, shared_isolate, isolate_id, {
-            let context = v8::Context::new(scope, v8::ContextOptions::default());
+            let microtask_queue = from_ref(&*shared_isolate.microtask_queue).cast_mut();
+            let context = v8::Context::new(
+                scope,
+                v8::ContextOptions {
+                    microtask_queue: Some(microtask_queue),
+                    ..v8::ContextOptions::default()
+                },
+            );
             let context_handle = v8::Global::new(scope, context);
             let context_scope = &mut v8::ContextScope::new(scope, context);
             let global = context.global(context_scope);
-            let realm_global = V8Object(wrap_local_value(context_scope, isolate_id, global.into()));
+            let realm_global = object_from_wrapped_value(wrap_local_value(
+                context_scope,
+                isolate_id,
+                global.into(),
+            ));
             (context_handle, realm_global)
         });
 
@@ -590,34 +676,85 @@ impl V8Engine {
             isolate_id,
             context: context_handle,
         };
+        let realm_state = Rc::new(V8RealmState {
+            realm,
+            realm_global: RefCell::new(realm_global),
+            intrinsics: None,
+            host_data_holder: None,
+        });
         let mut engine = Self {
             isolate_id,
-            realm,
-            realm_global,
-            intrinsics: None,
-            host_data: HashMap::new(),
-            associated_objects: Vec::new(),
-            queued_jobs: VecDeque::new(),
-            host_object_handles: Vec::new(),
-            callback_handles: Vec::new(),
+            realm_state,
             host_hooks: HostHooks::empty(),
             shared_isolate,
         };
-        engine.intrinsics = Some(engine.load_intrinsics());
+        let intrinsics = engine.load_intrinsics();
+        Rc::get_mut(&mut engine.realm_state)
+            .expect("new V8 realm state must not be shared while initializing intrinsics")
+            .intrinsics = Some(intrinsics.clone());
+        let host_data_holder = engine.create_object_with_any(
+            intrinsics.object_prototype,
+            Box::new(RealmHostData::default()),
+        );
+        Rc::get_mut(&mut engine.realm_state)
+            .expect("new V8 realm state must not be shared while initializing host data")
+            .host_data_holder = Some(host_data_holder);
+        engine
+            .shared_isolate
+            .realm_states
+            .borrow_mut()
+            .push(Rc::downgrade(&engine.realm_state));
         engine
     }
 
     pub fn associate_existing_object(&mut self, object: &V8Object, data: Box<dyn Any>) {
-        self.associated_objects.push((object.clone(), data));
+        self.realm_host_data_mut()
+            .associated_objects
+            .push((object.clone(), data));
     }
 
     pub fn new_child_realm(&self) -> Self {
         Self::new_with_shared_isolate(Rc::clone(&self.shared_isolate))
     }
 
+    fn realm_host_data(&self) -> &RealmHostData {
+        let holder = self
+            .realm_state
+            .host_data_holder
+            .as_ref()
+            .expect("V8 realm host data is not initialized");
+        self.with_object_any(holder)
+            .and_then(|data| data.downcast_ref::<RealmHostData>())
+            .expect("V8 realm host-data holder contains an unexpected value")
+    }
+
+    fn realm_host_data_mut(&mut self) -> &mut RealmHostData {
+        let holder = self
+            .realm_state
+            .host_data_holder
+            .as_ref()
+            .expect("V8 realm host data is not initialized")
+            .clone();
+        self.with_object_any_mut(&holder)
+            .and_then(|data| data.downcast_mut::<RealmHostData>())
+            .expect("V8 realm host-data holder contains an unexpected value")
+    }
+
+    fn state_for_realm(&self, realm: &V8Realm) -> Option<Rc<V8RealmState>> {
+        if realm.isolate_id != self.isolate_id {
+            return None;
+        }
+        let mut realm_states = self.shared_isolate.realm_states.borrow_mut();
+        realm_states.retain(|state| state.strong_count() != 0);
+        realm_states
+            .iter()
+            .filter_map(RcWeak::upgrade)
+            .find(|state| state.realm.context == realm.context)
+    }
+
     pub(crate) fn create_weak_object(&mut self, object: &V8Object) -> Rc<v8::Weak<v8::Object>> {
         let isolate_id = self.isolate_id;
-        v8_engine_scope_with_context!(scope, self, &self.realm.context, {
+        v8_engine_scope_with_context!(scope, self, &self.realm_state.realm.context, {
             let local = local_object(scope, isolate_id, object)
                 .expect("reflector creation received a non-object or cross-isolate handle");
             Rc::new(v8::Weak::new(scope, local))
@@ -626,10 +763,14 @@ impl V8Engine {
 
     pub(crate) fn upgrade_weak_object(&mut self, weak: &v8::Weak<v8::Object>) -> Option<V8Object> {
         let isolate_id = self.isolate_id;
-        v8_engine_scope_with_context!(scope, self, &self.realm.context, {
+        v8_engine_scope_with_context!(scope, self, &self.realm_state.realm.context, {
             let global = weak.to_global(scope)?;
             let local = v8::Local::new(scope, global);
-            Some(V8Object(wrap_local_value(scope, isolate_id, local.into())))
+            Some(object_from_wrapped_value(wrap_local_value(
+                scope,
+                isolate_id,
+                local.into(),
+            )))
         })
     }
 
@@ -645,7 +786,7 @@ impl V8Engine {
         }
         let _current_engine = CurrentEngineGuard::enter(self);
         let isolate_id = self.isolate_id;
-        v8_engine_scope_with_context!(scope, self, &self.realm.context, {
+        v8_engine_scope_with_context!(scope, self, &self.realm_state.realm.context, {
             v8::tc_scope!(let try_catch, scope);
             let Some(source) = v8::String::new(try_catch, source) else {
                 return Err(caught_exception(
@@ -690,30 +831,36 @@ impl V8Engine {
         }
     }
 
+    fn intrinsic_constructor(&mut self, source: &str) -> V8Constructor {
+        let object = self.intrinsic_object(source);
+        V8Types::object_as_constructor(&object)
+            .unwrap_or_else(|| panic!("V8 intrinsic `{source}` is not a constructor"))
+    }
+
     fn load_intrinsics(&mut self) -> RealmIntrinsics<V8Types> {
         RealmIntrinsics {
-            array_buffer: self.intrinsic_object("ArrayBuffer"),
-            shared_array_buffer: self.intrinsic_object("SharedArrayBuffer"),
-            promise: self.intrinsic_object("Promise"),
-            object: self.intrinsic_object("Object"),
-            function: self.intrinsic_object("Function"),
-            error: self.intrinsic_object("Error"),
-            type_error: self.intrinsic_object("TypeError"),
-            range_error: self.intrinsic_object("RangeError"),
-            syntax_error: self.intrinsic_object("SyntaxError"),
-            reference_error: self.intrinsic_object("ReferenceError"),
-            uri_error: self.intrinsic_object("URIError"),
-            eval_error: self.intrinsic_object("EvalError"),
-            array: self.intrinsic_object("Array"),
-            uint8_array: self.intrinsic_object("Uint8Array"),
-            boolean: self.intrinsic_object("Boolean"),
-            number: self.intrinsic_object("Number"),
-            string: self.intrinsic_object("String"),
-            bigint: self.intrinsic_object("BigInt"),
-            date: self.intrinsic_object("Date"),
-            regexp: self.intrinsic_object("RegExp"),
-            map: self.intrinsic_object("Map"),
-            set: self.intrinsic_object("Set"),
+            array_buffer: self.intrinsic_constructor("ArrayBuffer"),
+            shared_array_buffer: self.intrinsic_constructor("SharedArrayBuffer"),
+            promise: self.intrinsic_constructor("Promise"),
+            object: self.intrinsic_constructor("Object"),
+            function: self.intrinsic_constructor("Function"),
+            error: self.intrinsic_constructor("Error"),
+            type_error: self.intrinsic_constructor("TypeError"),
+            range_error: self.intrinsic_constructor("RangeError"),
+            syntax_error: self.intrinsic_constructor("SyntaxError"),
+            reference_error: self.intrinsic_constructor("ReferenceError"),
+            uri_error: self.intrinsic_constructor("URIError"),
+            eval_error: self.intrinsic_constructor("EvalError"),
+            array: self.intrinsic_constructor("Array"),
+            uint8_array: self.intrinsic_constructor("Uint8Array"),
+            boolean: self.intrinsic_constructor("Boolean"),
+            number: self.intrinsic_constructor("Number"),
+            string: self.intrinsic_constructor("String"),
+            bigint: self.intrinsic_constructor("BigInt"),
+            date: self.intrinsic_constructor("Date"),
+            regexp: self.intrinsic_constructor("RegExp"),
+            map: self.intrinsic_constructor("Map"),
+            set: self.intrinsic_constructor("Set"),
             boolean_prototype: self.intrinsic_object("Boolean.prototype"),
             number_prototype: self.intrinsic_object("Number.prototype"),
             string_prototype: self.intrinsic_object("String.prototype"),
@@ -743,16 +890,17 @@ impl V8Engine {
         length: u32,
         name: V8PropertyKey,
         is_constructor: bool,
-    ) -> V8Object {
+    ) -> V8Function {
         let record = Box::new(CallbackRecord {
             isolate_id: self.isolate_id,
+            creation_realm: Rc::downgrade(&self.realm_state),
             behaviour,
         });
         let record_pointer = Box::into_raw(record);
         let isolate_id = self.isolate_id;
         let function_name = self.property_key_to_rust_string(&name);
 
-        v8_engine_scope_with_context!(scope, self, &self.realm.context, {
+        v8_engine_scope_with_context!(scope, self, &self.realm_state.realm.context, {
             let external = v8::External::new(scope, record_pointer.cast());
             let constructor_behavior = if is_constructor {
                 v8::ConstructorBehavior::Allow
@@ -785,8 +933,13 @@ impl V8Engine {
                     }
                 }),
             );
-            self.callback_handles.push(callback_handle);
-            V8Object(function_value)
+            self.shared_isolate
+                .callback_handles
+                .borrow_mut()
+                .push(callback_handle);
+            let object = object_from_wrapped_value(function_value);
+            V8Types::object_as_function(&object)
+                .expect("V8 native function wrapper is not a function")
         })
     }
 }
@@ -801,7 +954,14 @@ impl JsEngine<V8Types> for V8Engine {
     fn create_realm(&mut self) -> V8Realm {
         let isolate_id = self.isolate_id;
         v8_engine_scope!(scope, self, {
-            let context = v8::Context::new(scope, v8::ContextOptions::default());
+            let microtask_queue = from_ref(&*self.shared_isolate.microtask_queue).cast_mut();
+            let context = v8::Context::new(
+                scope,
+                v8::ContextOptions {
+                    microtask_queue: Some(microtask_queue),
+                    ..v8::ContextOptions::default()
+                },
+            );
             V8Realm {
                 isolate_id,
                 context: v8::Global::new(scope, context),
@@ -818,8 +978,8 @@ impl JsEngine<V8Types> for V8Engine {
         if realm.isolate_id != self.isolate_id || global.0.isolate_id != self.isolate_id {
             return;
         }
-        if realm.context == self.realm.context {
-            self.realm_global = global;
+        if realm.context == self.realm_state.realm.context {
+            self.realm_state.realm_global.replace(global);
         }
     }
 
@@ -902,16 +1062,16 @@ impl JsEngine<V8Types> for V8Engine {
 
     fn allocate_array_buffer(
         &mut self,
-        constructor: V8Object,
+        constructor: V8Constructor,
         byte_length: u64,
         max_byte_length: Option<u64>,
-    ) -> Completion<V8Object, V8Types> {
+    ) -> Completion<V8ArrayBuffer, V8Types> {
         ExecutionContext::allocate_array_buffer(self, constructor, byte_length, max_byte_length)
     }
 
     fn detach_array_buffer(
         &mut self,
-        array_buffer: V8Object,
+        array_buffer: V8ArrayBuffer,
         key: Option<V8Value>,
     ) -> Completion<(), V8Types> {
         ExecutionContext::detach_array_buffer(self, array_buffer, key)
@@ -919,11 +1079,11 @@ impl JsEngine<V8Types> for V8Engine {
 
     fn clone_array_buffer(
         &mut self,
-        source: V8Object,
+        source: V8ArrayBuffer,
         source_byte_offset: u64,
         source_length: u64,
-        constructor: V8Object,
-    ) -> Completion<V8Object, V8Types> {
+        constructor: V8Constructor,
+    ) -> Completion<V8ArrayBuffer, V8Types> {
         ExecutionContext::clone_array_buffer(
             self,
             source,
@@ -935,13 +1095,15 @@ impl JsEngine<V8Types> for V8Engine {
 
     fn allocate_shared_array_buffer(
         &mut self,
-        _constructor: V8Object,
+        _constructor: V8Constructor,
         byte_length: u64,
-    ) -> Completion<V8Object, V8Types> {
+    ) -> Completion<V8SharedArrayBuffer, V8Types> {
         let byte_length = self.value_from_number(byte_length as f64);
         let value =
             self.call_js_helper("length => new SharedArrayBuffer(length)", &[byte_length])?;
-        V8Types::value_as_object(&value)
+        let object = V8Types::value_as_object(&value)
+            .ok_or_else(|| self.new_type_error("SharedArrayBuffer allocation failed"))?;
+        V8Types::object_as_shared_array_buffer(&object)
             .ok_or_else(|| self.new_type_error("SharedArrayBuffer allocation failed"))
     }
 
@@ -1019,14 +1181,14 @@ where
     );
     let result = engine.make_builtin_function(stored, length, name, is_constructor);
 
-    // SAFETY: In a V8-selected build T::Function is V8Object. The result is
+    // SAFETY: In a V8-selected build T::Function is V8Function. The result is
     // moved into its associated-type spelling without duplicating ownership.
     unsafe {
         let mut destination = std::mem::MaybeUninit::<T::Function>::uninit();
         std::ptr::copy_nonoverlapping(
             std::ptr::addr_of!(result).cast::<u8>(),
             destination.as_mut_ptr().cast::<u8>(),
-            std::mem::size_of::<V8Object>(),
+            std::mem::size_of::<V8Function>(),
         );
         std::mem::forget(result);
         destination.assume_init()
@@ -1043,7 +1205,7 @@ impl EcmascriptHost<V8Types> for V8Engine {
         value
             .object_profile
             .as_ref()
-            .is_some_and(|profile| profile.is_function)
+            .is_some_and(|profile| profile.function_handle.is_some())
     }
 
     fn call(
@@ -1062,7 +1224,7 @@ impl EcmascriptHost<V8Types> for V8Engine {
         }
         let _current_engine = CurrentEngineGuard::enter(self);
         let isolate_id = self.isolate_id;
-        v8_engine_scope_with_context!(scope, self, &self.realm.context, {
+        v8_engine_scope_with_context!(scope, self, &self.realm_state.realm.context, {
             v8::tc_scope!(let try_catch, scope);
             let callable = local_value(try_catch, isolate_id, &callable.0)?;
             let function = v8::Local::<v8::Function>::try_from(callable).map_err(|_| {
@@ -1083,25 +1245,39 @@ impl EcmascriptHost<V8Types> for V8Engine {
     fn perform_a_microtask_checkpoint(&mut self) -> Completion<(), V8Types> {
         let _current_engine = CurrentEngineGuard::enter(self);
         loop {
-            while let Some(job) = self.queued_jobs.pop_front() {
-                match job {
-                    QueuedJob::Plain(job) => job(),
-                    QueuedJob::WithRealm(realm, job) => {
-                        if realm.isolate_id != self.isolate_id {
-                            return Err(
-                                self.new_type_error("job realm belongs to a different V8 isolate")
-                            );
-                        }
-                        job(self);
+            loop {
+                let queued_job = self.shared_isolate.queued_jobs.borrow_mut().pop_front();
+                let Some(queued_job) = queued_job else {
+                    break;
+                };
+                let (realm_state, job_result) = match queued_job {
+                    QueuedJob::Plain(realm_state, job) => {
+                        let previous_realm =
+                            replace(&mut self.realm_state, Rc::clone(&realm_state));
+                        let result = catch_unwind(AssertUnwindSafe(job));
+                        self.realm_state = previous_realm;
+                        (realm_state, result)
                     }
+                    QueuedJob::WithRealm(realm_state, job) => {
+                        let previous_realm =
+                            replace(&mut self.realm_state, Rc::clone(&realm_state));
+                        let result = catch_unwind(AssertUnwindSafe(|| job(self)));
+                        self.realm_state = previous_realm;
+                        (realm_state, result)
+                    }
+                };
+                if job_result.is_err() {
+                    let previous_realm = replace(&mut self.realm_state, realm_state);
+                    let exception = self.new_type_error("Rust panic in queued V8 job");
+                    self.realm_state = previous_realm;
+                    return Err(exception);
                 }
             }
-            let queued_before_checkpoint = self.queued_jobs.len();
             let shared_isolate = Rc::clone(&self.shared_isolate);
             v8_shared_isolate!(isolate, shared_isolate, self.isolate_id, {
-                isolate.perform_microtask_checkpoint();
+                shared_isolate.microtask_queue.perform_checkpoint(isolate);
             });
-            if self.queued_jobs.len() == queued_before_checkpoint {
+            if self.shared_isolate.queued_jobs.borrow().is_empty() {
                 break;
             }
         }
@@ -1124,7 +1300,7 @@ impl EcmascriptHost<V8Types> for V8Engine {
 
     fn value_undefined(&mut self) -> V8Value {
         let isolate_id = self.isolate_id;
-        v8_engine_scope_with_context!(scope, self, &self.realm.context, {
+        v8_engine_scope_with_context!(scope, self, &self.realm_state.realm.context, {
             let value = v8::undefined(scope).into();
             wrap_local_value(scope, isolate_id, value)
         })
@@ -1132,7 +1308,7 @@ impl EcmascriptHost<V8Types> for V8Engine {
 
     fn value_null(&mut self) -> V8Value {
         let isolate_id = self.isolate_id;
-        v8_engine_scope_with_context!(scope, self, &self.realm.context, {
+        v8_engine_scope_with_context!(scope, self, &self.realm_state.realm.context, {
             let value = v8::null(scope).into();
             wrap_local_value(scope, isolate_id, value)
         })
@@ -1140,7 +1316,7 @@ impl EcmascriptHost<V8Types> for V8Engine {
 
     fn value_from_bool(&mut self, boolean: bool) -> V8Value {
         let isolate_id = self.isolate_id;
-        v8_engine_scope_with_context!(scope, self, &self.realm.context, {
+        v8_engine_scope_with_context!(scope, self, &self.realm_state.realm.context, {
             let value = v8::Boolean::new(scope, boolean).into();
             wrap_local_value(scope, isolate_id, value)
         })
@@ -1148,7 +1324,7 @@ impl EcmascriptHost<V8Types> for V8Engine {
 
     fn value_from_number(&mut self, number: f64) -> V8Value {
         let isolate_id = self.isolate_id;
-        v8_engine_scope_with_context!(scope, self, &self.realm.context, {
+        v8_engine_scope_with_context!(scope, self, &self.realm_state.realm.context, {
             let value = v8::Number::new(scope, number).into();
             wrap_local_value(scope, isolate_id, value)
         })
@@ -1159,7 +1335,7 @@ impl EcmascriptHost<V8Types> for V8Engine {
             return value;
         }
         let isolate_id = self.isolate_id;
-        v8_engine_scope_with_context!(scope, self, &self.realm.context, {
+        v8_engine_scope_with_context!(scope, self, &self.realm_state.realm.context, {
             let local =
                 v8::String::new_from_two_byte(scope, &string.utf16, v8::NewStringType::Normal)
                     .expect("V8 string allocation failed");
@@ -1351,7 +1527,7 @@ impl ExecutionContext<V8Types> for V8Engine {
         value
             .object_profile
             .as_ref()
-            .is_some_and(|profile| profile.is_constructor)
+            .is_some_and(|profile| profile.function_handle.is_some())
     }
 
     fn is_extensible(&mut self, object: &V8Object) -> Completion<bool, V8Types> {
@@ -1425,7 +1601,7 @@ impl ExecutionContext<V8Types> for V8Engine {
     ) -> Completion<V8Value, V8Types> {
         let _current_engine = CurrentEngineGuard::enter(self);
         let isolate_id = self.isolate_id;
-        v8_engine_scope_with_context!(scope, self, &self.realm.context, {
+        v8_engine_scope_with_context!(scope, self, &self.realm_state.realm.context, {
             v8::tc_scope!(let try_catch, scope);
             let object = local_object(try_catch, isolate_id, &object)?;
             let key = local_property_key(try_catch, isolate_id, &property_key)?;
@@ -1454,7 +1630,7 @@ impl ExecutionContext<V8Types> for V8Engine {
     ) -> Completion<(), V8Types> {
         let _current_engine = CurrentEngineGuard::enter(self);
         let isolate_id = self.isolate_id;
-        v8_engine_scope_with_context!(scope, self, &self.realm.context, {
+        v8_engine_scope_with_context!(scope, self, &self.realm_state.realm.context, {
             v8::tc_scope!(let try_catch, scope);
             let object = local_object(try_catch, isolate_id, &object)?;
             let key = local_property_key(try_catch, isolate_id, &property_key)?;
@@ -1481,7 +1657,7 @@ impl ExecutionContext<V8Types> for V8Engine {
     ) -> Completion<bool, V8Types> {
         let _current_engine = CurrentEngineGuard::enter(self);
         let isolate_id = self.isolate_id;
-        v8_engine_scope_with_context!(scope, self, &self.realm.context, {
+        v8_engine_scope_with_context!(scope, self, &self.realm_state.realm.context, {
             v8::tc_scope!(let try_catch, scope);
             let object = local_object(try_catch, isolate_id, &object)?;
             let key = local_name(try_catch, isolate_id, &property_key)?;
@@ -1561,7 +1737,7 @@ impl ExecutionContext<V8Types> for V8Engine {
     ) -> Completion<(), V8Types> {
         let _current_engine = CurrentEngineGuard::enter(self);
         let isolate_id = self.isolate_id;
-        v8_engine_scope_with_context!(scope, self, &self.realm.context, {
+        v8_engine_scope_with_context!(scope, self, &self.realm_state.realm.context, {
             v8::tc_scope!(let try_catch, scope);
             let object = local_object(try_catch, isolate_id, &object)?;
             let key = local_name(try_catch, isolate_id, &property_key)?;
@@ -1569,11 +1745,15 @@ impl ExecutionContext<V8Types> for V8Engine {
             let undefined = v8::undefined(try_catch).into();
             let mut v8_descriptor = if descriptor.get.is_some() || descriptor.set.is_some() {
                 let getter = match &descriptor.get {
-                    Some(getter) => local_value(try_catch, isolate_id, &getter.0)?,
+                    Some(getter) => {
+                        local_typed_object(try_catch, isolate_id, &getter.0, &getter.1)?.into()
+                    }
                     None => undefined,
                 };
                 let setter = match &descriptor.set {
-                    Some(setter) => local_value(try_catch, isolate_id, &setter.0)?,
+                    Some(setter) => {
+                        local_typed_object(try_catch, isolate_id, &setter.0, &setter.1)?.into()
+                    }
                     None => undefined,
                 };
                 v8::PropertyDescriptor::new_from_get_set(getter, setter)
@@ -1617,7 +1797,7 @@ impl ExecutionContext<V8Types> for V8Engine {
     ) -> Completion<(), V8Types> {
         let _current_engine = CurrentEngineGuard::enter(self);
         let isolate_id = self.isolate_id;
-        v8_engine_scope_with_context!(scope, self, &self.realm.context, {
+        v8_engine_scope_with_context!(scope, self, &self.realm_state.realm.context, {
             v8::tc_scope!(let try_catch, scope);
             let object = local_object(try_catch, isolate_id, &object)?;
             let key = local_property_key(try_catch, isolate_id, &property_key)?;
@@ -1668,7 +1848,7 @@ impl ExecutionContext<V8Types> for V8Engine {
         &mut self,
         value: V8Value,
         property_key: V8PropertyKey,
-    ) -> Completion<Option<V8Object>, V8Types> {
+    ) -> Completion<Option<V8Function>, V8Types> {
         let method = self.get_v(value, property_key)?;
         if V8Types::value_is_null(&method) || V8Types::value_is_undefined(&method) {
             return Ok(None);
@@ -1686,7 +1866,7 @@ impl ExecutionContext<V8Types> for V8Engine {
     ) -> Completion<bool, V8Types> {
         let _current_engine = CurrentEngineGuard::enter(self);
         let isolate_id = self.isolate_id;
-        v8_engine_scope_with_context!(scope, self, &self.realm.context, {
+        v8_engine_scope_with_context!(scope, self, &self.realm_state.realm.context, {
             v8::tc_scope!(let try_catch, scope);
             let object = local_object(try_catch, isolate_id, &object)?;
             let key = local_property_key(try_catch, isolate_id, &property_key)?;
@@ -1703,7 +1883,7 @@ impl ExecutionContext<V8Types> for V8Engine {
     ) -> Completion<bool, V8Types> {
         let _current_engine = CurrentEngineGuard::enter(self);
         let isolate_id = self.isolate_id;
-        v8_engine_scope_with_context!(scope, self, &self.realm.context, {
+        v8_engine_scope_with_context!(scope, self, &self.realm_state.realm.context, {
             v8::tc_scope!(let try_catch, scope);
             let object = local_object(try_catch, isolate_id, &object)?;
             let key = local_name(try_catch, isolate_id, &property_key)?;
@@ -1736,7 +1916,7 @@ impl ExecutionContext<V8Types> for V8Engine {
         let descriptor = {
             let _current_engine = CurrentEngineGuard::enter(self);
             let isolate_id = self.isolate_id;
-            v8_engine_scope_with_context!(scope, self, &self.realm.context, {
+            v8_engine_scope_with_context!(scope, self, &self.realm_state.realm.context, {
                 v8::tc_scope!(let try_catch, scope);
                 let object = local_object(try_catch, isolate_id, &object)?;
                 let key = local_name(try_catch, isolate_id, &property_key)?;
@@ -1765,13 +1945,13 @@ impl ExecutionContext<V8Types> for V8Engine {
 
     fn construct(
         &mut self,
-        function: V8Object,
+        function: V8Constructor,
         arguments: &[V8Value],
-        new_target: Option<V8Object>,
+        new_target: Option<V8Constructor>,
     ) -> Completion<V8Object, V8Types> {
         if let Some(new_target) = new_target {
-            let mut helper_arguments = vec![function.0];
-            helper_arguments.push(new_target.0);
+            let mut helper_arguments = vec![function.0.0];
+            helper_arguments.push(new_target.0.0);
             helper_arguments.extend_from_slice(arguments);
             let result = self.call_js_helper(
                 "(constructor, newTarget, ...args) => Reflect.construct(constructor, args, newTarget)",
@@ -1781,15 +1961,15 @@ impl ExecutionContext<V8Types> for V8Engine {
                 .ok_or_else(|| self.new_type_error("constructor did not return an object"));
         }
 
-        let wrapper_primitive = self.intrinsics.as_ref().and_then(|intrinsics| {
+        let wrapper_primitive = self.realm_state.intrinsics.as_ref().and_then(|intrinsics| {
             let argument = arguments.first().map(|value| value.primitive.clone());
-            if function == intrinsics.boolean {
+            if function.0 == intrinsics.boolean.0 {
                 Some(argument.unwrap_or(CachedPrimitive::Boolean(false)))
-            } else if function == intrinsics.number {
+            } else if function.0 == intrinsics.number.0 {
                 Some(argument.unwrap_or(CachedPrimitive::Number(0.0)))
-            } else if function == intrinsics.string {
+            } else if function.0 == intrinsics.string.0 {
                 Some(argument.unwrap_or_else(|| CachedPrimitive::String(Arc::from([]))))
-            } else if function == intrinsics.bigint {
+            } else if function.0 == intrinsics.bigint.0 {
                 argument
             } else {
                 None
@@ -1797,12 +1977,9 @@ impl ExecutionContext<V8Types> for V8Engine {
         });
         let _current_engine = CurrentEngineGuard::enter(self);
         let isolate_id = self.isolate_id;
-        v8_engine_scope_with_context!(scope, self, &self.realm.context, {
+        v8_engine_scope_with_context!(scope, self, &self.realm_state.realm.context, {
             v8::tc_scope!(let try_catch, scope);
-            let function = local_value(try_catch, isolate_id, &function.0)?;
-            let function = v8::Local::<v8::Function>::try_from(function).map_err(|_| {
-                caught_exception(try_catch, isolate_id, None, "value is not a constructor")
-            })?;
+            let function = local_typed_object(try_catch, isolate_id, &function.0, &function.1)?;
             let local_arguments: Result<Vec<_>, _> = arguments
                 .iter()
                 .map(|argument| local_value(try_catch, isolate_id, argument))
@@ -1810,7 +1987,8 @@ impl ExecutionContext<V8Types> for V8Engine {
             let Some(object) = function.new_instance(try_catch, &local_arguments?) else {
                 return Err(caught!(try_catch, isolate_id, "constructor call failed"));
             };
-            let mut object = V8Object(wrap_local_value(try_catch, isolate_id, object.into()));
+            let mut object =
+                object_from_wrapped_value(wrap_local_value(try_catch, isolate_id, object.into()));
             if let Some(wrapper_primitive) = wrapper_primitive
                 && let Some(profile) = object.0.object_profile.as_mut()
             {
@@ -1827,7 +2005,7 @@ impl ExecutionContext<V8Types> for V8Engine {
     ) -> Completion<bool, V8Types> {
         let _current_engine = CurrentEngineGuard::enter(self);
         let isolate_id = self.isolate_id;
-        v8_engine_scope_with_context!(scope, self, &self.realm.context, {
+        v8_engine_scope_with_context!(scope, self, &self.realm_state.realm.context, {
             v8::tc_scope!(let try_catch, scope);
             let object = local_object(try_catch, isolate_id, &object)?;
             let level = match level {
@@ -1856,14 +2034,16 @@ impl ExecutionContext<V8Types> for V8Engine {
     fn species_constructor(
         &mut self,
         object: V8Object,
-        default_constructor: V8Object,
-    ) -> Completion<V8Object, V8Types> {
+        default_constructor: V8Constructor,
+    ) -> Completion<V8Constructor, V8Types> {
         let result = self.call_js_helper(
             "(object, defaultConstructor) => { const constructor = object.constructor; if (constructor === undefined) return defaultConstructor; if (Object(constructor) !== constructor) throw new TypeError('constructor is not an object'); const species = constructor[Symbol.species]; if (species == null) return defaultConstructor; if (typeof species !== 'function') throw new TypeError('species is not a constructor'); return species; }",
-            &[object.0, default_constructor.0],
+            &[object.0, default_constructor.0.0],
         )?;
-        V8Types::value_as_object(&result)
-            .ok_or_else(|| self.new_type_error("SpeciesConstructor did not return an object"))
+        let result = V8Types::value_as_object(&result)
+            .ok_or_else(|| self.new_type_error("SpeciesConstructor did not return an object"))?;
+        V8Types::object_as_constructor(&result)
+            .ok_or_else(|| self.new_type_error("SpeciesConstructor did not return a constructor"))
     }
 
     fn get_function_realm(&mut self, function: &V8Object) -> Completion<V8Realm, V8Types> {
@@ -1871,7 +2051,7 @@ impl ExecutionContext<V8Types> for V8Engine {
             return Err(self.new_type_error("function belongs to a different V8 isolate"));
         }
         let isolate_id = self.isolate_id;
-        v8_engine_scope_with_context!(scope, self, &self.realm.context, {
+        v8_engine_scope_with_context!(scope, self, &self.realm_state.realm.context, {
             let function = local_object(scope, isolate_id, function)?;
             let context = function.get_creation_context(scope).ok_or_else(|| {
                 caught_exception(scope, isolate_id, None, "function has no creation context")
@@ -1887,7 +2067,7 @@ impl ExecutionContext<V8Types> for V8Engine {
         &mut self,
         object: V8Value,
         kind: IteratorKind,
-        method: Option<V8Object>,
+        method: Option<V8Function>,
     ) -> Completion<IteratorRecord<V8Types>, V8Types> {
         let method = match method {
             Some(method) => method,
@@ -1901,7 +2081,7 @@ impl ExecutionContext<V8Types> for V8Engine {
                     .ok_or_else(|| self.new_type_error("value is not iterable"))?
             }
         };
-        let iterator_value = EcmascriptHost::call(self, &method, &object, &[])?;
+        let iterator_value = EcmascriptHost::call(self, &method.0, &object, &[])?;
         let iterator = V8Types::value_as_object(&iterator_value)
             .ok_or_else(|| self.new_type_error("iterator method did not return an object"))?;
         let next = self
@@ -1919,7 +2099,7 @@ impl ExecutionContext<V8Types> for V8Engine {
         iterator: &mut IteratorRecord<V8Types>,
     ) -> Completion<Option<V8Value>, V8Types> {
         let this_value = iterator.iterator.0.clone();
-        let result = EcmascriptHost::call(self, &iterator.next_method, &this_value, &[])?;
+        let result = EcmascriptHost::call(self, &iterator.next_method.0, &this_value, &[])?;
         let result_object = V8Types::value_as_object(&result)
             .ok_or_else(|| self.new_type_error("iterator result is not an object"))?;
         let done = ExecutionContext::get(
@@ -1943,7 +2123,7 @@ impl ExecutionContext<V8Types> for V8Engine {
         if let Some(return_method) =
             self.get_method(iterator_value.clone(), self.property_key_from_str("return"))?
         {
-            let close_result = EcmascriptHost::call(self, &return_method, &iterator_value, &[])?;
+            let close_result = EcmascriptHost::call(self, &return_method.0, &iterator_value, &[])?;
             if V8Types::value_as_object(&close_result).is_none() {
                 return Err(self.new_type_error("iterator return method did not return an object"));
             }
@@ -1960,11 +2140,11 @@ impl ExecutionContext<V8Types> for V8Engine {
     }
 
     fn current_realm(&self) -> V8Realm {
-        self.realm.clone()
+        self.realm_state.realm.clone()
     }
 
     fn realm_global_object(&self) -> V8Object {
-        self.realm_global.clone()
+        self.realm_state.realm_global.borrow().clone()
     }
 
     fn realm_intrinsics(&self, realm: &V8Realm) -> RealmIntrinsics<V8Types> {
@@ -1972,14 +2152,19 @@ impl ExecutionContext<V8Types> for V8Engine {
             realm.isolate_id, self.isolate_id,
             "realm belongs to a different V8 isolate"
         );
-        self.intrinsics
+        self.state_for_realm(realm)
+            .unwrap_or_else(|| Rc::clone(&self.realm_state))
+            .intrinsics
             .as_ref()
             .expect("V8 intrinsics are not initialized")
             .clone()
     }
 
     fn enqueue_job(&mut self, job: Box<dyn FnOnce()>) {
-        self.queued_jobs.push_back(QueuedJob::Plain(job));
+        self.shared_isolate
+            .queued_jobs
+            .borrow_mut()
+            .push_back(QueuedJob::Plain(Rc::clone(&self.realm_state), job));
     }
 
     fn enqueue_job_with_realm(
@@ -1987,7 +2172,17 @@ impl ExecutionContext<V8Types> for V8Engine {
         realm: V8Realm,
         job: Box<dyn FnOnce(&mut dyn ExecutionContext<V8Types>)>,
     ) {
-        self.queued_jobs.push_back(QueuedJob::WithRealm(realm, job));
+        assert_eq!(
+            realm.isolate_id, self.isolate_id,
+            "queued job realm belongs to a different V8 isolate"
+        );
+        let realm_state = self
+            .state_for_realm(&realm)
+            .unwrap_or_else(|| Rc::clone(&self.realm_state));
+        self.shared_isolate
+            .queued_jobs
+            .borrow_mut()
+            .push_back(QueuedJob::WithRealm(realm_state, job));
     }
 
     fn run_jobs(&mut self) {
@@ -1996,8 +2191,9 @@ impl ExecutionContext<V8Types> for V8Engine {
         }
     }
 
-    fn is_detached_buffer(&self, array_buffer: &V8Object) -> bool {
+    fn is_detached_buffer(&self, array_buffer: &V8ArrayBuffer) -> bool {
         array_buffer
+            .0
             .0
             .object_profile
             .as_ref()
@@ -2005,8 +2201,9 @@ impl ExecutionContext<V8Types> for V8Engine {
             .is_some_and(|state| state.detached.get())
     }
 
-    fn is_fixed_length_array_buffer(&self, array_buffer: &V8Object) -> bool {
+    fn is_fixed_length_array_buffer(&self, array_buffer: &V8ArrayBuffer) -> bool {
         array_buffer
+            .0
             .0
             .object_profile
             .as_ref()
@@ -2016,10 +2213,10 @@ impl ExecutionContext<V8Types> for V8Engine {
 
     fn allocate_array_buffer(
         &mut self,
-        _constructor: V8Object,
+        _constructor: V8Constructor,
         byte_length: u64,
         max_byte_length: Option<u64>,
-    ) -> Completion<V8Object, V8Types> {
+    ) -> Completion<V8ArrayBuffer, V8Types> {
         if let Some(max_byte_length) = max_byte_length {
             let byte_length = self.value_from_number(byte_length as f64);
             let max_byte_length = self.value_from_number(max_byte_length as f64);
@@ -2027,29 +2224,30 @@ impl ExecutionContext<V8Types> for V8Engine {
                 "(length, maxByteLength) => new ArrayBuffer(length, { maxByteLength })",
                 &[byte_length, max_byte_length],
             )?;
-            return V8Types::value_as_object(&value)
+            let object = V8Types::value_as_object(&value)
+                .ok_or_else(|| self.new_type_error("ArrayBuffer allocation failed"))?;
+            return V8Types::object_as_array_buffer(&object)
                 .ok_or_else(|| self.new_type_error("ArrayBuffer allocation failed"));
         }
         let isolate_id = self.isolate_id;
         let byte_length = usize::try_from(byte_length)
             .map_err(|_| self.new_range_error("ArrayBuffer length is too large"))?;
-        v8_engine_scope_with_context!(scope, self, &self.realm.context, {
+        v8_engine_scope_with_context!(scope, self, &self.realm_state.realm.context, {
             let array_buffer = v8::ArrayBuffer::new(scope, byte_length);
-            Ok(V8Object(wrap_local_value(
-                scope,
-                isolate_id,
-                array_buffer.into(),
-            )))
+            let object =
+                object_from_wrapped_value(wrap_local_value(scope, isolate_id, array_buffer.into()));
+            V8Types::object_as_array_buffer(&object)
+                .ok_or_else(|| self.new_type_error("ArrayBuffer allocation failed"))
         })
     }
 
     fn clone_array_buffer(
         &mut self,
-        source: V8Object,
+        source: V8ArrayBuffer,
         source_byte_offset: u64,
         source_length: u64,
-        constructor: V8Object,
-    ) -> Completion<V8Object, V8Types> {
+        constructor: V8Constructor,
+    ) -> Completion<V8ArrayBuffer, V8Types> {
         let bytes = self
             .array_buffer_data(&source)
             .ok_or_else(|| self.new_type_error("source ArrayBuffer is detached"))?;
@@ -2065,6 +2263,7 @@ impl ExecutionContext<V8Types> for V8Engine {
             ExecutionContext::allocate_array_buffer(self, constructor, source_length, None)?;
         let state = clone
             .0
+            .0
             .object_profile
             .as_ref()
             .and_then(|profile| profile.array_buffer_state.as_ref())
@@ -2077,15 +2276,12 @@ impl ExecutionContext<V8Types> for V8Engine {
 
     fn detach_array_buffer(
         &mut self,
-        array_buffer: V8Object,
+        array_buffer: V8ArrayBuffer,
         key: Option<V8Value>,
     ) -> Completion<(), V8Types> {
         let isolate_id = self.isolate_id;
-        v8_engine_scope_with_context!(scope, self, &self.realm.context, {
-            let value = local_value(scope, isolate_id, &array_buffer.0)?;
-            let local = v8::Local::<v8::ArrayBuffer>::try_from(value).map_err(|_| {
-                caught_exception(scope, isolate_id, None, "value is not an ArrayBuffer")
-            })?;
+        v8_engine_scope_with_context!(scope, self, &self.realm_state.realm.context, {
+            let local = local_typed_object(scope, isolate_id, &array_buffer.0, &array_buffer.1)?;
             let key = key
                 .as_ref()
                 .map(|key| local_value(scope, isolate_id, key))
@@ -2093,6 +2289,7 @@ impl ExecutionContext<V8Types> for V8Engine {
             match local.detach(key) {
                 Some(true) => {
                     if let Some(state) = array_buffer
+                        .0
                         .0
                         .object_profile
                         .as_ref()
@@ -2114,7 +2311,7 @@ impl ExecutionContext<V8Types> for V8Engine {
 
     fn get_value_from_buffer(
         &mut self,
-        array_buffer: &V8Object,
+        array_buffer: &V8ArrayBuffer,
         byte_index: u64,
         element_type: TypedArrayElementType,
         _is_typed_array: bool,
@@ -2137,14 +2334,14 @@ impl ExecutionContext<V8Types> for V8Engine {
         let byte_index = self.value_from_number(byte_index as f64);
         self.call_js_helper(
             &format!("(buffer, offset) => new {constructor}(buffer, offset, 1)[0]"),
-            &[array_buffer.0.clone(), byte_index],
+            &[array_buffer.0.0.clone(), byte_index],
         )
         .unwrap_or_else(|exception| exception)
     }
 
     fn set_value_in_buffer(
         &mut self,
-        array_buffer: &V8Object,
+        array_buffer: &V8ArrayBuffer,
         byte_index: u64,
         element_type: TypedArrayElementType,
         value: V8Value,
@@ -2170,36 +2367,47 @@ impl ExecutionContext<V8Types> for V8Engine {
             &format!(
                 "(buffer, offset, value) => {{ new {constructor}(buffer, offset, 1)[0] = value; }}"
             ),
-            &[array_buffer.0.clone(), byte_index, value],
+            &[array_buffer.0.0.clone(), byte_index, value],
         )?;
         Ok(())
     }
 
-    fn typed_array_buffer(&mut self, typed_array: &V8Object) -> Completion<V8Object, V8Types> {
-        let value =
-            self.call_js_helper("view => view.buffer", std::slice::from_ref(&typed_array.0))?;
-        V8Types::value_as_object(&value)
+    fn typed_array_buffer(
+        &mut self,
+        typed_array: &V8TypedArray,
+    ) -> Completion<V8ArrayBuffer, V8Types> {
+        let value = self.call_js_helper(
+            "view => view.buffer",
+            std::slice::from_ref(&typed_array.0.0),
+        )?;
+        let object = V8Types::value_as_object(&value)
+            .ok_or_else(|| self.new_type_error("typed array has no ArrayBuffer"))?;
+        V8Types::object_as_array_buffer(&object)
             .ok_or_else(|| self.new_type_error("typed array has no ArrayBuffer"))
     }
 
-    fn typed_array_byte_offset(&mut self, typed_array: &V8Object) -> Completion<u64, V8Types> {
+    fn typed_array_byte_offset(&mut self, typed_array: &V8TypedArray) -> Completion<u64, V8Types> {
         let value = self.call_js_helper(
             "view => view.byteOffset",
-            std::slice::from_ref(&typed_array.0),
+            std::slice::from_ref(&typed_array.0.0),
         )?;
         Ok(V8Types::value_as_number(&value).unwrap_or(0.0) as u64)
     }
 
-    fn typed_array_byte_length(&mut self, typed_array: &V8Object) -> Completion<u64, V8Types> {
+    fn typed_array_byte_length(&mut self, typed_array: &V8TypedArray) -> Completion<u64, V8Types> {
         let value = self.call_js_helper(
             "view => view.byteLength",
-            std::slice::from_ref(&typed_array.0),
+            std::slice::from_ref(&typed_array.0.0),
         )?;
         Ok(V8Types::value_as_number(&value).unwrap_or(0.0) as u64)
     }
 
-    fn typed_array_element_type(&self, typed_array: &V8Object) -> Option<TypedArrayElementType> {
+    fn typed_array_element_type(
+        &self,
+        typed_array: &V8TypedArray,
+    ) -> Option<TypedArrayElementType> {
         typed_array
+            .0
             .0
             .object_profile
             .as_ref()
@@ -2209,10 +2417,10 @@ impl ExecutionContext<V8Types> for V8Engine {
     fn construct_typed_array_view(
         &mut self,
         element_type: TypedArrayElementType,
-        buffer: V8Object,
+        buffer: V8ArrayBuffer,
         byte_offset: u64,
         byte_length: u64,
-    ) -> Completion<V8Object, V8Types> {
+    ) -> Completion<V8TypedArray, V8Types> {
         let isolate_id = self.isolate_id;
         let byte_offset = usize::try_from(byte_offset)
             .map_err(|_| self.new_range_error("typed array byte offset is too large"))?;
@@ -2235,11 +2443,8 @@ impl ExecutionContext<V8Types> for V8Engine {
         }
         let length = usize::try_from(byte_length / element_size)
             .map_err(|_| self.new_range_error("typed array length is too large"))?;
-        v8_engine_scope_with_context!(scope, self, &self.realm.context, {
-            let buffer_value = local_value(scope, isolate_id, &buffer.0)?;
-            let buffer = v8::Local::<v8::ArrayBuffer>::try_from(buffer_value).map_err(|_| {
-                caught_exception(scope, isolate_id, None, "value is not an ArrayBuffer")
-            })?;
+        v8_engine_scope_with_context!(scope, self, &self.realm_state.realm.context, {
+            let buffer = local_typed_object(scope, isolate_id, &buffer.0, &buffer.1)?;
             if element_type == TypedArrayElementType::Float16 {
                 return Err(caught_exception(
                     scope,
@@ -2287,60 +2492,61 @@ impl ExecutionContext<V8Types> for V8Engine {
             let view = view.ok_or_else(|| {
                 caught_exception(scope, isolate_id, None, "typed array construction failed")
             })?;
-            Ok(V8Object(wrap_local_value(scope, isolate_id, view)))
+            let object = object_from_wrapped_value(wrap_local_value(scope, isolate_id, view));
+            V8Types::object_as_typed_array(&object)
+                .ok_or_else(|| self.new_type_error("typed array construction failed"))
         })
     }
 
-    fn data_view_buffer(&mut self, data_view: &V8Object) -> Completion<V8Object, V8Types> {
+    fn data_view_buffer(&mut self, data_view: &V8DataView) -> Completion<V8ArrayBuffer, V8Types> {
         let value =
-            self.call_js_helper("view => view.buffer", std::slice::from_ref(&data_view.0))?;
-        V8Types::value_as_object(&value)
+            self.call_js_helper("view => view.buffer", std::slice::from_ref(&data_view.0.0))?;
+        let object = V8Types::value_as_object(&value)
+            .ok_or_else(|| self.new_type_error("DataView has no ArrayBuffer"))?;
+        V8Types::object_as_array_buffer(&object)
             .ok_or_else(|| self.new_type_error("DataView has no ArrayBuffer"))
     }
 
-    fn data_view_byte_offset(&mut self, data_view: &V8Object) -> Completion<u64, V8Types> {
+    fn data_view_byte_offset(&mut self, data_view: &V8DataView) -> Completion<u64, V8Types> {
         let value = self.call_js_helper(
             "view => view.byteOffset",
-            std::slice::from_ref(&data_view.0),
+            std::slice::from_ref(&data_view.0.0),
         )?;
         Ok(V8Types::value_as_number(&value).unwrap_or(0.0) as u64)
     }
 
-    fn data_view_byte_length(&mut self, data_view: &V8Object) -> Completion<u64, V8Types> {
+    fn data_view_byte_length(&mut self, data_view: &V8DataView) -> Completion<u64, V8Types> {
         let value = self.call_js_helper(
             "view => view.byteLength",
-            std::slice::from_ref(&data_view.0),
+            std::slice::from_ref(&data_view.0.0),
         )?;
         Ok(V8Types::value_as_number(&value).unwrap_or(0.0) as u64)
     }
 
     fn construct_data_view_from_buffer(
         &mut self,
-        buffer: V8Object,
+        buffer: V8ArrayBuffer,
         byte_offset: u64,
         byte_length: u64,
-    ) -> Completion<V8Object, V8Types> {
+    ) -> Completion<V8DataView, V8Types> {
         let isolate_id = self.isolate_id;
         let byte_offset = usize::try_from(byte_offset)
             .map_err(|_| self.new_range_error("DataView byte offset is too large"))?;
         let byte_length = usize::try_from(byte_length)
             .map_err(|_| self.new_range_error("DataView byte length is too large"))?;
-        v8_engine_scope_with_context!(scope, self, &self.realm.context, {
-            let buffer = local_value(scope, isolate_id, &buffer.0)?;
-            let buffer = v8::Local::<v8::ArrayBuffer>::try_from(buffer).map_err(|_| {
-                caught_exception(scope, isolate_id, None, "value is not an ArrayBuffer")
-            })?;
+        v8_engine_scope_with_context!(scope, self, &self.realm_state.realm.context, {
+            let buffer = local_typed_object(scope, isolate_id, &buffer.0, &buffer.1)?;
             let data_view = v8::DataView::new(scope, buffer, byte_offset, byte_length);
-            Ok(V8Object(wrap_local_value(
-                scope,
-                isolate_id,
-                data_view.into(),
-            )))
+            let object =
+                object_from_wrapped_value(wrap_local_value(scope, isolate_id, data_view.into()));
+            V8Types::object_as_data_view(&object)
+                .ok_or_else(|| self.new_type_error("DataView construction failed"))
         })
     }
 
-    fn array_buffer_data(&self, array_buffer: &V8Object) -> Option<Vec<u8>> {
+    fn array_buffer_data(&self, array_buffer: &V8ArrayBuffer) -> Option<Vec<u8>> {
         let state = array_buffer
+            .0
             .0
             .object_profile
             .as_ref()?
@@ -2373,10 +2579,10 @@ impl ExecutionContext<V8Types> for V8Engine {
         self.to_rust_string(value)
     }
 
-    fn map_get_entries(&mut self, map: &V8Object) -> Completion<Vec<(V8Value, V8Value)>, V8Types> {
+    fn map_get_entries(&mut self, map: &V8Map) -> Completion<Vec<(V8Value, V8Value)>, V8Types> {
         let entries = self.call_js_helper(
             "map => Array.from(map.entries()).flat()",
-            std::slice::from_ref(&map.0),
+            std::slice::from_ref(&map.0.0),
         )?;
         let entries = V8Types::value_as_object(&entries)
             .ok_or_else(|| self.new_type_error("Map entries did not produce an array"))?;
@@ -2395,21 +2601,21 @@ impl ExecutionContext<V8Types> for V8Engine {
 
     fn map_set_entry(
         &mut self,
-        map: &V8Object,
+        map: &V8Map,
         key: V8Value,
         value: V8Value,
     ) -> Completion<(), V8Types> {
         self.call_js_helper(
             "(map, key, value) => { map.set(key, value); }",
-            &[map.0.clone(), key, value],
+            &[map.0.0.clone(), key, value],
         )?;
         Ok(())
     }
 
-    fn set_get_values(&mut self, set: &V8Object) -> Completion<Vec<V8Value>, V8Types> {
+    fn set_get_values(&mut self, set: &V8Set) -> Completion<Vec<V8Value>, V8Types> {
         let values = self.call_js_helper(
             "set => Array.from(set.values())",
-            std::slice::from_ref(&set.0),
+            std::slice::from_ref(&set.0.0),
         )?;
         let values = V8Types::value_as_object(&values)
             .ok_or_else(|| self.new_type_error("Set values did not produce an array"))?;
@@ -2427,34 +2633,36 @@ impl ExecutionContext<V8Types> for V8Engine {
         Ok(result)
     }
 
-    fn set_add_entry(&mut self, set: &V8Object, value: V8Value) -> Completion<(), V8Types> {
+    fn set_add_entry(&mut self, set: &V8Set, value: V8Value) -> Completion<(), V8Types> {
         self.call_js_helper(
             "(set, value) => { set.add(value); }",
-            &[set.0.clone(), value],
+            &[set.0.0.clone(), value],
         )?;
         Ok(())
     }
 
     fn promise_resolve(
         &mut self,
-        constructor: V8Object,
+        constructor: V8Constructor,
         value: V8Value,
-    ) -> Completion<V8Object, V8Types> {
+    ) -> Completion<V8Promise, V8Types> {
         let promise = self.call_js_helper(
             "(constructor, value) => Promise.resolve.call(constructor, value)",
-            &[constructor.0, value],
+            &[constructor.0.0, value],
         )?;
-        V8Types::value_as_object(&promise)
+        let object = V8Types::value_as_object(&promise)
+            .ok_or_else(|| self.new_type_error("PromiseResolve did not return a promise"))?;
+        V8Types::object_as_promise(&object)
             .ok_or_else(|| self.new_type_error("PromiseResolve did not return a promise"))
     }
 
     fn new_promise_capability(
         &mut self,
-        constructor: V8Object,
+        constructor: V8Constructor,
     ) -> Completion<PromiseCapability<V8Types>, V8Types> {
         let parts = self.call_js_helper(
             "constructor => { let resolve, reject; const promise = new constructor((res, rej) => { resolve = res; reject = rej; }); return [promise, resolve, reject]; }",
-            &[constructor.0],
+            &[constructor.0.0],
         )?;
         let parts = V8Types::value_as_object(&parts)
             .ok_or_else(|| self.new_type_error("promise capability did not produce an array"))?;
@@ -2475,50 +2683,141 @@ impl ExecutionContext<V8Types> for V8Engine {
     }
 
     fn new_promise_pending(&mut self) -> Completion<(V8Value, PromiseResolvers<V8Types>), V8Types> {
-        let promise_constructor = self.realm_intrinsics(&self.realm).promise;
+        let realm = self.realm_state.realm.clone();
+        let promise_constructor = self.realm_intrinsics(&realm).promise;
         let capability = self.new_promise_capability(promise_constructor)?;
         let promise = capability.promise;
         let resolve = capability.resolve;
         let reject = capability.reject;
-        let resolvers = PromiseResolvers::new(resolve, reject, self);
+        let resolvers = PromiseResolvers::new(resolve.0, reject.0, self);
         Ok((promise, resolvers))
     }
 
     fn perform_promise_then(
         &mut self,
-        promise: V8Object,
-        on_fulfilled: Option<V8Object>,
-        on_rejected: Option<V8Object>,
+        promise: V8Promise,
+        on_fulfilled: Option<V8Function>,
+        on_rejected: Option<V8Function>,
         result_capability: Option<PromiseCapability<V8Types>>,
     ) -> Completion<V8Value, V8Types> {
-        let undefined = self.value_undefined();
-        let on_fulfilled = on_fulfilled.map_or_else(|| undefined.clone(), |function| function.0);
-        let on_rejected = on_rejected.map_or(undefined, |function| function.0);
-        if let Some(result_capability) = result_capability {
-            return self.call_js_helper(
-                "(promise, onFulfilled, onRejected, resultPromise, resolve, reject) => { promise.then(value => { try { resolve(onFulfilled === undefined ? value : onFulfilled(value)); } catch (error) { reject(error); } }, reason => { if (onRejected === undefined) { reject(reason); return; } try { resolve(onRejected(reason)); } catch (error) { reject(error); } }); return resultPromise; }",
-                &[
-                    promise.0,
-                    on_fulfilled,
-                    on_rejected,
-                    result_capability.promise,
-                    result_capability.resolve.0,
-                    result_capability.reject.0,
-                ],
-            );
-        }
-        self.call_js_helper(
-            "(promise, onFulfilled, onRejected) => promise.then(onFulfilled, onRejected)",
-            &[promise.0, on_fulfilled, on_rejected],
-        )
+        let returned_promise = result_capability
+            .as_ref()
+            .map(|capability| capability.promise.clone());
+        let fulfilled_capability = result_capability
+            .as_ref()
+            .map(|capability| (capability.resolve.clone(), capability.reject.clone()));
+        let rejected_capability = result_capability
+            .as_ref()
+            .map(|capability| (capability.resolve.clone(), capability.reject.clone()));
+        let empty_name = self.property_key_from_str("");
+
+        let fulfilled_handler = self.make_builtin_function(
+            Box::new(move |arguments, _this, execution_context| {
+                let value = arguments
+                    .first()
+                    .cloned()
+                    .unwrap_or_else(|| execution_context.value_undefined());
+                let completion = if let Some(on_fulfilled) = &on_fulfilled {
+                    let undefined = execution_context.value_undefined();
+                    execution_context.call(&on_fulfilled.0, &undefined, &[value])
+                } else {
+                    Ok(value)
+                };
+                let Some((resolve, reject)) = &fulfilled_capability else {
+                    return completion;
+                };
+                let undefined = execution_context.value_undefined();
+                match completion {
+                    Ok(value) => match execution_context.call(&resolve.0, &undefined, &[value]) {
+                        Ok(_) => Ok(undefined),
+                        Err(exception) => {
+                            execution_context.call(&reject.0, &undefined, &[exception])?;
+                            Ok(undefined)
+                        }
+                    },
+                    Err(exception) => {
+                        execution_context.call(&reject.0, &undefined, &[exception])?;
+                        Ok(undefined)
+                    }
+                }
+            }),
+            1,
+            empty_name.clone(),
+            false,
+        );
+        let rejected_handler = self.make_builtin_function(
+            Box::new(move |arguments, _this, execution_context| {
+                let reason = arguments
+                    .first()
+                    .cloned()
+                    .unwrap_or_else(|| execution_context.value_undefined());
+                let completion = if let Some(on_rejected) = &on_rejected {
+                    let undefined = execution_context.value_undefined();
+                    execution_context.call(&on_rejected.0, &undefined, &[reason])
+                } else {
+                    Err(reason)
+                };
+                let Some((resolve, reject)) = &rejected_capability else {
+                    return completion;
+                };
+                let undefined = execution_context.value_undefined();
+                match completion {
+                    Ok(value) => match execution_context.call(&resolve.0, &undefined, &[value]) {
+                        Ok(_) => Ok(undefined),
+                        Err(exception) => {
+                            execution_context.call(&reject.0, &undefined, &[exception])?;
+                            Ok(undefined)
+                        }
+                    },
+                    Err(exception) => {
+                        execution_context.call(&reject.0, &undefined, &[exception])?;
+                        Ok(undefined)
+                    }
+                }
+            }),
+            1,
+            empty_name,
+            false,
+        );
+
+        let _current_engine = CurrentEngineGuard::enter(self);
+        let isolate_id = self.isolate_id;
+        v8_engine_scope_with_context!(scope, self, &self.realm_state.realm.context, {
+            v8::tc_scope!(let try_catch, scope);
+            let promise = local_typed_object(try_catch, isolate_id, &promise.0, &promise.1)?;
+            let fulfilled_handler = local_typed_object(
+                try_catch,
+                isolate_id,
+                &fulfilled_handler.0,
+                &fulfilled_handler.1,
+            )?;
+            let rejected_handler = local_typed_object(
+                try_catch,
+                isolate_id,
+                &rejected_handler.0,
+                &rejected_handler.1,
+            )?;
+            let Some(derived_promise) =
+                promise.then2(try_catch, fulfilled_handler, rejected_handler)
+            else {
+                return Err(caught!(
+                    try_catch,
+                    isolate_id,
+                    "failed to register promise reactions"
+                ));
+            };
+            Ok(returned_promise
+                .unwrap_or_else(|| wrap_local_value(try_catch, isolate_id, derived_promise.into())))
+        })
     }
 
     fn promise_state(&mut self, promise: &V8Object) -> Completion<PromiseState<V8Types>, V8Types> {
         let isolate_id = self.isolate_id;
-        v8_engine_scope_with_context!(scope, self, &self.realm.context, {
-            let promise_value = local_value(scope, isolate_id, &promise.0)?;
-            let promise = v8::Local::<v8::Promise>::try_from(promise_value)
-                .map_err(|_| caught_exception(scope, isolate_id, None, "value is not a Promise"))?;
+        v8_engine_scope_with_context!(scope, self, &self.realm_state.realm.context, {
+            let promise = V8Types::object_as_promise(promise).ok_or_else(|| {
+                caught_exception(scope, isolate_id, None, "value is not a Promise")
+            })?;
+            let promise = local_typed_object(scope, isolate_id, &promise.0, &promise.1)?;
             match promise.state() {
                 v8::PromiseState::Pending => Ok(PromiseState::Pending),
                 v8::PromiseState::Fulfilled => {
@@ -2539,14 +2838,14 @@ impl ExecutionContext<V8Types> for V8Engine {
 
     fn generator_start(
         &mut self,
-        _generator: V8Object,
-        _closure: V8Object,
+        _generator: V8Generator,
+        _closure: V8Function,
     ) -> Completion<(), V8Types> {
         Ok(())
     }
 
     fn global_object(&self) -> V8Object {
-        self.realm_global.clone()
+        self.realm_state.realm_global.borrow().clone()
     }
 
     fn property_key_from_str(&self, string: &str) -> V8PropertyKey {
@@ -2563,7 +2862,7 @@ impl ExecutionContext<V8Types> for V8Engine {
 
     fn value_from_property_key(&mut self, key: V8PropertyKey) -> V8Value {
         let isolate_id = self.isolate_id;
-        v8_engine_scope_with_context!(scope, self, &self.realm.context, {
+        v8_engine_scope_with_context!(scope, self, &self.realm_state.realm.context, {
             match local_property_key(scope, isolate_id, &key) {
                 Ok(value) => wrap_local_value(scope, isolate_id, value),
                 Err(error) => error,
@@ -2593,15 +2892,15 @@ impl ExecutionContext<V8Types> for V8Engine {
     }
 
     fn store_host_any(&mut self, id: TypeId, value: Box<dyn Any>) {
-        self.host_data.insert(id, value);
+        self.realm_host_data_mut().values.insert(id, value);
     }
 
     fn get_host_any(&self, id: &TypeId) -> Option<&dyn Any> {
-        self.host_data.get(id).map(Box::as_ref)
+        self.realm_host_data().values.get(id).map(Box::as_ref)
     }
 
     fn remove_host_any(&mut self, id: &TypeId) -> Option<Box<dyn Any>> {
-        self.host_data.remove(id)
+        self.realm_host_data_mut().values.remove(id)
     }
 
     fn create_object_with_any(
@@ -2610,7 +2909,7 @@ impl ExecutionContext<V8Types> for V8Engine {
         data: Box<dyn Any + 'static>,
     ) -> V8Object {
         let isolate_id = self.isolate_id;
-        v8_engine_scope_with_context!(scope, self, &self.realm.context, {
+        v8_engine_scope_with_context!(scope, self, &self.realm_state.realm.context, {
             let object_template = v8::ObjectTemplate::new(scope);
             object_template.set_internal_field_count(2);
             let object = object_template
@@ -2631,7 +2930,8 @@ impl ExecutionContext<V8Types> for V8Engine {
             assert!(object.set_internal_field(0, marker.into()));
             object.set_aligned_pointer_in_internal_field(1, record_pointer.cast(), HOST_OBJECT_TAG);
 
-            let value = V8Object(wrap_local_value(scope, isolate_id, object.into()));
+            let value =
+                object_from_wrapped_value(wrap_local_value(scope, isolate_id, object.into()));
             let weak = v8::Weak::with_guaranteed_finalizer(
                 scope,
                 object,
@@ -2645,7 +2945,10 @@ impl ExecutionContext<V8Types> for V8Engine {
                     }
                 }),
             );
-            self.host_object_handles.push(weak);
+            self.shared_isolate
+                .host_object_handles
+                .borrow_mut()
+                .push(weak);
             value
         })
     }
@@ -2659,7 +2962,8 @@ impl ExecutionContext<V8Types> for V8Engine {
             let record = unsafe { &*pointer.cast::<HostObjectRecord>().as_ptr() };
             return Some(record.data.as_ref());
         }
-        self.associated_objects
+        self.realm_host_data()
+            .associated_objects
             .iter()
             .find(|(candidate, _)| candidate == object)
             .map(|(_, data)| data.as_ref())
@@ -2674,7 +2978,8 @@ impl ExecutionContext<V8Types> for V8Engine {
             let record = unsafe { &mut *pointer.cast::<HostObjectRecord>().as_ptr() };
             return Some(record.data.as_mut());
         }
-        self.associated_objects
+        self.realm_host_data_mut()
+            .associated_objects
             .iter_mut()
             .find(|(candidate, _)| candidate == object)
             .map(|(_, data)| data.as_mut())
@@ -2693,7 +2998,8 @@ impl ExecutionContext<V8Types> for V8Engine {
             let record = unsafe { &mut *pointer.cast::<HostObjectRecord>().as_ptr() };
             Some(record.data.as_mut())
         } else {
-            self.associated_objects
+            self.realm_host_data_mut()
+                .associated_objects
                 .iter_mut()
                 .find(|(candidate, _)| candidate == object)
                 .map(|(_, data)| data.as_mut() as *mut dyn Any)
@@ -2709,7 +3015,7 @@ impl ExecutionContext<V8Types> for V8Engine {
 
     fn new_type_error(&mut self, message: &str) -> V8Value {
         let isolate_id = self.isolate_id;
-        v8_engine_scope_with_context!(scope, self, &self.realm.context, {
+        v8_engine_scope_with_context!(scope, self, &self.realm_state.realm.context, {
             let message =
                 v8::String::new(scope, message).expect("V8 TypeError message allocation failed");
             let exception = v8::Exception::type_error(scope, message);
@@ -2719,7 +3025,7 @@ impl ExecutionContext<V8Types> for V8Engine {
 
     fn new_range_error(&mut self, message: &str) -> V8Value {
         let isolate_id = self.isolate_id;
-        v8_engine_scope_with_context!(scope, self, &self.realm.context, {
+        v8_engine_scope_with_context!(scope, self, &self.realm_state.realm.context, {
             let message =
                 v8::String::new(scope, message).expect("V8 RangeError message allocation failed");
             let exception = v8::Exception::range_error(scope, message);
@@ -2729,7 +3035,7 @@ impl ExecutionContext<V8Types> for V8Engine {
 
     fn new_syntax_error(&mut self, message: &str) -> V8Value {
         let isolate_id = self.isolate_id;
-        v8_engine_scope_with_context!(scope, self, &self.realm.context, {
+        v8_engine_scope_with_context!(scope, self, &self.realm_state.realm.context, {
             let message =
                 v8::String::new(scope, message).expect("V8 SyntaxError message allocation failed");
             let exception = v8::Exception::syntax_error(scope, message);
@@ -2743,13 +3049,17 @@ impl ExecutionContext<V8Types> for V8Engine {
         handler: V8Object,
     ) -> Completion<V8Object, V8Types> {
         let isolate_id = self.isolate_id;
-        v8_engine_scope_with_context!(scope, self, &self.realm.context, {
+        v8_engine_scope_with_context!(scope, self, &self.realm_state.realm.context, {
             let target = local_object(scope, isolate_id, &target)?;
             let handler = local_object(scope, isolate_id, &handler)?;
             let proxy = v8::Proxy::new(scope, target, handler).ok_or_else(|| {
                 caught_exception(scope, isolate_id, None, "Proxy creation failed")
             })?;
-            Ok(V8Object(wrap_local_value(scope, isolate_id, proxy.into())))
+            Ok(object_from_wrapped_value(wrap_local_value(
+                scope,
+                isolate_id,
+                proxy.into(),
+            )))
         })
     }
 
@@ -2759,9 +3069,9 @@ impl ExecutionContext<V8Types> for V8Engine {
 
     fn create_empty_array(&mut self) -> V8Object {
         let isolate_id = self.isolate_id;
-        v8_engine_scope_with_context!(scope, self, &self.realm.context, {
+        v8_engine_scope_with_context!(scope, self, &self.realm_state.realm.context, {
             let array = v8::Array::new(scope, 0);
-            V8Object(wrap_local_value(scope, isolate_id, array.into()))
+            object_from_wrapped_value(wrap_local_value(scope, isolate_id, array.into()))
         })
     }
 
@@ -2775,7 +3085,7 @@ impl ExecutionContext<V8Types> for V8Engine {
 
     fn create_plain_object(&mut self, prototype: Option<&V8Object>) -> V8Object {
         let isolate_id = self.isolate_id;
-        v8_engine_scope_with_context!(scope, self, &self.realm.context, {
+        v8_engine_scope_with_context!(scope, self, &self.realm_state.realm.context, {
             let object = v8::Object::new(scope);
             if let Some(prototype) = prototype {
                 let prototype = local_value(scope, isolate_id, &prototype.0)
@@ -2784,7 +3094,7 @@ impl ExecutionContext<V8Types> for V8Engine {
                     .set_prototype(scope, prototype)
                     .expect("V8 failed to set plain-object prototype");
             }
-            V8Object(wrap_local_value(scope, isolate_id, object.into()))
+            object_from_wrapped_value(wrap_local_value(scope, isolate_id, object.into()))
         })
     }
 
@@ -2797,13 +3107,13 @@ impl ExecutionContext<V8Types> for V8Engine {
     }
 
     fn evaluate_script(&mut self, source: &str) -> Completion<V8Value, V8Types> {
-        let realm = self.realm.clone();
+        let realm = self.realm_state.realm.clone();
         JsEngine::evaluate_script(self, source, &realm)
     }
 
     fn value_from_bigint(&mut self, number: i64) -> V8Value {
         let isolate_id = self.isolate_id;
-        v8_engine_scope_with_context!(scope, self, &self.realm.context, {
+        v8_engine_scope_with_context!(scope, self, &self.realm_state.realm.context, {
             let bigint = v8::BigInt::new_from_i64(scope, number);
             wrap_local_value(scope, isolate_id, bigint.into())
         })
@@ -2818,7 +3128,7 @@ impl ExecutionContext<V8Types> for V8Engine {
         ) -> Completion<V8Value, V8Types>,
         length: u32,
         name: V8PropertyKey,
-    ) -> V8Object {
+    ) -> V8Function {
         self.make_builtin_function(Box::new(behaviour), length, name, false)
     }
 
@@ -2827,7 +3137,7 @@ impl ExecutionContext<V8Types> for V8Engine {
         behaviour: StoredBehaviour,
         length: u32,
         name: V8PropertyKey,
-    ) -> V8Object {
+    ) -> V8Function {
         self.make_builtin_function(behaviour, length, name, false)
     }
 
@@ -2837,26 +3147,106 @@ impl ExecutionContext<V8Types> for V8Engine {
         length: u32,
         name: V8PropertyKey,
         is_constructor: bool,
-    ) -> V8Object {
+    ) -> V8Function {
         self.make_builtin_function(behaviour, length, name, is_constructor)
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use std::cell::Cell;
+    use std::any::TypeId;
+    use std::cell::{Cell, RefCell};
+    use std::ptr::from_ref;
     use std::rc::Rc;
+
+    use rusty_v8 as v8;
 
     use crate::{EcmascriptHost, ExecutionContext, JsTypes};
 
-    use super::{V8Engine, V8Types};
+    use super::super::{V8AsyncGenerator, V8WeakMap, V8WeakRef, V8WeakSet};
+    use super::{
+        CURRENT_CALLBACK_ISOLATE_ID, CURRENT_CALLBACK_SCOPE, V8ArrayBuffer, V8Constructor,
+        V8DataView, V8Engine, V8Function, V8Generator, V8Map, V8Object, V8Promise, V8Set,
+        V8SharedArrayBuffer, V8TypedArray, V8Types,
+    };
 
     struct DropFlag(Rc<Cell<bool>>);
+
+    struct RealmMarker(&'static str);
 
     impl Drop for DropFlag {
         fn drop(&mut self) {
             self.0.set(true);
         }
+    }
+
+    #[test]
+    fn object_categories_keep_distinct_strong_v8_handles() {
+        let type_ids = [
+            TypeId::of::<V8Object>(),
+            TypeId::of::<V8ArrayBuffer>(),
+            TypeId::of::<V8SharedArrayBuffer>(),
+            TypeId::of::<V8TypedArray>(),
+            TypeId::of::<V8DataView>(),
+            TypeId::of::<V8Promise>(),
+            TypeId::of::<V8Map>(),
+            TypeId::of::<V8Set>(),
+            TypeId::of::<V8WeakMap>(),
+            TypeId::of::<V8WeakSet>(),
+            TypeId::of::<V8WeakRef>(),
+            TypeId::of::<V8Generator>(),
+            TypeId::of::<V8AsyncGenerator>(),
+            TypeId::of::<V8Function>(),
+            TypeId::of::<V8Constructor>(),
+        ];
+        for (index, type_id) in type_ids.iter().enumerate() {
+            assert!(!type_ids[..index].contains(type_id));
+        }
+
+        let mut engine = V8Engine::new();
+        let mut evaluate_object = |source| {
+            let value = ExecutionContext::evaluate_script(&mut engine, source)
+                .expect("the typed V8 object must evaluate");
+            V8Types::value_as_object(&value).expect("the evaluated value must be an object")
+        };
+
+        let array_buffer = evaluate_object("new ArrayBuffer(8)");
+        let array_buffer = V8Types::object_as_array_buffer(&array_buffer)
+            .expect("ArrayBuffer must retain a Global<ArrayBuffer>");
+        let _: &v8::Global<v8::ArrayBuffer> = &array_buffer.1;
+
+        let shared_array_buffer = evaluate_object("new SharedArrayBuffer(8)");
+        let shared_array_buffer = V8Types::object_as_shared_array_buffer(&shared_array_buffer)
+            .expect("SharedArrayBuffer must retain a Global<SharedArrayBuffer>");
+        let _: &v8::Global<v8::SharedArrayBuffer> = &shared_array_buffer.1;
+
+        let typed_array = evaluate_object("new Uint8Array(8)");
+        let typed_array = V8Types::object_as_typed_array(&typed_array)
+            .expect("TypedArray must retain a Global<TypedArray>");
+        let _: &v8::Global<v8::TypedArray> = &typed_array.1;
+
+        let data_view = evaluate_object("new DataView(new ArrayBuffer(8))");
+        let data_view = V8Types::object_as_data_view(&data_view)
+            .expect("DataView must retain a Global<DataView>");
+        let _: &v8::Global<v8::DataView> = &data_view.1;
+
+        let promise = evaluate_object("Promise.resolve(1)");
+        let promise =
+            V8Types::object_as_promise(&promise).expect("Promise must retain a Global<Promise>");
+        let _: &v8::Global<v8::Promise> = &promise.1;
+
+        let map = evaluate_object("new Map()");
+        let map = V8Types::object_as_map(&map).expect("Map must retain a Global<Map>");
+        let _: &v8::Global<v8::Map> = &map.1;
+
+        let set = evaluate_object("new Set()");
+        let set = V8Types::object_as_set(&set).expect("Set must retain a Global<Set>");
+        let _: &v8::Global<v8::Set> = &set.1;
+
+        let function = evaluate_object("(function typedFunction() {})");
+        let function = V8Types::object_as_function(&function)
+            .expect("Function must retain a Global<Function>");
+        let _: &v8::Global<v8::Function> = &function.1;
     }
 
     #[test]
@@ -2909,7 +3299,7 @@ mod tests {
             callback_name.clone(),
             false,
         );
-        let callback_value = V8Types::value_from_object(callback);
+        let callback_value = V8Types::value_from_object(callback.0);
         let global = second_document_engine.realm_global_object();
         second_document_engine
             .create_data_property(global, callback_name, callback_value)
@@ -2924,6 +3314,329 @@ mod tests {
                 .expect("the callback result must be numeric"),
             7.0
         );
+    }
+
+    #[test]
+    fn sibling_contexts_use_the_shared_explicit_microtask_queue() {
+        let parent_engine = V8Engine::new();
+        let first_engine = parent_engine.new_child_realm();
+        let second_engine = parent_engine.new_child_realm();
+
+        assert!(Rc::ptr_eq(
+            &first_engine.shared_isolate,
+            &second_engine.shared_isolate
+        ));
+
+        let shared_queue = from_ref(&*first_engine.shared_isolate.microtask_queue);
+        let first_realm = first_engine.current_realm();
+        let first_queue =
+            v8_engine_scope_with_context!(scope, first_engine, &first_realm.context, {
+                let context = v8::Local::new(scope, &first_realm.context);
+                from_ref(context.get_microtask_queue())
+            });
+        let second_realm = second_engine.current_realm();
+        let second_queue =
+            v8_engine_scope_with_context!(scope, second_engine, &second_realm.context, {
+                let context = v8::Local::new(scope, &second_realm.context);
+                from_ref(context.get_microtask_queue())
+            });
+
+        assert_eq!(first_queue, shared_queue);
+        assert_eq!(second_queue, shared_queue);
+    }
+
+    #[test]
+    fn promise_callback_runs_with_its_creation_realm() {
+        let parent_engine = V8Engine::new();
+        let mut checkpoint_engine = parent_engine.new_child_realm();
+        let mut promise_engine = parent_engine.new_child_realm();
+        checkpoint_engine.store_host_any(
+            TypeId::of::<RealmMarker>(),
+            Box::new(RealmMarker("checkpoint")),
+        );
+        promise_engine.store_host_any(
+            TypeId::of::<RealmMarker>(),
+            Box::new(RealmMarker("promise")),
+        );
+
+        let promise_global = promise_engine.realm_global_object();
+        let expected_global = promise_global.clone();
+        let callback_used_creation_realm = Rc::new(Cell::new(false));
+        let callback_result = Rc::clone(&callback_used_creation_realm);
+        let callback_name = promise_engine.property_key_from_str("creationRealmCallback");
+        let callback = promise_engine.create_builtin_function(
+            Box::new(move |_arguments, _this, execution_context| {
+                let marker = execution_context
+                    .get_host_any(&TypeId::of::<RealmMarker>())
+                    .and_then(|data| data.downcast_ref::<RealmMarker>())
+                    .map(|marker| marker.0);
+                callback_result.set(
+                    execution_context.realm_global_object() == expected_global
+                        && marker == Some("promise"),
+                );
+                Ok(execution_context.value_undefined())
+            }),
+            0,
+            callback_name.clone(),
+            false,
+        );
+        promise_engine
+            .create_data_property(
+                promise_global,
+                callback_name,
+                V8Types::value_from_object(callback.0),
+            )
+            .expect("the promise callback must be installed");
+        ExecutionContext::evaluate_script(
+            &mut promise_engine,
+            "Promise.resolve().then(creationRealmCallback)",
+        )
+        .expect("the promise callback must be queued");
+
+        checkpoint_engine
+            .perform_a_microtask_checkpoint()
+            .expect("the sibling checkpoint must drain the shared queue");
+
+        assert!(callback_used_creation_realm.get());
+        assert_eq!(
+            checkpoint_engine
+                .get_host_any(&TypeId::of::<RealmMarker>())
+                .and_then(|data| data.downcast_ref::<RealmMarker>())
+                .map(|marker| marker.0),
+            Some("checkpoint")
+        );
+    }
+
+    #[test]
+    fn perform_promise_then_bypasses_a_patched_then_method() {
+        let mut engine = V8Engine::new();
+        let promise = ExecutionContext::evaluate_script(
+            &mut engine,
+            "globalThis.thenCalls = 0; const originalThen = Promise.prototype.then; Promise.prototype.then = function(...arguments) { thenCalls += 1; return originalThen.apply(this, arguments); }; Promise.resolve(42)",
+        )
+        .expect("the patched Promise and source promise must be created");
+        let promise =
+            V8Types::value_as_object(&promise).expect("the source value must be a Promise");
+        let promise =
+            V8Types::object_as_promise(&promise).expect("the source value must be a Promise");
+        let callback_called = Rc::new(Cell::new(false));
+        let callback_result = Rc::clone(&callback_called);
+        let callback_name = engine.property_key_from_str("promiseReaction");
+        let callback = engine.create_builtin_function(
+            Box::new(move |_arguments, _this, execution_context| {
+                callback_result.set(true);
+                Ok(execution_context.value_undefined())
+            }),
+            1,
+            callback_name,
+            false,
+        );
+
+        engine
+            .perform_promise_then(promise, Some(callback), None, None)
+            .expect("the direct V8 promise reaction must be registered");
+        engine
+            .perform_a_microtask_checkpoint()
+            .expect("the direct V8 promise reaction must run");
+        let then_calls = ExecutionContext::evaluate_script(&mut engine, "thenCalls")
+            .expect("the patched then call count must be readable");
+
+        assert!(callback_called.get());
+        assert_eq!(
+            engine
+                .to_number(then_calls)
+                .expect("the patched then call count must be numeric"),
+            0.0
+        );
+    }
+
+    #[test]
+    fn nested_cross_realm_callbacks_restore_each_previous_realm() {
+        let parent_engine = V8Engine::new();
+        let mut first_engine = parent_engine.new_child_realm();
+        let mut second_engine = parent_engine.new_child_realm();
+        first_engine.store_host_any(TypeId::of::<RealmMarker>(), Box::new(RealmMarker("first")));
+        second_engine.store_host_any(TypeId::of::<RealmMarker>(), Box::new(RealmMarker("second")));
+
+        let first_global = first_engine.realm_global_object();
+        let first_callback_global = first_global.clone();
+        let first_callback_used_first_realm = Rc::new(Cell::new(false));
+        let first_callback_result = Rc::clone(&first_callback_used_first_realm);
+        let first_callback_name = first_engine.property_key_from_str("firstRealmCallback");
+        let first_callback = first_engine.create_builtin_function(
+            Box::new(move |_arguments, _this, execution_context| {
+                let marker = execution_context
+                    .get_host_any(&TypeId::of::<RealmMarker>())
+                    .and_then(|data| data.downcast_ref::<RealmMarker>())
+                    .map(|marker| marker.0);
+                first_callback_result.set(
+                    execution_context.realm_global_object() == first_callback_global
+                        && marker == Some("first"),
+                );
+                panic!("intentional nested callback panic")
+            }),
+            0,
+            first_callback_name,
+            false,
+        );
+
+        let second_global = second_engine.realm_global_object();
+        let second_callback_global = second_global.clone();
+        let second_callback_restored = Rc::new(Cell::new(false));
+        let second_callback_result = Rc::clone(&second_callback_restored);
+        let second_callback_name = second_engine.property_key_from_str("secondRealmCallback");
+        let second_callback = second_engine.create_builtin_function(
+            Box::new(move |_arguments, _this, execution_context| {
+                let undefined = execution_context.value_undefined();
+                let inner_result = execution_context.call(&first_callback.0, &undefined, &[]);
+                assert!(inner_result.is_err());
+                let marker = execution_context
+                    .get_host_any(&TypeId::of::<RealmMarker>())
+                    .and_then(|data| data.downcast_ref::<RealmMarker>())
+                    .map(|marker| marker.0);
+                second_callback_result.set(
+                    execution_context.realm_global_object() == second_callback_global
+                        && marker == Some("second"),
+                );
+                Ok(execution_context.value_undefined())
+            }),
+            0,
+            second_callback_name.clone(),
+            false,
+        );
+        second_engine
+            .create_data_property(
+                second_global,
+                second_callback_name,
+                V8Types::value_from_object(second_callback.0),
+            )
+            .expect("the second callback must be installed");
+        ExecutionContext::evaluate_script(
+            &mut second_engine,
+            "Promise.resolve().then(secondRealmCallback)",
+        )
+        .expect("the nested callback must be queued");
+
+        first_engine
+            .perform_a_microtask_checkpoint()
+            .expect("the nested callbacks must complete");
+
+        assert!(first_callback_used_first_realm.get());
+        assert!(second_callback_restored.get());
+        assert_eq!(first_engine.realm_global_object(), first_global);
+    }
+
+    #[test]
+    fn rust_jobs_use_their_creation_realm_and_drain_until_stable() {
+        let parent_engine = V8Engine::new();
+        let mut checkpoint_engine = parent_engine.new_child_realm();
+        let mut promise_engine = parent_engine.new_child_realm();
+        promise_engine.store_host_any(
+            TypeId::of::<RealmMarker>(),
+            Box::new(RealmMarker("promise")),
+        );
+
+        let execution_steps = Rc::new(RefCell::new(Vec::new()));
+        let callback_steps = Rc::clone(&execution_steps);
+        let promise_global = promise_engine.realm_global_object();
+        let expected_global = promise_global.clone();
+        let callback_name = promise_engine.property_key_from_str("enqueueRealmJobs");
+        let callback = promise_engine.create_builtin_function(
+            Box::new(move |_arguments, _this, execution_context| {
+                callback_steps.borrow_mut().push("promise");
+                let first_job_steps = Rc::clone(&callback_steps);
+                let first_job_global = expected_global.clone();
+                let realm = execution_context.current_realm();
+                execution_context.enqueue_job_with_realm(
+                    realm,
+                    Box::new(move |job_context| {
+                        let marker = job_context
+                            .get_host_any(&TypeId::of::<RealmMarker>())
+                            .and_then(|data| data.downcast_ref::<RealmMarker>())
+                            .map(|marker| marker.0);
+                        assert_eq!(job_context.realm_global_object(), first_job_global);
+                        assert_eq!(marker, Some("promise"));
+                        first_job_steps.borrow_mut().push("first job");
+
+                        let second_job_steps = Rc::clone(&first_job_steps);
+                        let second_realm = job_context.current_realm();
+                        job_context.enqueue_job_with_realm(
+                            second_realm,
+                            Box::new(move |nested_job_context| {
+                                let marker = nested_job_context
+                                    .get_host_any(&TypeId::of::<RealmMarker>())
+                                    .and_then(|data| data.downcast_ref::<RealmMarker>())
+                                    .map(|marker| marker.0);
+                                assert_eq!(marker, Some("promise"));
+                                second_job_steps.borrow_mut().push("second job");
+                            }),
+                        );
+                    }),
+                );
+                Ok(execution_context.value_undefined())
+            }),
+            0,
+            callback_name.clone(),
+            false,
+        );
+        promise_engine
+            .create_data_property(
+                promise_global,
+                callback_name,
+                V8Types::value_from_object(callback.0),
+            )
+            .expect("the job callback must be installed");
+        ExecutionContext::evaluate_script(
+            &mut promise_engine,
+            "Promise.resolve().then(enqueueRealmJobs)",
+        )
+        .expect("the promise job must be queued");
+
+        checkpoint_engine
+            .perform_a_microtask_checkpoint()
+            .expect("the shared queues must drain until stable");
+
+        assert_eq!(
+            execution_steps.borrow().as_slice(),
+            ["promise", "first job", "second job"]
+        );
+    }
+
+    #[test]
+    fn queued_realm_state_survives_context_destruction_and_forced_gc() {
+        let mut parent_engine = V8Engine::new();
+        let mut child_engine = parent_engine.new_child_realm();
+        let realm_data_dropped = Rc::new(Cell::new(false));
+        child_engine.store_host_any(
+            TypeId::of::<DropFlag>(),
+            Box::new(DropFlag(Rc::clone(&realm_data_dropped))),
+        );
+        let job_ran = Rc::new(Cell::new(false));
+        let job_result = Rc::clone(&job_ran);
+        let child_realm = child_engine.current_realm();
+        child_engine.enqueue_job_with_realm(
+            child_realm,
+            Box::new(move |execution_context| {
+                assert!(
+                    execution_context
+                        .get_host_any(&TypeId::of::<DropFlag>())
+                        .and_then(|data| data.downcast_ref::<DropFlag>())
+                        .is_some()
+                );
+                job_result.set(true);
+            }),
+        );
+
+        drop(child_engine);
+        assert!(!realm_data_dropped.get());
+
+        parent_engine
+            .perform_a_microtask_checkpoint()
+            .expect("the queued child-realm job must remain valid");
+        parent_engine.gc();
+
+        assert!(job_ran.get());
+        assert!(realm_data_dropped.get());
     }
 
     #[test]
@@ -2946,7 +3659,7 @@ mod tests {
             callback_name.clone(),
             false,
         );
-        let callback_value = V8Types::value_from_object(callback);
+        let callback_value = V8Types::value_from_object(callback.0);
         let global = engine.realm_global_object();
         engine
             .create_data_property(global, callback_name, callback_value)
@@ -2977,7 +3690,7 @@ mod tests {
             callback_name.clone(),
             false,
         );
-        let callback_value = V8Types::value_from_object(callback);
+        let callback_value = V8Types::value_from_object(callback.0);
         let global = engine.realm_global_object();
         engine
             .create_data_property(global, callback_name, callback_value)
@@ -3021,8 +3734,9 @@ mod tests {
             .get_function_realm(&function)
             .expect("the function realm must be found");
 
-        assert_eq!(function_realm.isolate_id, child_engine.realm.isolate_id);
-        assert_eq!(function_realm.context, child_engine.realm.context);
+        let child_realm = child_engine.current_realm();
+        assert_eq!(function_realm.isolate_id, child_realm.isolate_id);
+        assert_eq!(function_realm.context, child_realm.context);
     }
 
     #[test]

--- a/js_engine/src/v8/engine.rs
+++ b/js_engine/src/v8/engine.rs
@@ -1,0 +1,2823 @@
+use std::any::{Any, TypeId};
+use std::cell::{Cell, RefCell, RefMut};
+use std::collections::{HashMap, VecDeque};
+use std::convert::TryFrom;
+use std::ffi::c_void;
+use std::ops::{Deref, DerefMut};
+use std::panic::{AssertUnwindSafe, catch_unwind};
+use std::ptr::NonNull;
+use std::rc::Rc;
+use std::sync::{Arc, Once};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use log::error;
+use rusty_v8 as v8;
+
+use crate::enums::{
+    IntegrityLevel, IteratorKind, PromiseState, SharedMemoryOrder, TypedArrayElementType,
+};
+use crate::gc::{JsTypesGcExt, Trace};
+use crate::records::{IteratorRecord, PromiseCapability, PromiseResolvers, RealmIntrinsics};
+use crate::{
+    Completion, EcmascriptHost, ExecutionContext, HostHooks, JsEngine, JsTypes, Numeric,
+    JsTypesWithRealm, PreferredType, PropertyDescriptor,
+};
+
+use super::types::{CachedPrimitive, ObjectProfile, V8ArrayBufferState};
+use super::{
+    V8BigInt, V8Object, V8PropertyKey, V8Realm, V8String, V8Symbol, V8Types, V8Value,
+};
+
+const HOST_OBJECT_TAG: u16 = 1;
+static HOST_OBJECT_MARKER: u8 = 0;
+static NEXT_ISOLATE_ID: AtomicU64 = AtomicU64::new(1);
+
+type StoredBehaviour = Box<
+    dyn Fn(
+        &[V8Value],
+        V8Value,
+        &mut dyn ExecutionContext<V8Types>,
+    ) -> Completion<V8Value, V8Types>,
+>;
+
+enum QueuedJob {
+    Plain(Box<dyn FnOnce()>),
+    WithRealm(
+        V8Realm,
+        Box<dyn FnOnce(&mut dyn ExecutionContext<V8Types>)>,
+    ),
+}
+
+struct CallbackRecord {
+    isolate_id: u64,
+    behaviour: StoredBehaviour,
+}
+
+struct HostObjectRecord {
+    data: Box<dyn Any>,
+}
+
+thread_local! {
+    static CURRENT_ENGINE: Cell<*mut V8Engine> = const { Cell::new(std::ptr::null_mut()) };
+    static CURRENT_CALLBACK_ISOLATE: Cell<*mut v8::Isolate> = const { Cell::new(std::ptr::null_mut()) };
+    static CURRENT_CALLBACK_ISOLATE_ID: Cell<u64> = const { Cell::new(0) };
+}
+
+struct SharedIsolate {
+    isolate_id: u64,
+    isolate: RefCell<v8::OwnedIsolate>,
+}
+
+enum IsolateAccess<'a> {
+    Owned(RefMut<'a, v8::OwnedIsolate>),
+    Callback(NonNull<v8::Isolate>),
+}
+
+impl Deref for IsolateAccess<'_> {
+    type Target = v8::Isolate;
+
+    fn deref(&self) -> &Self::Target {
+        match self {
+            Self::Owned(isolate) => isolate,
+            Self::Callback(isolate) => {
+                // SAFETY: This pointer is installed only by `native_callback`
+                // from V8's pinned callback scope. Callback execution is
+                // synchronous on the isolate thread, and the guard clears the
+                // pointer before that scope ends. The isolate id is checked by
+                // `SharedIsolate::borrow` before this variant is constructed.
+                unsafe { isolate.as_ref() }
+            }
+        }
+    }
+}
+
+impl DerefMut for IsolateAccess<'_> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        match self {
+            Self::Owned(isolate) => isolate,
+            Self::Callback(isolate) => {
+                // SAFETY: The callback-scope, thread, lifetime, and isolate
+                // identity invariants are established in the `Deref` block.
+                // Native callbacks are the only reentrant path while the
+                // outer `RefMut` is live.
+                unsafe { isolate.as_mut() }
+            }
+        }
+    }
+}
+
+impl SharedIsolate {
+    fn new() -> Rc<Self> {
+        initialize_v8();
+        let mut isolate = v8::Isolate::new(v8::CreateParams::default());
+        isolate.set_microtasks_policy(v8::MicrotasksPolicy::Explicit);
+        Rc::new(Self {
+            isolate_id: NEXT_ISOLATE_ID.fetch_add(1, Ordering::Relaxed),
+            isolate: RefCell::new(isolate),
+        })
+    }
+
+    fn borrow(&self, expected_isolate_id: u64) -> IsolateAccess<'_> {
+        assert_eq!(
+            self.isolate_id, expected_isolate_id,
+            "V8 engine and shared isolate identities differ"
+        );
+        match self.isolate.try_borrow_mut() {
+            Ok(isolate) => IsolateAccess::Owned(isolate),
+            Err(_) => {
+                let callback_isolate_id = CURRENT_CALLBACK_ISOLATE_ID.get();
+                let callback_isolate = CURRENT_CALLBACK_ISOLATE.get();
+                assert_eq!(
+                    callback_isolate_id, expected_isolate_id,
+                    "reentrant V8 isolate access occurred outside its native callback"
+                );
+                let callback_isolate = NonNull::new(callback_isolate).expect(
+                    "reentrant V8 isolate access occurred without a native callback scope",
+                );
+                IsolateAccess::Callback(callback_isolate)
+            }
+        }
+    }
+}
+
+macro_rules! v8_engine_scope_with_context {
+    (let $scope:ident, $engine:expr, $context:expr) => {
+        let shared_isolate_for_scope = Rc::clone(&$engine.shared_isolate);
+        let mut isolate_for_scope = shared_isolate_for_scope.borrow($engine.isolate_id);
+        v8::scope_with_context!(let $scope, &mut *isolate_for_scope, $context);
+    };
+}
+
+macro_rules! v8_engine_scope {
+    (let $scope:ident, $engine:expr) => {
+        let shared_isolate_for_scope = Rc::clone(&$engine.shared_isolate);
+        let mut isolate_for_scope = shared_isolate_for_scope.borrow($engine.isolate_id);
+        v8::scope!(let $scope, &mut *isolate_for_scope);
+    };
+}
+
+struct CurrentEngineGuard {
+    previous: *mut V8Engine,
+}
+
+struct CurrentCallbackIsolateGuard {
+    previous_isolate: *mut v8::Isolate,
+    previous_isolate_id: u64,
+}
+
+impl CurrentCallbackIsolateGuard {
+    fn enter(scope: &mut v8::PinScope<'_, '_>, isolate_id: u64) -> Self {
+        let isolate = &mut ***scope as *mut v8::Isolate;
+        let previous_isolate = CURRENT_CALLBACK_ISOLATE.replace(isolate);
+        let previous_isolate_id = CURRENT_CALLBACK_ISOLATE_ID.replace(isolate_id);
+        Self {
+            previous_isolate,
+            previous_isolate_id,
+        }
+    }
+}
+
+impl Drop for CurrentCallbackIsolateGuard {
+    fn drop(&mut self) {
+        CURRENT_CALLBACK_ISOLATE.set(self.previous_isolate);
+        CURRENT_CALLBACK_ISOLATE_ID.set(self.previous_isolate_id);
+    }
+}
+
+impl CurrentEngineGuard {
+    fn enter(engine: &mut V8Engine) -> Self {
+        let engine_pointer = engine as *mut V8Engine;
+        let previous = CURRENT_ENGINE.replace(engine_pointer);
+        Self { previous }
+    }
+}
+
+impl Drop for CurrentEngineGuard {
+    fn drop(&mut self) {
+        CURRENT_ENGINE.set(self.previous);
+    }
+}
+
+pub struct V8Engine {
+    isolate_id: u64,
+    realm: V8Realm,
+    realm_global: V8Object,
+    intrinsics: Option<RealmIntrinsics<V8Types>>,
+    host_data: HashMap<TypeId, Box<dyn Any>>,
+    associated_objects: Vec<(V8Object, Box<dyn Any>)>,
+    queued_jobs: VecDeque<QueuedJob>,
+    host_object_handles: Vec<v8::Weak<v8::Object>>,
+    callback_handles: Vec<v8::Weak<v8::Function>>,
+    host_hooks: HostHooks<V8Types>,
+    shared_isolate: Rc<SharedIsolate>,
+}
+
+fn initialize_v8() {
+    static INITIALIZE: Once = Once::new();
+    INITIALIZE.call_once(|| {
+        v8::V8::set_flags_from_string("--expose-gc");
+        v8::V8::initialize_platform(v8::new_default_platform(0, false).make_shared());
+        v8::V8::initialize();
+    });
+}
+
+fn cache_string(scope: &v8::PinScope<'_, '_>, string: &v8::String) -> Arc<[u16]> {
+    let mut utf16 = vec![0; string.length()];
+    string.write_v2(scope, 0, &mut utf16, v8::WriteFlags::empty());
+    Arc::from(utf16)
+}
+
+fn host_data_pointer<'scope>(
+    scope: &v8::PinScope<'scope, '_>,
+    object: v8::Local<'scope, v8::Object>,
+) -> Option<NonNull<c_void>> {
+    if object.internal_field_count() != 2 {
+        return None;
+    }
+    let marker_data = object.get_internal_field(scope, 0)?;
+    let marker = v8::Local::<v8::External>::try_from(marker_data).ok()?;
+    if marker.value() != std::ptr::addr_of!(HOST_OBJECT_MARKER).cast_mut().cast() {
+        return None;
+    }
+
+    // SAFETY: Field 1 is read only after field 0 proves that this object was
+    // created by `create_object_with_any`. That constructor stores an aligned
+    // `HostObjectRecord` pointer in field 1 with this exact tag. The weak
+    // handle keeps the record alive for at least as long as the JS object.
+    let pointer = unsafe {
+        object.get_aligned_pointer_from_internal_field(1, HOST_OBJECT_TAG)
+    } as *mut c_void;
+    NonNull::new(pointer)
+}
+
+fn wrap_local_value(
+    scope: &mut v8::PinScope<'_, '_>,
+    isolate_id: u64,
+    value: v8::Local<'_, v8::Value>,
+) -> V8Value {
+    let primitive = if value.is_undefined() {
+        CachedPrimitive::Undefined
+    } else if value.is_null() {
+        CachedPrimitive::Null
+    } else if value.is_boolean() {
+        CachedPrimitive::Boolean(value.boolean_value(scope))
+    } else if value.is_number() {
+        CachedPrimitive::Number(value.number_value(scope).unwrap_or(f64::NAN))
+    } else if value.is_string() {
+        let string = v8::Local::<v8::String>::try_from(value).expect("V8 string type check failed");
+        CachedPrimitive::String(cache_string(scope, &string))
+    } else if value.is_big_int() {
+        let canonical = value
+            .to_string(scope)
+            .map(|string| string.to_rust_string_lossy(scope))
+            .unwrap_or_default();
+        CachedPrimitive::BigInt(Arc::from(canonical))
+    } else {
+        CachedPrimitive::Other
+    };
+
+    let mut host_data = None;
+    let object_profile = if value.is_object() {
+        let object = v8::Local::<v8::Object>::try_from(value).expect("V8 object type check failed");
+        host_data = host_data_pointer(scope, object);
+        let array_buffer_state = if value.is_array_buffer() {
+            let array_buffer = v8::Local::<v8::ArrayBuffer>::try_from(value)
+                .expect("V8 ArrayBuffer type check failed");
+            let backing_store = array_buffer.get_backing_store();
+            Some(V8ArrayBufferState {
+                resizable: backing_store.is_resizable_by_user_javascript(),
+                backing_store,
+                detached: Rc::new(Cell::new(array_buffer.was_detached())),
+            })
+        } else {
+            None
+        };
+        let typed_array_element_type = if value.is_int8_array() {
+            Some(TypedArrayElementType::Int8)
+        } else if value.is_uint8_array() {
+            Some(TypedArrayElementType::Uint8)
+        } else if value.is_uint8_clamped_array() {
+            Some(TypedArrayElementType::Uint8Clamped)
+        } else if value.is_int16_array() {
+            Some(TypedArrayElementType::Int16)
+        } else if value.is_uint16_array() {
+            Some(TypedArrayElementType::Uint16)
+        } else if value.is_int32_array() {
+            Some(TypedArrayElementType::Int32)
+        } else if value.is_uint32_array() {
+            Some(TypedArrayElementType::Uint32)
+        } else if value.is_float16_array() {
+            Some(TypedArrayElementType::Float16)
+        } else if value.is_float32_array() {
+            Some(TypedArrayElementType::Float32)
+        } else if value.is_float64_array() {
+            Some(TypedArrayElementType::Float64)
+        } else if value.is_big_int64_array() {
+            Some(TypedArrayElementType::BigInt64)
+        } else if value.is_big_uint64_array() {
+            Some(TypedArrayElementType::BigUint64)
+        } else {
+            None
+        };
+        Some(ObjectProfile {
+            is_array_buffer: value.is_array_buffer(),
+            is_shared_array_buffer: value.is_shared_array_buffer(),
+            is_typed_array: value.is_typed_array(),
+            is_data_view: value.is_data_view(),
+            is_promise: value.is_promise(),
+            is_function: value.is_function(),
+            is_constructor: value.is_function(),
+            is_map: value.is_map(),
+            is_set: value.is_set(),
+            is_weak_map: value.is_weak_map(),
+            is_weak_set: value.is_weak_set(),
+            is_generator: value.is_generator_object(),
+            is_boolean_wrapper: value.is_boolean_object(),
+            is_number_wrapper: value.is_number_object(),
+            is_string_wrapper: value.is_string_object(),
+            is_bigint_wrapper: value.is_big_int_object(),
+            is_date: value.is_date(),
+            is_regexp: value.is_reg_exp(),
+            is_error: value.is_native_error(),
+            wrapper_primitive: None,
+            array_buffer_state,
+            typed_array_element_type,
+        })
+    } else {
+        None
+    };
+
+    V8Value {
+        isolate_id,
+        handle: v8::Global::new(scope, value),
+        primitive,
+        object_profile,
+        host_data,
+    }
+}
+
+fn local_value<'scope>(
+    scope: &mut v8::PinScope<'scope, '_>,
+    isolate_id: u64,
+    value: &V8Value,
+) -> Result<v8::Local<'scope, v8::Value>, V8Value> {
+    if value.isolate_id != isolate_id {
+        let message = v8::String::new(scope, "value belongs to a different V8 isolate")
+            .expect("static V8 error string allocation failed");
+        let exception = v8::Exception::type_error(scope, message);
+        return Err(wrap_local_value(scope, isolate_id, exception));
+    }
+    Ok(v8::Local::new(scope, &value.handle))
+}
+
+fn local_object<'scope>(
+    scope: &mut v8::PinScope<'scope, '_>,
+    isolate_id: u64,
+    object: &V8Object,
+) -> Result<v8::Local<'scope, v8::Object>, V8Value> {
+    let value = local_value(scope, isolate_id, &object.0)?;
+    v8::Local::<v8::Object>::try_from(value).map_err(|_| {
+        let message = v8::String::new(scope, "value is not an object")
+            .expect("static V8 error string allocation failed");
+        let exception = v8::Exception::type_error(scope, message);
+        wrap_local_value(scope, isolate_id, exception)
+    })
+}
+
+fn local_property_key<'scope>(
+    scope: &mut v8::PinScope<'scope, '_>,
+    isolate_id: u64,
+    key: &V8PropertyKey,
+) -> Result<v8::Local<'scope, v8::Value>, V8Value> {
+    match key {
+        V8PropertyKey::String(string) => {
+            if let Some(value) = &string.value {
+                local_value(scope, isolate_id, value)
+            } else {
+                let string = v8::String::new_from_two_byte(
+                    scope,
+                    &string.utf16,
+                    v8::NewStringType::Normal,
+                )
+                .expect("V8 property name allocation failed");
+                Ok(string.into())
+            }
+        }
+        V8PropertyKey::Symbol(symbol) => local_value(scope, isolate_id, &symbol.0),
+        V8PropertyKey::Index(index) => Ok(v8::Integer::new_from_unsigned(scope, *index).into()),
+    }
+}
+
+fn local_name<'scope>(
+    scope: &mut v8::PinScope<'scope, '_>,
+    isolate_id: u64,
+    key: &V8PropertyKey,
+) -> Result<v8::Local<'scope, v8::Name>, V8Value> {
+    let value = match key {
+        V8PropertyKey::Index(index) => {
+            let string = v8::String::new(scope, &index.to_string())
+                .expect("V8 array-index name allocation failed");
+            return Ok(string.into());
+        }
+        _ => local_property_key(scope, isolate_id, key)?,
+    };
+    v8::Local::<v8::Name>::try_from(value).map_err(|_| {
+        let message = v8::String::new(scope, "property key is not a name")
+            .expect("static V8 error string allocation failed");
+        let exception = v8::Exception::type_error(scope, message);
+        wrap_local_value(scope, isolate_id, exception)
+    })
+}
+
+fn caught_exception(
+    scope: &mut v8::PinScope<'_, '_>,
+    isolate_id: u64,
+    exception: Option<v8::Local<'_, v8::Value>>,
+    fallback: &str,
+) -> V8Value {
+    let exception = exception.unwrap_or_else(|| {
+        let message = v8::String::new(scope, fallback)
+            .expect("static V8 exception string allocation failed");
+        v8::Exception::error(scope, message)
+    });
+    wrap_local_value(scope, isolate_id, exception)
+}
+
+macro_rules! caught {
+    ($scope:expr, $isolate_id:expr, $fallback:expr) => {{
+        let exception = $scope.exception();
+        caught_exception($scope, $isolate_id, exception, $fallback)
+    }};
+}
+
+fn native_callback(
+    scope: &mut v8::PinScope<'_, '_>,
+    arguments: v8::FunctionCallbackArguments,
+    mut return_value: v8::ReturnValue,
+) {
+    let data = arguments.data();
+    let Ok(external) = v8::Local::<v8::External>::try_from(data) else {
+        let message = v8::String::new(scope, "missing native callback record")
+            .expect("static V8 callback error allocation failed");
+        let exception = v8::Exception::error(scope, message);
+        scope.throw_exception(exception);
+        return;
+    };
+    let record_pointer = external.value().cast::<CallbackRecord>();
+    if record_pointer.is_null() {
+        let message = v8::String::new(scope, "invalid native callback record")
+            .expect("static V8 callback error allocation failed");
+        let exception = v8::Exception::error(scope, message);
+        scope.throw_exception(exception);
+        return;
+    }
+
+    let engine_pointer = CURRENT_ENGINE.get();
+    if engine_pointer.is_null() {
+        let message = v8::String::new(scope, "native callback entered without an active engine")
+            .expect("static V8 callback error allocation failed");
+        let exception = v8::Exception::error(scope, message);
+        scope.throw_exception(exception);
+        return;
+    }
+
+    // SAFETY: Callback records are allocated by `make_builtin_function` and
+    // released only by the function's guaranteed weak finalizer. V8 invokes
+    // this callback while the function is strongly reachable. CURRENT_ENGINE
+    // is installed around every operation that can execute JavaScript and is
+    // restricted to the isolate thread. The isolate id check below prevents a
+    // record from being used by another isolate. `catch_unwind` prevents Rust
+    // unwinding from crossing V8's callback boundary.
+    let result = unsafe {
+        let record = &*record_pointer;
+        let engine = &mut *engine_pointer;
+        if record.isolate_id != engine.isolate_id {
+            Err(engine.new_type_error("native callback belongs to a different V8 isolate"))
+        } else {
+            let _current_callback_isolate =
+                CurrentCallbackIsolateGuard::enter(scope, record.isolate_id);
+            let callback_arguments: Vec<_> = (0..arguments.length())
+                .map(|index| wrap_local_value(scope, record.isolate_id, arguments.get(index)))
+                .collect();
+            let this_value = wrap_local_value(scope, record.isolate_id, arguments.this().into());
+            match catch_unwind(AssertUnwindSafe(|| {
+                (record.behaviour)(&callback_arguments, this_value, engine)
+            })) {
+                Ok(completion) => completion,
+                Err(_) => Err(engine.new_type_error("Rust panic in native callback")),
+            }
+        }
+    };
+
+    match result {
+        Ok(value) => match local_value(scope, unsafe { (*record_pointer).isolate_id }, &value) {
+            Ok(value) => return_value.set(value),
+            Err(exception) => {
+                let exception = v8::Local::new(scope, &exception.handle);
+                scope.throw_exception(exception);
+            }
+        },
+        Err(exception) => {
+            if exception.isolate_id == unsafe { (*record_pointer).isolate_id } {
+                let exception = v8::Local::new(scope, &exception.handle);
+                scope.throw_exception(exception);
+            } else {
+                let message = v8::String::new(scope, "callback returned a cross-isolate exception")
+                    .expect("static V8 callback error allocation failed");
+                let exception = v8::Exception::type_error(scope, message);
+                scope.throw_exception(exception);
+            }
+        }
+    }
+}
+
+fn reject_module_import<'scope>(
+    context: v8::Local<'scope, v8::Context>,
+    _specifier: v8::Local<'scope, v8::String>,
+    _import_attributes: v8::Local<'scope, v8::FixedArray>,
+    _referrer: v8::Local<'scope, v8::Module>,
+) -> Option<v8::Local<'scope, v8::Module>> {
+    // SAFETY: V8 invokes module-resolution callbacks with the entered context
+    // and no Rust handle scope. rusty_v8 requires CallbackScope only at this
+    // callback boundary; the scope is pinned for its full use below.
+    v8::callback_scope!(unsafe scope, context);
+    let message = v8::String::new(scope, "module imports are not enabled for the V8 backend")
+        .expect("static module error allocation failed");
+    let exception = v8::Exception::type_error(scope, message);
+    scope.throw_exception(exception);
+    None
+}
+
+impl V8Engine {
+    pub fn new() -> Self {
+        Self::new_with_shared_isolate(SharedIsolate::new())
+    }
+
+    fn new_with_shared_isolate(shared_isolate: Rc<SharedIsolate>) -> Self {
+        let isolate_id = shared_isolate.isolate_id;
+
+        let (context_handle, realm_global) = {
+            let mut isolate = shared_isolate.borrow(isolate_id);
+            v8::scope!(let scope, &mut *isolate);
+            let context = v8::Context::new(scope, v8::ContextOptions::default());
+            let context_handle = v8::Global::new(scope, context);
+            let context_scope = &mut v8::ContextScope::new(scope, context);
+            let global = context.global(context_scope);
+            let realm_global =
+                V8Object(wrap_local_value(context_scope, isolate_id, global.into()));
+            (context_handle, realm_global)
+        };
+
+        let realm = V8Realm {
+            isolate_id,
+            context: context_handle,
+        };
+        let mut engine = Self {
+            isolate_id,
+            realm,
+            realm_global,
+            intrinsics: None,
+            host_data: HashMap::new(),
+            associated_objects: Vec::new(),
+            queued_jobs: VecDeque::new(),
+            host_object_handles: Vec::new(),
+            callback_handles: Vec::new(),
+            host_hooks: HostHooks::empty(),
+            shared_isolate,
+        };
+        engine.intrinsics = Some(engine.load_intrinsics());
+        engine
+    }
+
+    pub fn associate_existing_object(&mut self, object: &V8Object, data: Box<dyn Any>) {
+        self.associated_objects.push((object.clone(), data));
+    }
+
+    pub fn new_child_realm(&self) -> Self {
+        Self::new_with_shared_isolate(Rc::clone(&self.shared_isolate))
+    }
+
+    pub(crate) fn create_weak_object(&mut self, object: &V8Object) -> Rc<v8::Weak<v8::Object>> {
+        let isolate_id = self.isolate_id;
+        v8_engine_scope_with_context!(let scope, self, &self.realm.context);
+        let local = local_object(scope, isolate_id, object)
+            .expect("reflector creation received a non-object or cross-isolate handle");
+        Rc::new(v8::Weak::new(scope, local))
+    }
+
+    pub(crate) fn upgrade_weak_object(
+        &mut self,
+        weak: &v8::Weak<v8::Object>,
+    ) -> Option<V8Object> {
+        let isolate_id = self.isolate_id;
+        let shared_isolate = Rc::clone(&self.shared_isolate);
+        let mut isolate = shared_isolate.borrow(isolate_id);
+        let global = weak.to_global(&mut *isolate)?;
+        v8::scope_with_context!(let scope, &mut *isolate, &self.realm.context);
+        let local = v8::Local::new(scope, global);
+        Some(V8Object(wrap_local_value(scope, isolate_id, local.into())))
+    }
+
+    fn call_js_helper(&mut self, source: &str, arguments: &[V8Value]) -> Completion<V8Value, V8Types> {
+        for argument in arguments {
+            if argument.isolate_id != self.isolate_id {
+                return Err(self.new_type_error("value belongs to a different V8 isolate"));
+            }
+        }
+        let _current_engine = CurrentEngineGuard::enter(self);
+        let isolate_id = self.isolate_id;
+        v8_engine_scope_with_context!(let scope, self, &self.realm.context);
+        v8::tc_scope!(let try_catch, scope);
+        let Some(source) = v8::String::new(try_catch, source) else {
+            return Err(caught_exception(try_catch, isolate_id, None, "failed to allocate helper source"));
+        };
+        let Some(script) = v8::Script::compile(try_catch, source, None) else {
+            return Err(caught!(try_catch, isolate_id, "failed to compile helper"));
+        };
+        let Some(function_value) = script.run(try_catch) else {
+            return Err(caught!(try_catch, isolate_id, "failed to evaluate helper"));
+        };
+        let Ok(function) = v8::Local::<v8::Function>::try_from(function_value) else {
+            return Err(caught_exception(try_catch, isolate_id, None, "helper is not callable"));
+        };
+        let local_arguments: Result<Vec<_>, _> = arguments
+            .iter()
+            .map(|argument| local_value(try_catch, isolate_id, argument))
+            .collect();
+        let local_arguments = local_arguments?;
+        let receiver = v8::undefined(try_catch).into();
+        let Some(result) = function.call(try_catch, receiver, &local_arguments) else {
+            return Err(caught!(try_catch, isolate_id, "helper call failed"));
+        };
+        Ok(wrap_local_value(try_catch, isolate_id, result))
+    }
+
+    fn intrinsic_object(&mut self, source: &str) -> V8Object {
+        match <Self as ExecutionContext<V8Types>>::evaluate_script(self, source) {
+            Ok(value) => V8Types::value_as_object(&value)
+                .unwrap_or_else(|| panic!("V8 intrinsic `{source}` is not an object")),
+            Err(_) => panic!("failed to load V8 intrinsic `{source}`"),
+        }
+    }
+
+    fn load_intrinsics(&mut self) -> RealmIntrinsics<V8Types> {
+        RealmIntrinsics {
+            array_buffer: self.intrinsic_object("ArrayBuffer"),
+            shared_array_buffer: self.intrinsic_object("SharedArrayBuffer"),
+            promise: self.intrinsic_object("Promise"),
+            object: self.intrinsic_object("Object"),
+            function: self.intrinsic_object("Function"),
+            error: self.intrinsic_object("Error"),
+            type_error: self.intrinsic_object("TypeError"),
+            range_error: self.intrinsic_object("RangeError"),
+            syntax_error: self.intrinsic_object("SyntaxError"),
+            reference_error: self.intrinsic_object("ReferenceError"),
+            uri_error: self.intrinsic_object("URIError"),
+            eval_error: self.intrinsic_object("EvalError"),
+            array: self.intrinsic_object("Array"),
+            uint8_array: self.intrinsic_object("Uint8Array"),
+            boolean: self.intrinsic_object("Boolean"),
+            number: self.intrinsic_object("Number"),
+            string: self.intrinsic_object("String"),
+            bigint: self.intrinsic_object("BigInt"),
+            date: self.intrinsic_object("Date"),
+            regexp: self.intrinsic_object("RegExp"),
+            map: self.intrinsic_object("Map"),
+            set: self.intrinsic_object("Set"),
+            boolean_prototype: self.intrinsic_object("Boolean.prototype"),
+            number_prototype: self.intrinsic_object("Number.prototype"),
+            string_prototype: self.intrinsic_object("String.prototype"),
+            bigint_prototype: self.intrinsic_object("BigInt.prototype"),
+            date_prototype: self.intrinsic_object("Date.prototype"),
+            regexp_prototype: self.intrinsic_object("RegExp.prototype"),
+            map_prototype: self.intrinsic_object("Map.prototype"),
+            set_prototype: self.intrinsic_object("Set.prototype"),
+            error_prototype: self.intrinsic_object("Error.prototype"),
+            type_error_prototype: self.intrinsic_object("TypeError.prototype"),
+            range_error_prototype: self.intrinsic_object("RangeError.prototype"),
+            syntax_error_prototype: self.intrinsic_object("SyntaxError.prototype"),
+            reference_error_prototype: self.intrinsic_object("ReferenceError.prototype"),
+            uri_error_prototype: self.intrinsic_object("URIError.prototype"),
+            eval_error_prototype: self.intrinsic_object("EvalError.prototype"),
+            object_prototype: self.intrinsic_object("Object.prototype"),
+            function_prototype: self.intrinsic_object("Function.prototype"),
+            async_iterator_prototype: self.intrinsic_object(
+                "Object.getPrototypeOf(Object.getPrototypeOf(async function*(){}()))",
+            ),
+        }
+    }
+
+    fn make_builtin_function(
+        &mut self,
+        behaviour: StoredBehaviour,
+        length: u32,
+        name: V8PropertyKey,
+        is_constructor: bool,
+    ) -> V8Object {
+        let record = Box::new(CallbackRecord {
+            isolate_id: self.isolate_id,
+            behaviour,
+        });
+        let record_pointer = Box::into_raw(record);
+        let isolate_id = self.isolate_id;
+        let function_name = self.property_key_to_rust_string(&name);
+
+        v8_engine_scope_with_context!(let scope, self, &self.realm.context);
+        let external = v8::External::new(scope, record_pointer.cast());
+        let constructor_behavior = if is_constructor {
+            v8::ConstructorBehavior::Allow
+        } else {
+            v8::ConstructorBehavior::Throw
+        };
+        let function = v8::Function::builder(native_callback)
+            .data(external.into())
+            .length(length as i32)
+            .constructor_behavior(constructor_behavior)
+            .build(scope)
+            .expect("V8 failed to create native function");
+        if let Some(name) = v8::String::new(scope, &function_name) {
+            function.set_name(name);
+        }
+        let function_value = wrap_local_value(scope, isolate_id, function.into());
+
+        // The weak handle is retained by the engine. The finalizer owns the
+        // callback record and is guaranteed to release it before isolate
+        // destruction, even if no collection happens first.
+        let callback_handle = v8::Weak::with_guaranteed_finalizer(
+            scope,
+            function,
+            Box::new(move || {
+                // SAFETY: `record_pointer` came from one Box::into_raw above
+                // and this guaranteed finalizer is its sole owner. The weak
+                // handle invokes this closure at most once.
+                unsafe {
+                    drop(Box::from_raw(record_pointer));
+                }
+            }),
+        );
+        self.callback_handles.push(callback_handle);
+        V8Object(function_value)
+    }
+}
+
+impl Default for V8Engine {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl JsEngine<V8Types> for V8Engine {
+    fn create_realm(&mut self) -> V8Realm {
+        let isolate_id = self.isolate_id;
+        v8_engine_scope!(let scope, self);
+        let context = v8::Context::new(scope, v8::ContextOptions::default());
+        V8Realm {
+            isolate_id,
+            context: v8::Global::new(scope, context),
+        }
+    }
+
+    fn set_realm_global_object(
+        &mut self,
+        realm: &V8Realm,
+        global: V8Object,
+        _this_value: Option<V8Object>,
+    ) {
+        if realm.isolate_id != self.isolate_id || global.0.isolate_id != self.isolate_id {
+            return;
+        }
+        if realm.context == self.realm.context {
+            self.realm_global = global;
+        }
+    }
+
+    fn set_default_global_bindings(&mut self, realm: &V8Realm) -> Completion<(), V8Types> {
+        if realm.isolate_id != self.isolate_id {
+            Err(self.new_type_error("realm belongs to a different V8 isolate"))
+        } else {
+            Ok(())
+        }
+    }
+
+    fn evaluate_script(
+        &mut self,
+        source: &str,
+        realm: &V8Realm,
+    ) -> Completion<V8Value, V8Types> {
+        if realm.isolate_id != self.isolate_id {
+            return Err(self.new_type_error("realm belongs to a different V8 isolate"));
+        }
+        let _current_engine = CurrentEngineGuard::enter(self);
+        let isolate_id = self.isolate_id;
+        v8_engine_scope_with_context!(let scope, self, &realm.context);
+        v8::tc_scope!(let try_catch, scope);
+        let Some(source) = v8::String::new(try_catch, source) else {
+            return Err(caught_exception(try_catch, isolate_id, None, "script source allocation failed"));
+        };
+        let Some(script) = v8::Script::compile(try_catch, source, None) else {
+            return Err(caught!(try_catch, isolate_id, "script compilation failed"));
+        };
+        let Some(value) = script.run(try_catch) else {
+            return Err(caught!(try_catch, isolate_id, "script evaluation failed"));
+        };
+        Ok(wrap_local_value(try_catch, isolate_id, value))
+    }
+
+    fn evaluate_module(
+        &mut self,
+        source: &str,
+        realm: &V8Realm,
+    ) -> Completion<V8Object, V8Types> {
+        if realm.isolate_id != self.isolate_id {
+            return Err(self.new_type_error("realm belongs to a different V8 isolate"));
+        }
+        let _current_engine = CurrentEngineGuard::enter(self);
+        let isolate_id = self.isolate_id;
+        v8_engine_scope_with_context!(let scope, self, &realm.context);
+        v8::tc_scope!(let try_catch, scope);
+        let Some(source_string) = v8::String::new(try_catch, source) else {
+            return Err(caught_exception(try_catch, isolate_id, None, "module source allocation failed"));
+        };
+        let mut source = v8::script_compiler::Source::new(source_string, None);
+        let Some(module) = v8::script_compiler::compile_module(try_catch, &mut source) else {
+            return Err(caught!(try_catch, isolate_id, "module compilation failed"));
+        };
+        if module.instantiate_module(try_catch, reject_module_import) != Some(true) {
+            return Err(caught!(try_catch, isolate_id, "module instantiation failed"));
+        }
+        if module.evaluate(try_catch).is_none() {
+            return Err(caught!(try_catch, isolate_id, "module evaluation failed"));
+        }
+        let namespace = module.get_module_namespace();
+        let namespace = wrap_local_value(try_catch, isolate_id, namespace);
+        V8Types::value_as_object(&namespace)
+            .ok_or_else(|| caught_exception(try_catch, isolate_id, None, "module namespace is not an object"))
+    }
+
+    fn allocate_array_buffer(
+        &mut self,
+        constructor: V8Object,
+        byte_length: u64,
+        max_byte_length: Option<u64>,
+    ) -> Completion<V8Object, V8Types> {
+        ExecutionContext::allocate_array_buffer(self, constructor, byte_length, max_byte_length)
+    }
+
+    fn detach_array_buffer(
+        &mut self,
+        array_buffer: V8Object,
+        key: Option<V8Value>,
+    ) -> Completion<(), V8Types> {
+        ExecutionContext::detach_array_buffer(self, array_buffer, key)
+    }
+
+    fn clone_array_buffer(
+        &mut self,
+        source: V8Object,
+        source_byte_offset: u64,
+        source_length: u64,
+        constructor: V8Object,
+    ) -> Completion<V8Object, V8Types> {
+        ExecutionContext::clone_array_buffer(
+            self,
+            source,
+            source_byte_offset,
+            source_length,
+            constructor,
+        )
+    }
+
+    fn allocate_shared_array_buffer(
+        &mut self,
+        _constructor: V8Object,
+        byte_length: u64,
+    ) -> Completion<V8Object, V8Types> {
+        let byte_length = self.value_from_number(byte_length as f64);
+        let value = self.call_js_helper("length => new SharedArrayBuffer(length)", &[byte_length])?;
+        V8Types::value_as_object(&value)
+            .ok_or_else(|| self.new_type_error("SharedArrayBuffer allocation failed"))
+    }
+
+    fn set_host_hooks(&mut self, hooks: HostHooks<V8Types>) {
+        self.host_hooks = hooks;
+    }
+}
+
+impl JsTypesGcExt for V8Types {
+    type Reflector = Rc<v8::Weak<v8::Object>>;
+    type Context = V8Engine;
+
+    fn create_reflector(context: &mut Self::Context, object: &V8Object) -> Self::Reflector {
+        context.create_weak_object(object)
+    }
+
+    fn upgrade_reflector(
+        context: &mut Self::Context,
+        reflector: &Self::Reflector,
+    ) -> Option<V8Object> {
+        context.upgrade_weak_object(reflector)
+    }
+}
+
+unsafe impl Trace for V8Value {}
+unsafe impl Trace for V8Object {}
+unsafe impl Trace for V8String {}
+unsafe impl Trace for V8Symbol {}
+unsafe impl Trace for V8BigInt {}
+
+pub fn create_builtin_fn_with_captures<T, C>(
+    execution_context: &mut dyn ExecutionContext<T>,
+    captures: C,
+    behaviour: fn(
+        &[T::JsValue],
+        T::JsValue,
+        &C,
+        &mut dyn ExecutionContext<T>,
+    ) -> Completion<T::JsValue, T>,
+    length: u32,
+    name: T::PropertyKey,
+    is_constructor: bool,
+) -> T::Function
+where
+    T: JsTypes + JsTypesWithRealm,
+    C: Trace + 'static,
+{
+    let engine = execution_context
+        .as_any_mut()
+        .downcast_mut::<V8Engine>()
+        .expect("create_builtin_fn_with_captures called with a non-V8 engine");
+
+    // SAFETY: This function is exported only by the V8-selected content
+    // build, where T is V8Types. Function pointers have identical pointer
+    // representation; the callback trampoline validates the active isolate
+    // before invoking the converted behaviour.
+    let behaviour: fn(
+        &[V8Value],
+        V8Value,
+        &C,
+        &mut dyn ExecutionContext<V8Types>,
+    ) -> Completion<V8Value, V8Types> = unsafe { std::mem::transmute_copy(&behaviour) };
+
+    // SAFETY: In a V8-selected build T::PropertyKey is V8PropertyKey. Moving
+    // through MaybeUninit preserves ownership without creating a second drop.
+    let name: V8PropertyKey = unsafe {
+        let mut destination = std::mem::MaybeUninit::<V8PropertyKey>::uninit();
+        std::ptr::copy_nonoverlapping(
+            std::ptr::addr_of!(name).cast::<u8>(),
+            destination.as_mut_ptr().cast::<u8>(),
+            std::mem::size_of::<V8PropertyKey>(),
+        );
+        std::mem::forget(name);
+        destination.assume_init()
+    };
+    let stored = Box::new(move |arguments: &[V8Value], this_value, execution_context: &mut dyn ExecutionContext<V8Types>| {
+        behaviour(arguments, this_value, &captures, execution_context)
+    });
+    let result = engine.make_builtin_function(stored, length, name, is_constructor);
+
+    // SAFETY: In a V8-selected build T::Function is V8Object. The result is
+    // moved into its associated-type spelling without duplicating ownership.
+    unsafe {
+        let mut destination = std::mem::MaybeUninit::<T::Function>::uninit();
+        std::ptr::copy_nonoverlapping(
+            std::ptr::addr_of!(result).cast::<u8>(),
+            destination.as_mut_ptr().cast::<u8>(),
+            std::mem::size_of::<V8Object>(),
+        );
+        std::mem::forget(result);
+        destination.assume_init()
+    }
+}
+
+impl EcmascriptHost<V8Types> for V8Engine {
+    fn get(&mut self, object: &V8Object, property: &str) -> Completion<V8Value, V8Types> {
+        let key = self.property_key_from_str(property);
+        ExecutionContext::get(self, object.clone(), key)
+    }
+
+    fn is_callable(&self, value: &V8Value) -> bool {
+        value
+            .object_profile
+            .as_ref()
+            .is_some_and(|profile| profile.is_function)
+    }
+
+    fn call(
+        &mut self,
+        callable: &V8Object,
+        this_argument: &V8Value,
+        arguments: &[V8Value],
+    ) -> Completion<V8Value, V8Types> {
+        if callable.0.isolate_id != self.isolate_id
+            || this_argument.isolate_id != self.isolate_id
+            || arguments.iter().any(|value| value.isolate_id != self.isolate_id)
+        {
+            return Err(self.new_type_error("value belongs to a different V8 isolate"));
+        }
+        let _current_engine = CurrentEngineGuard::enter(self);
+        let isolate_id = self.isolate_id;
+        v8_engine_scope_with_context!(let scope, self, &self.realm.context);
+        v8::tc_scope!(let try_catch, scope);
+        let callable = local_value(try_catch, isolate_id, &callable.0)?;
+        let function = v8::Local::<v8::Function>::try_from(callable).map_err(|_| {
+            caught_exception(try_catch, isolate_id, None, "callback is not callable")
+        })?;
+        let this_argument = local_value(try_catch, isolate_id, this_argument)?;
+        let local_arguments: Result<Vec<_>, _> = arguments
+            .iter()
+            .map(|argument| local_value(try_catch, isolate_id, argument))
+            .collect();
+        let Some(result) = function.call(try_catch, this_argument, &local_arguments?) else {
+            return Err(caught!(try_catch, isolate_id, "callback call failed"));
+        };
+        Ok(wrap_local_value(try_catch, isolate_id, result))
+    }
+
+    fn perform_a_microtask_checkpoint(&mut self) -> Completion<(), V8Types> {
+        let _current_engine = CurrentEngineGuard::enter(self);
+        loop {
+            while let Some(job) = self.queued_jobs.pop_front() {
+                match job {
+                    QueuedJob::Plain(job) => job(),
+                    QueuedJob::WithRealm(realm, job) => {
+                        if realm.isolate_id != self.isolate_id {
+                            return Err(self.new_type_error("job realm belongs to a different V8 isolate"));
+                        }
+                        job(self);
+                    }
+                }
+            }
+            let queued_before_checkpoint = self.queued_jobs.len();
+            let shared_isolate = Rc::clone(&self.shared_isolate);
+            let mut isolate = shared_isolate.borrow(self.isolate_id);
+            isolate.perform_microtask_checkpoint();
+            if self.queued_jobs.len() == queued_before_checkpoint {
+                break;
+            }
+        }
+        Ok(())
+    }
+
+    fn report_exception(&mut self, exception: V8Value) {
+        let message = self
+            .to_rust_string(exception)
+            .unwrap_or_else(|_| "unknown V8 exception".to_owned());
+        error!("unhandled V8 exception: {message}");
+    }
+
+    fn gc(&mut self) {
+        let shared_isolate = Rc::clone(&self.shared_isolate);
+        let mut isolate = shared_isolate.borrow(self.isolate_id);
+        isolate.request_garbage_collection_for_testing(v8::GarbageCollectionType::Full);
+    }
+
+    fn value_undefined(&mut self) -> V8Value {
+        let isolate_id = self.isolate_id;
+        v8_engine_scope_with_context!(let scope, self, &self.realm.context);
+        let value = v8::undefined(scope).into();
+        wrap_local_value(scope, isolate_id, value)
+    }
+
+    fn value_null(&mut self) -> V8Value {
+        let isolate_id = self.isolate_id;
+        v8_engine_scope_with_context!(let scope, self, &self.realm.context);
+        let value = v8::null(scope).into();
+        wrap_local_value(scope, isolate_id, value)
+    }
+
+    fn value_from_bool(&mut self, boolean: bool) -> V8Value {
+        let isolate_id = self.isolate_id;
+        v8_engine_scope_with_context!(let scope, self, &self.realm.context);
+        let value = v8::Boolean::new(scope, boolean).into();
+        wrap_local_value(scope, isolate_id, value)
+    }
+
+    fn value_from_number(&mut self, number: f64) -> V8Value {
+        let isolate_id = self.isolate_id;
+        v8_engine_scope_with_context!(let scope, self, &self.realm.context);
+        let value = v8::Number::new(scope, number).into();
+        wrap_local_value(scope, isolate_id, value)
+    }
+
+    fn value_from_string(&mut self, string: V8String) -> V8Value {
+        if let Some(value) = string.value {
+            return value;
+        }
+        let isolate_id = self.isolate_id;
+        v8_engine_scope_with_context!(let scope, self, &self.realm.context);
+        let local = v8::String::new_from_two_byte(
+            scope,
+            &string.utf16,
+            v8::NewStringType::Normal,
+        )
+        .expect("V8 string allocation failed");
+        wrap_local_value(scope, isolate_id, local.into())
+    }
+
+    fn js_string_from_str(&self, string: &str) -> V8String {
+        V8String {
+            value: None,
+            utf16: Arc::from(string.encode_utf16().collect::<Vec<_>>()),
+        }
+    }
+}
+
+impl ExecutionContext<V8Types> for V8Engine {
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+
+    fn to_primitive(
+        &mut self,
+        input: V8Value,
+        preferred_type: Option<PreferredType>,
+    ) -> Completion<V8Value, V8Types> {
+        if input.object_profile.is_none() {
+            return Ok(input);
+        }
+        let hint = match preferred_type {
+            Some(PreferredType::String) => "string",
+            Some(PreferredType::Number) => "number",
+            None => "default",
+        };
+        let hint = self.value_from_string(self.js_string_from_str(hint));
+        self.call_js_helper(
+            "(value, hint) => { const exotic = value[Symbol.toPrimitive]; if (exotic !== undefined) { const result = exotic.call(value, hint); if (Object(result) === result) throw new TypeError('cannot convert object to primitive'); return result; } const methods = hint === 'string' ? ['toString', 'valueOf'] : ['valueOf', 'toString']; for (const name of methods) { const method = value[name]; if (typeof method === 'function') { const result = method.call(value); if (Object(result) !== result) return result; } } throw new TypeError('cannot convert object to primitive'); }",
+            &[input, hint],
+        )
+    }
+
+    fn to_boolean(&self, value: &V8Value) -> bool {
+        match &value.primitive {
+            CachedPrimitive::Undefined | CachedPrimitive::Null => false,
+            CachedPrimitive::Boolean(boolean) => *boolean,
+            CachedPrimitive::Number(number) => *number != 0.0 && !number.is_nan(),
+            CachedPrimitive::String(string) => !string.is_empty(),
+            CachedPrimitive::BigInt(canonical) => canonical.as_ref() != "0",
+            CachedPrimitive::Other => true,
+        }
+    }
+
+    fn to_number(&mut self, value: V8Value) -> Completion<f64, V8Types> {
+        let result = self.call_js_helper("value => Number(value)", &[value])?;
+        V8Types::value_as_number(&result)
+            .ok_or_else(|| self.new_type_error("ToNumber did not produce a number"))
+    }
+
+    fn to_numeric(&mut self, value: V8Value) -> Completion<Numeric<V8Types>, V8Types> {
+        if let Some(bigint) = V8Types::value_as_bigint(&value) {
+            return Ok(Numeric::BigInt(bigint));
+        }
+        self.to_number(value).map(Numeric::Number)
+    }
+
+    fn to_int32(&mut self, value: V8Value) -> Completion<i32, V8Types> {
+        let result = self.call_js_helper("value => value | 0", &[value])?;
+        Ok(V8Types::value_as_number(&result).unwrap_or(0.0) as i32)
+    }
+
+    fn to_uint32(&mut self, value: V8Value) -> Completion<u32, V8Types> {
+        let result = self.call_js_helper("value => value >>> 0", &[value])?;
+        Ok(V8Types::value_as_number(&result).unwrap_or(0.0) as u32)
+    }
+
+    fn to_int16(&mut self, value: V8Value) -> Completion<i16, V8Types> {
+        let result = self.call_js_helper("value => new Int16Array([value])[0]", &[value])?;
+        Ok(V8Types::value_as_number(&result).unwrap_or(0.0) as i16)
+    }
+
+    fn to_uint16(&mut self, value: V8Value) -> Completion<u16, V8Types> {
+        let result = self.call_js_helper("value => new Uint16Array([value])[0]", &[value])?;
+        Ok(V8Types::value_as_number(&result).unwrap_or(0.0) as u16)
+    }
+
+    fn to_int8(&mut self, value: V8Value) -> Completion<i8, V8Types> {
+        let result = self.call_js_helper("value => new Int8Array([value])[0]", &[value])?;
+        Ok(V8Types::value_as_number(&result).unwrap_or(0.0) as i8)
+    }
+
+    fn to_uint8(&mut self, value: V8Value) -> Completion<u8, V8Types> {
+        let result = self.call_js_helper("value => new Uint8Array([value])[0]", &[value])?;
+        Ok(V8Types::value_as_number(&result).unwrap_or(0.0) as u8)
+    }
+
+    fn to_uint8_clamp(&mut self, value: V8Value) -> Completion<u8, V8Types> {
+        let result = self.call_js_helper("value => new Uint8ClampedArray([value])[0]", &[value])?;
+        Ok(V8Types::value_as_number(&result).unwrap_or(0.0) as u8)
+    }
+
+    fn to_bigint(&mut self, value: V8Value) -> Completion<V8BigInt, V8Types> {
+        let result = self.call_js_helper("value => BigInt(value)", &[value])?;
+        V8Types::value_as_bigint(&result)
+            .ok_or_else(|| self.new_type_error("ToBigInt did not produce a BigInt"))
+    }
+
+    fn string_to_bigint(&mut self, string: V8String) -> Option<V8BigInt> {
+        let value = self.value_from_string(string);
+        self.call_js_helper("value => BigInt(value)", &[value])
+            .ok()
+            .and_then(|value| V8Types::value_as_bigint(&value))
+    }
+
+    fn to_js_string(&mut self, value: V8Value) -> Completion<V8String, V8Types> {
+        let result = self.call_js_helper(
+            "value => { if (typeof value === 'symbol') throw new TypeError('cannot convert Symbol to string'); return `${value}`; }",
+            &[value],
+        )?;
+        V8Types::value_as_string(&result)
+            .ok_or_else(|| self.new_type_error("ToString did not produce a string"))
+    }
+
+    fn to_object(&mut self, value: V8Value) -> Completion<V8Object, V8Types> {
+        let result = self.call_js_helper(
+            "value => { if (value == null) throw new TypeError('cannot convert null or undefined to object'); return Object(value); }",
+            &[value],
+        )?;
+        V8Types::value_as_object(&result)
+            .ok_or_else(|| self.new_type_error("ToObject did not produce an object"))
+    }
+
+    fn to_property_key(&mut self, value: V8Value) -> Completion<V8PropertyKey, V8Types> {
+        let primitive = self.to_primitive(value, Some(PreferredType::String))?;
+        if let Some(symbol) = V8Types::value_as_symbol(&primitive) {
+            Ok(V8PropertyKey::Symbol(symbol))
+        } else {
+            self.to_js_string(primitive).map(V8PropertyKey::String)
+        }
+    }
+
+    fn to_length(&mut self, value: V8Value) -> Completion<u64, V8Types> {
+        let result = self.call_js_helper(
+            "value => Math.min(Math.max(Math.trunc(Number(value)) || 0, 0), Number.MAX_SAFE_INTEGER)",
+            &[value],
+        )?;
+        Ok(V8Types::value_as_number(&result).unwrap_or(0.0) as u64)
+    }
+
+    fn canonical_numeric_index_string(&self, argument: &V8String) -> Option<f64> {
+        let string = String::from_utf16_lossy(&argument.utf16);
+        if string == "-0" {
+            return Some(-0.0);
+        }
+        let number = string.parse::<f64>().ok()?;
+        let canonical = if number.is_nan() {
+            "NaN".to_owned()
+        } else if number == f64::INFINITY {
+            "Infinity".to_owned()
+        } else if number == f64::NEG_INFINITY {
+            "-Infinity".to_owned()
+        } else {
+            number.to_string()
+        };
+        (canonical == string).then_some(number)
+    }
+
+    fn to_index(&mut self, value: V8Value) -> Completion<u64, V8Types> {
+        let result = self.call_js_helper(
+            "value => { if (value === undefined) return 0; const integer = Math.trunc(Number(value)); if (integer < 0 || integer > Number.MAX_SAFE_INTEGER || !Number.isFinite(integer)) throw new RangeError('invalid index'); return integer || 0; }",
+            &[value],
+        )?;
+        Ok(V8Types::value_as_number(&result).unwrap_or(0.0) as u64)
+    }
+
+    fn require_object_coercible(&mut self, value: V8Value) -> Completion<V8Value, V8Types> {
+        if V8Types::value_is_null(&value) || V8Types::value_is_undefined(&value) {
+            Err(self.new_type_error("value is null or undefined"))
+        } else {
+            Ok(value)
+        }
+    }
+
+    fn is_array(&mut self, value: &V8Value) -> Completion<bool, V8Types> {
+        let result = self.call_js_helper("value => Array.isArray(value)", &[value.clone()])?;
+        Ok(V8Types::value_as_bool(&result).unwrap_or(false))
+    }
+
+    fn is_constructor(&self, value: &V8Value) -> bool {
+        value
+            .object_profile
+            .as_ref()
+            .is_some_and(|profile| profile.is_constructor)
+    }
+
+    fn is_extensible(&mut self, object: &V8Object) -> Completion<bool, V8Types> {
+        let result = self.call_js_helper("value => Object.isExtensible(value)", &[object.0.clone()])?;
+        Ok(V8Types::value_as_bool(&result).unwrap_or(false))
+    }
+
+    fn is_integral_number(&self, value: &V8Value) -> bool {
+        V8Types::value_as_number(value).is_some_and(|number| number.is_finite() && number.fract() == 0.0)
+    }
+
+    fn is_property_key(&self, value: &V8Value) -> bool {
+        V8Types::value_as_string(value).is_some() || V8Types::value_as_symbol(value).is_some()
+    }
+
+    fn same_value(&self, left: &V8Value, right: &V8Value) -> bool {
+        if left.isolate_id != right.isolate_id {
+            return false;
+        }
+        match (&left.primitive, &right.primitive) {
+            (CachedPrimitive::Undefined, CachedPrimitive::Undefined)
+            | (CachedPrimitive::Null, CachedPrimitive::Null) => true,
+            (CachedPrimitive::Boolean(left), CachedPrimitive::Boolean(right)) => left == right,
+            (CachedPrimitive::Number(left), CachedPrimitive::Number(right)) => {
+                (left.is_nan() && right.is_nan())
+                    || (left == right && (left != &0.0 || left.is_sign_positive() == right.is_sign_positive()))
+            }
+            (CachedPrimitive::String(left), CachedPrimitive::String(right)) => left == right,
+            (CachedPrimitive::BigInt(left), CachedPrimitive::BigInt(right)) => left == right,
+            (CachedPrimitive::Other, CachedPrimitive::Other) => left.handle == right.handle,
+            _ => false,
+        }
+    }
+
+    fn same_value_zero(&self, left: &V8Value, right: &V8Value) -> bool {
+        if let (Some(left_number), Some(right_number)) = (
+            V8Types::value_as_number(left),
+            V8Types::value_as_number(right),
+        ) {
+            return left_number == right_number || (left_number.is_nan() && right_number.is_nan());
+        }
+        self.is_strictly_equal(left, right)
+    }
+
+    fn is_loosely_equal(&mut self, left: V8Value, right: V8Value) -> Completion<bool, V8Types> {
+        let result = self.call_js_helper("(left, right) => left == right", &[left, right])?;
+        Ok(V8Types::value_as_bool(&result).unwrap_or(false))
+    }
+
+    fn is_strictly_equal(&self, left: &V8Value, right: &V8Value) -> bool {
+        if left.isolate_id != right.isolate_id {
+            return false;
+        }
+        match (&left.primitive, &right.primitive) {
+            (CachedPrimitive::Number(left), CachedPrimitive::Number(right)) => {
+                !left.is_nan() && !right.is_nan() && left == right
+            }
+            _ => self.same_value(left, right),
+        }
+    }
+
+    fn get(
+        &mut self,
+        object: V8Object,
+        property_key: V8PropertyKey,
+    ) -> Completion<V8Value, V8Types> {
+        let _current_engine = CurrentEngineGuard::enter(self);
+        let isolate_id = self.isolate_id;
+        v8_engine_scope_with_context!(let scope, self, &self.realm.context);
+        v8::tc_scope!(let try_catch, scope);
+        let object = local_object(try_catch, isolate_id, &object)?;
+        let key = local_property_key(try_catch, isolate_id, &property_key)?;
+        let Some(value) = object.get(try_catch, key) else {
+            return Err(caught!(try_catch, isolate_id, "property get failed"));
+        };
+        Ok(wrap_local_value(try_catch, isolate_id, value))
+    }
+
+    fn get_v(
+        &mut self,
+        value: V8Value,
+        property_key: V8PropertyKey,
+    ) -> Completion<V8Value, V8Types> {
+        let object = self.to_object(value)?;
+        ExecutionContext::get(self, object, property_key)
+    }
+
+    fn set(
+        &mut self,
+        object: V8Object,
+        property_key: V8PropertyKey,
+        value: V8Value,
+        throw: bool,
+    ) -> Completion<(), V8Types> {
+        let _current_engine = CurrentEngineGuard::enter(self);
+        let isolate_id = self.isolate_id;
+        v8_engine_scope_with_context!(let scope, self, &self.realm.context);
+        v8::tc_scope!(let try_catch, scope);
+        let object = local_object(try_catch, isolate_id, &object)?;
+        let key = local_property_key(try_catch, isolate_id, &property_key)?;
+        let value = local_value(try_catch, isolate_id, &value)?;
+        match object.set(try_catch, key, value) {
+            Some(true) => Ok(()),
+            Some(false) if !throw => Ok(()),
+            Some(false) => Err(caught_exception(
+                try_catch,
+                isolate_id,
+                None,
+                "property assignment was rejected",
+            )),
+            None => Err(caught!(try_catch, isolate_id, "property assignment failed")),
+        }
+    }
+
+    fn create_data_property(
+        &mut self,
+        object: V8Object,
+        property_key: V8PropertyKey,
+        value: V8Value,
+    ) -> Completion<bool, V8Types> {
+        let _current_engine = CurrentEngineGuard::enter(self);
+        let isolate_id = self.isolate_id;
+        v8_engine_scope_with_context!(let scope, self, &self.realm.context);
+        v8::tc_scope!(let try_catch, scope);
+        let object = local_object(try_catch, isolate_id, &object)?;
+        let key = local_name(try_catch, isolate_id, &property_key)?;
+        let value = local_value(try_catch, isolate_id, &value)?;
+        object
+            .create_data_property(try_catch, key, value)
+            .ok_or_else(|| caught!(try_catch, isolate_id, "CreateDataProperty failed"))
+    }
+
+    fn to_property_descriptor(
+        &mut self,
+        descriptor_object: V8Object,
+    ) -> Completion<PropertyDescriptor<V8Types>, V8Types> {
+        let mut descriptor = PropertyDescriptor {
+            value: None,
+            writable: None,
+            get: None,
+            set: None,
+            enumerable: None,
+            configurable: None,
+        };
+        for property in ["enumerable", "configurable", "value", "writable", "get", "set"] {
+            let key = self.property_key_from_str(property);
+            if !self.has_property(descriptor_object.clone(), key.clone())? {
+                continue;
+            }
+            let value = ExecutionContext::get(self, descriptor_object.clone(), key)?;
+            match property {
+                "enumerable" => descriptor.enumerable = Some(self.to_boolean(&value)),
+                "configurable" => descriptor.configurable = Some(self.to_boolean(&value)),
+                "value" => descriptor.value = Some(value),
+                "writable" => descriptor.writable = Some(self.to_boolean(&value)),
+                "get" => {
+                    if !V8Types::value_is_undefined(&value) {
+                        let object = V8Types::value_as_object(&value)
+                            .and_then(|object| V8Types::object_as_function(&object))
+                            .ok_or_else(|| self.new_type_error("descriptor getter is not callable"))?;
+                        descriptor.get = Some(object);
+                    }
+                }
+                "set" => {
+                    if !V8Types::value_is_undefined(&value) {
+                        let object = V8Types::value_as_object(&value)
+                            .and_then(|object| V8Types::object_as_function(&object))
+                            .ok_or_else(|| self.new_type_error("descriptor setter is not callable"))?;
+                        descriptor.set = Some(object);
+                    }
+                }
+                _ => unreachable!(),
+            }
+        }
+        if (descriptor.get.is_some() || descriptor.set.is_some())
+            && (descriptor.value.is_some() || descriptor.writable.is_some())
+        {
+            return Err(self.new_type_error("invalid mixed property descriptor"));
+        }
+        Ok(descriptor)
+    }
+
+    fn define_property_or_throw(
+        &mut self,
+        object: V8Object,
+        property_key: V8PropertyKey,
+        descriptor: PropertyDescriptor<V8Types>,
+    ) -> Completion<(), V8Types> {
+        let _current_engine = CurrentEngineGuard::enter(self);
+        let isolate_id = self.isolate_id;
+        v8_engine_scope_with_context!(let scope, self, &self.realm.context);
+        v8::tc_scope!(let try_catch, scope);
+        let object = local_object(try_catch, isolate_id, &object)?;
+        let key = local_name(try_catch, isolate_id, &property_key)?;
+
+        let undefined = v8::undefined(try_catch).into();
+        let mut v8_descriptor = if descriptor.get.is_some() || descriptor.set.is_some() {
+            let getter = match &descriptor.get {
+                Some(getter) => local_value(try_catch, isolate_id, &getter.0)?,
+                None => undefined,
+            };
+            let setter = match &descriptor.set {
+                Some(setter) => local_value(try_catch, isolate_id, &setter.0)?,
+                None => undefined,
+            };
+            v8::PropertyDescriptor::new_from_get_set(getter, setter)
+        } else {
+            let value = match &descriptor.value {
+                Some(value) => local_value(try_catch, isolate_id, value)?,
+                None => undefined,
+            };
+            v8::PropertyDescriptor::new_from_value_writable(
+                value,
+                descriptor.writable.unwrap_or(false),
+            )
+        };
+        if let Some(enumerable) = descriptor.enumerable {
+            v8_descriptor.set_enumerable(enumerable);
+        }
+        if let Some(configurable) = descriptor.configurable {
+            v8_descriptor.set_configurable(configurable);
+        }
+        match object.define_property(try_catch, key, &v8_descriptor) {
+            Some(true) => Ok(()),
+            Some(false) => Err(caught_exception(
+                try_catch,
+                isolate_id,
+                None,
+                "DefinePropertyOrThrow was rejected",
+            )),
+            None => Err(caught!(try_catch, isolate_id, "DefinePropertyOrThrow failed")),
+        }
+    }
+
+    fn delete_property_or_throw(
+        &mut self,
+        object: V8Object,
+        property_key: V8PropertyKey,
+    ) -> Completion<(), V8Types> {
+        let _current_engine = CurrentEngineGuard::enter(self);
+        let isolate_id = self.isolate_id;
+        v8_engine_scope_with_context!(let scope, self, &self.realm.context);
+        v8::tc_scope!(let try_catch, scope);
+        let object = local_object(try_catch, isolate_id, &object)?;
+        let key = local_property_key(try_catch, isolate_id, &property_key)?;
+        match object.delete(try_catch, key) {
+            Some(true) => Ok(()),
+            Some(false) => Err(caught_exception(
+                try_catch,
+                isolate_id,
+                None,
+                "DeletePropertyOrThrow was rejected",
+            )),
+            None => Err(caught!(try_catch, isolate_id, "DeletePropertyOrThrow failed")),
+        }
+    }
+
+    fn get_prototype_of(&mut self, object: V8Object) -> Completion<Option<V8Object>, V8Types> {
+        let isolate_id = self.isolate_id;
+        v8_engine_scope_with_context!(let scope, self, &self.realm.context);
+        let object = local_object(scope, isolate_id, &object)?;
+        let prototype = object
+            .get_prototype(scope)
+            .ok_or_else(|| caught_exception(scope, isolate_id, None, "GetPrototypeOf failed"))?;
+        if prototype.is_null() {
+            Ok(None)
+        } else {
+            Ok(Some(V8Object(wrap_local_value(scope, isolate_id, prototype))))
+        }
+    }
+
+    fn set_prototype(
+        &mut self,
+        object: V8Object,
+        prototype: Option<V8Object>,
+    ) -> Completion<bool, V8Types> {
+        let isolate_id = self.isolate_id;
+        v8_engine_scope_with_context!(let scope, self, &self.realm.context);
+        let object = local_object(scope, isolate_id, &object)?;
+        let prototype = match &prototype {
+            Some(prototype) => local_value(scope, isolate_id, &prototype.0)?,
+            None => v8::null(scope).into(),
+        };
+        object
+            .set_prototype(scope, prototype)
+            .ok_or_else(|| caught_exception(scope, isolate_id, None, "SetPrototypeOf failed"))
+    }
+
+    fn get_method(
+        &mut self,
+        value: V8Value,
+        property_key: V8PropertyKey,
+    ) -> Completion<Option<V8Object>, V8Types> {
+        let method = self.get_v(value, property_key)?;
+        if V8Types::value_is_null(&method) || V8Types::value_is_undefined(&method) {
+            return Ok(None);
+        }
+        let function = V8Types::value_as_object(&method)
+            .and_then(|object| V8Types::object_as_function(&object))
+            .ok_or_else(|| self.new_type_error("property is not callable"))?;
+        Ok(Some(function))
+    }
+
+    fn has_property(
+        &mut self,
+        object: V8Object,
+        property_key: V8PropertyKey,
+    ) -> Completion<bool, V8Types> {
+        let _current_engine = CurrentEngineGuard::enter(self);
+        let isolate_id = self.isolate_id;
+        v8_engine_scope_with_context!(let scope, self, &self.realm.context);
+        v8::tc_scope!(let try_catch, scope);
+        let object = local_object(try_catch, isolate_id, &object)?;
+        let key = local_property_key(try_catch, isolate_id, &property_key)?;
+        object
+            .has(try_catch, key)
+            .ok_or_else(|| caught!(try_catch, isolate_id, "HasProperty failed"))
+    }
+
+    fn has_own_property(
+        &mut self,
+        object: V8Object,
+        property_key: V8PropertyKey,
+    ) -> Completion<bool, V8Types> {
+        let _current_engine = CurrentEngineGuard::enter(self);
+        let isolate_id = self.isolate_id;
+        v8_engine_scope_with_context!(let scope, self, &self.realm.context);
+        v8::tc_scope!(let try_catch, scope);
+        let object = local_object(try_catch, isolate_id, &object)?;
+        let key = local_name(try_catch, isolate_id, &property_key)?;
+        object
+            .has_own_property(try_catch, key)
+            .ok_or_else(|| caught!(try_catch, isolate_id, "HasOwnProperty failed"))
+    }
+
+    fn own_property_keys(&mut self, object: V8Object) -> Completion<Vec<V8PropertyKey>, V8Types> {
+        let array = self.call_js_helper("object => Reflect.ownKeys(object)", &[object.0])?;
+        let array = V8Types::value_as_object(&array)
+            .ok_or_else(|| self.new_type_error("Reflect.ownKeys did not return an array"))?;
+        let length_value = ExecutionContext::get(self, array.clone(), self.property_key_from_str("length"))?;
+        let length = V8Types::value_as_number(&length_value).unwrap_or(0.0) as u32;
+        let mut keys = Vec::with_capacity(length as usize);
+        for index in 0..length {
+            let value = ExecutionContext::get(self, array.clone(), V8PropertyKey::Index(index))?;
+            keys.push(self.to_property_key(value)?);
+        }
+        Ok(keys)
+    }
+
+    fn get_own_property(
+        &mut self,
+        object: V8Object,
+        property_key: V8PropertyKey,
+    ) -> Completion<Option<PropertyDescriptor<V8Types>>, V8Types> {
+        let descriptor = {
+            let _current_engine = CurrentEngineGuard::enter(self);
+            let isolate_id = self.isolate_id;
+        v8_engine_scope_with_context!(let scope, self, &self.realm.context);
+            v8::tc_scope!(let try_catch, scope);
+            let object = local_object(try_catch, isolate_id, &object)?;
+            let key = local_name(try_catch, isolate_id, &property_key)?;
+            let Some(descriptor) = object.get_own_property_descriptor(try_catch, key) else {
+                if let Some(exception) = try_catch.exception() {
+                    return Err(caught_exception(
+                        try_catch,
+                        isolate_id,
+                        Some(exception),
+                        "GetOwnProperty failed",
+                    ));
+                }
+                return Ok(None);
+            };
+            if descriptor.is_undefined() {
+                return Ok(None);
+            }
+            V8Types::value_as_object(&wrap_local_value(try_catch, isolate_id, descriptor))
+                .ok_or_else(|| {
+                    caught_exception(
+                        try_catch,
+                        isolate_id,
+                        None,
+                        "invalid property descriptor",
+                    )
+                })?
+        };
+        self.to_property_descriptor(descriptor).map(Some)
+    }
+
+    fn construct(
+        &mut self,
+        function: V8Object,
+        arguments: &[V8Value],
+        new_target: Option<V8Object>,
+    ) -> Completion<V8Object, V8Types> {
+        if new_target.is_some() {
+            let mut helper_arguments = vec![function.0];
+            helper_arguments.push(new_target.expect("new target checked above").0);
+            helper_arguments.extend_from_slice(arguments);
+            let result = self.call_js_helper(
+                "(constructor, newTarget, ...args) => Reflect.construct(constructor, args, newTarget)",
+                &helper_arguments,
+            )?;
+            return V8Types::value_as_object(&result)
+                .ok_or_else(|| self.new_type_error("constructor did not return an object"));
+        }
+
+        let wrapper_primitive = self.intrinsics.as_ref().and_then(|intrinsics| {
+            let argument = arguments.first().map(|value| value.primitive.clone());
+            if function == intrinsics.boolean {
+                Some(argument.unwrap_or(CachedPrimitive::Boolean(false)))
+            } else if function == intrinsics.number {
+                Some(argument.unwrap_or(CachedPrimitive::Number(0.0)))
+            } else if function == intrinsics.string {
+                Some(argument.unwrap_or_else(|| CachedPrimitive::String(Arc::from([]))))
+            } else if function == intrinsics.bigint {
+                argument
+            } else {
+                None
+            }
+        });
+        let _current_engine = CurrentEngineGuard::enter(self);
+        let isolate_id = self.isolate_id;
+        v8_engine_scope_with_context!(let scope, self, &self.realm.context);
+        v8::tc_scope!(let try_catch, scope);
+        let function = local_value(try_catch, isolate_id, &function.0)?;
+        let function = v8::Local::<v8::Function>::try_from(function)
+            .map_err(|_| caught_exception(try_catch, isolate_id, None, "value is not a constructor"))?;
+        let local_arguments: Result<Vec<_>, _> = arguments
+            .iter()
+            .map(|argument| local_value(try_catch, isolate_id, argument))
+            .collect();
+        let Some(object) = function.new_instance(try_catch, &local_arguments?) else {
+            return Err(caught!(try_catch, isolate_id, "constructor call failed"));
+        };
+        let mut object = V8Object(wrap_local_value(try_catch, isolate_id, object.into()));
+        if let Some(wrapper_primitive) = wrapper_primitive {
+            if let Some(profile) = object.0.object_profile.as_mut() {
+                profile.wrapper_primitive = Some(wrapper_primitive);
+            }
+        }
+        Ok(object)
+    }
+
+    fn set_integrity_level(
+        &mut self,
+        object: V8Object,
+        level: IntegrityLevel,
+    ) -> Completion<bool, V8Types> {
+        let isolate_id = self.isolate_id;
+        v8_engine_scope_with_context!(let scope, self, &self.realm.context);
+        let object = local_object(scope, isolate_id, &object)?;
+        let level = match level {
+            IntegrityLevel::Sealed => v8::IntegrityLevel::Sealed,
+            IntegrityLevel::Frozen => v8::IntegrityLevel::Frozen,
+        };
+        object
+            .set_integrity_level(scope, level)
+            .ok_or_else(|| caught_exception(scope, isolate_id, None, "SetIntegrityLevel failed"))
+    }
+
+    fn test_integrity_level(
+        &mut self,
+        object: V8Object,
+        level: IntegrityLevel,
+    ) -> Completion<bool, V8Types> {
+        let source = match level {
+            IntegrityLevel::Sealed => "object => Object.isSealed(object)",
+            IntegrityLevel::Frozen => "object => Object.isFrozen(object)",
+        };
+        let result = self.call_js_helper(source, &[object.0])?;
+        Ok(V8Types::value_as_bool(&result).unwrap_or(false))
+    }
+
+    fn species_constructor(
+        &mut self,
+        object: V8Object,
+        default_constructor: V8Object,
+    ) -> Completion<V8Object, V8Types> {
+        let result = self.call_js_helper(
+            "(object, defaultConstructor) => { const constructor = object.constructor; if (constructor === undefined) return defaultConstructor; if (Object(constructor) !== constructor) throw new TypeError('constructor is not an object'); const species = constructor[Symbol.species]; if (species == null) return defaultConstructor; if (typeof species !== 'function') throw new TypeError('species is not a constructor'); return species; }",
+            &[object.0, default_constructor.0],
+        )?;
+        V8Types::value_as_object(&result)
+            .ok_or_else(|| self.new_type_error("SpeciesConstructor did not return an object"))
+    }
+
+    fn get_function_realm(&mut self, function: &V8Object) -> Completion<V8Realm, V8Types> {
+        if function.0.isolate_id != self.isolate_id {
+            Err(self.new_type_error("function belongs to a different V8 isolate"))
+        } else {
+            Ok(self.realm.clone())
+        }
+    }
+
+    fn get_iterator(
+        &mut self,
+        object: V8Value,
+        kind: IteratorKind,
+        method: Option<V8Object>,
+    ) -> Completion<IteratorRecord<V8Types>, V8Types> {
+        let method = match method {
+            Some(method) => method,
+            None => {
+                let symbol_name = match kind {
+                    IteratorKind::Sync => "iterator",
+                    IteratorKind::Async => "asyncIterator",
+                };
+                let key = self.property_key_from_well_known_symbol(symbol_name);
+                self.get_method(object.clone(), key)?
+                    .ok_or_else(|| self.new_type_error("value is not iterable"))?
+            }
+        };
+        let iterator_value = EcmascriptHost::call(self, &method, &object, &[])?;
+        let iterator = V8Types::value_as_object(&iterator_value)
+            .ok_or_else(|| self.new_type_error("iterator method did not return an object"))?;
+        let next = self
+            .get_method(
+                iterator_value,
+                self.property_key_from_str("next"),
+            )?
+            .ok_or_else(|| self.new_type_error("iterator has no next method"))?;
+        Ok(IteratorRecord {
+            iterator,
+            next_method: next,
+            done: false,
+        })
+    }
+
+    fn iterator_step_value(
+        &mut self,
+        iterator: &mut IteratorRecord<V8Types>,
+    ) -> Completion<Option<V8Value>, V8Types> {
+        let this_value = iterator.iterator.0.clone();
+        let result = EcmascriptHost::call(self, &iterator.next_method, &this_value, &[])?;
+        let result_object = V8Types::value_as_object(&result)
+            .ok_or_else(|| self.new_type_error("iterator result is not an object"))?;
+        let done = ExecutionContext::get(
+            self,
+            result_object.clone(),
+            self.property_key_from_str("done"),
+        )?;
+        if self.to_boolean(&done) {
+            iterator.done = true;
+            return Ok(None);
+        }
+        ExecutionContext::get(self, result_object, self.property_key_from_str("value")).map(Some)
+    }
+
+    fn iterator_close(
+        &mut self,
+        iterator: IteratorRecord<V8Types>,
+        completion: Completion<V8Value, V8Types>,
+    ) -> Completion<V8Value, V8Types> {
+        let iterator_value = iterator.iterator.0.clone();
+        if let Some(return_method) = self.get_method(
+            iterator_value.clone(),
+            self.property_key_from_str("return"),
+        )? {
+            let close_result = EcmascriptHost::call(self, &return_method, &iterator_value, &[])?;
+            if V8Types::value_as_object(&close_result).is_none() {
+                return Err(self.new_type_error("iterator return method did not return an object"));
+            }
+        }
+        completion
+    }
+
+    fn async_iterator_close(
+        &mut self,
+        iterator: IteratorRecord<V8Types>,
+        completion: Completion<V8Value, V8Types>,
+    ) -> Completion<V8Value, V8Types> {
+        self.iterator_close(iterator, completion)
+    }
+
+    fn current_realm(&self) -> V8Realm {
+        self.realm.clone()
+    }
+
+    fn realm_global_object(&self) -> V8Object {
+        self.realm_global.clone()
+    }
+
+    fn realm_intrinsics(&self, realm: &V8Realm) -> RealmIntrinsics<V8Types> {
+        assert_eq!(realm.isolate_id, self.isolate_id, "realm belongs to a different V8 isolate");
+        self.intrinsics
+            .as_ref()
+            .expect("V8 intrinsics are not initialized")
+            .clone()
+    }
+
+    fn enqueue_job(&mut self, job: Box<dyn FnOnce()>) {
+        self.queued_jobs.push_back(QueuedJob::Plain(job));
+    }
+
+    fn enqueue_job_with_realm(
+        &mut self,
+        realm: V8Realm,
+        job: Box<dyn FnOnce(&mut dyn ExecutionContext<V8Types>)>,
+    ) {
+        self.queued_jobs.push_back(QueuedJob::WithRealm(realm, job));
+    }
+
+    fn run_jobs(&mut self) {
+        if let Err(exception) = self.perform_a_microtask_checkpoint() {
+            self.report_exception(exception);
+        }
+    }
+
+    fn is_detached_buffer(&self, array_buffer: &V8Object) -> bool {
+        array_buffer
+            .0
+            .object_profile
+            .as_ref()
+            .and_then(|profile| profile.array_buffer_state.as_ref())
+            .is_some_and(|state| state.detached.get())
+    }
+
+    fn is_fixed_length_array_buffer(&self, array_buffer: &V8Object) -> bool {
+        array_buffer
+            .0
+            .object_profile
+            .as_ref()
+            .and_then(|profile| profile.array_buffer_state.as_ref())
+            .is_some_and(|state| !state.resizable)
+    }
+
+    fn allocate_array_buffer(
+        &mut self,
+        _constructor: V8Object,
+        byte_length: u64,
+        max_byte_length: Option<u64>,
+    ) -> Completion<V8Object, V8Types> {
+        if let Some(max_byte_length) = max_byte_length {
+            let byte_length = self.value_from_number(byte_length as f64);
+            let max_byte_length = self.value_from_number(max_byte_length as f64);
+            let value = self.call_js_helper(
+                "(length, maxByteLength) => new ArrayBuffer(length, { maxByteLength })",
+                &[byte_length, max_byte_length],
+            )?;
+            return V8Types::value_as_object(&value)
+                .ok_or_else(|| self.new_type_error("ArrayBuffer allocation failed"));
+        }
+        let isolate_id = self.isolate_id;
+        let byte_length = usize::try_from(byte_length)
+            .map_err(|_| self.new_range_error("ArrayBuffer length is too large"))?;
+        v8_engine_scope_with_context!(let scope, self, &self.realm.context);
+        let array_buffer = v8::ArrayBuffer::new(scope, byte_length);
+        Ok(V8Object(wrap_local_value(scope, isolate_id, array_buffer.into())))
+    }
+
+    fn clone_array_buffer(
+        &mut self,
+        source: V8Object,
+        source_byte_offset: u64,
+        source_length: u64,
+        constructor: V8Object,
+    ) -> Completion<V8Object, V8Types> {
+        let bytes = self
+            .array_buffer_data(&source)
+            .ok_or_else(|| self.new_type_error("source ArrayBuffer is detached"))?;
+        let start = usize::try_from(source_byte_offset)
+            .map_err(|_| self.new_range_error("source byte offset is too large"))?;
+        let length = usize::try_from(source_length)
+            .map_err(|_| self.new_range_error("source length is too large"))?;
+        let end = start
+            .checked_add(length)
+            .filter(|end| *end <= bytes.len())
+            .ok_or_else(|| self.new_range_error("ArrayBuffer clone range is out of bounds"))?;
+        let clone = ExecutionContext::allocate_array_buffer(
+            self,
+            constructor,
+            source_length,
+            None,
+        )?;
+        let state = clone
+            .0
+            .object_profile
+            .as_ref()
+            .and_then(|profile| profile.array_buffer_state.as_ref())
+            .expect("new ArrayBuffer has no backing store");
+        for (destination, source) in state.backing_store.iter().zip(&bytes[start..end]) {
+            Cell::set(destination, *source);
+        }
+        Ok(clone)
+    }
+
+    fn detach_array_buffer(
+        &mut self,
+        array_buffer: V8Object,
+        key: Option<V8Value>,
+    ) -> Completion<(), V8Types> {
+        let isolate_id = self.isolate_id;
+        v8_engine_scope_with_context!(let scope, self, &self.realm.context);
+        let value = local_value(scope, isolate_id, &array_buffer.0)?;
+        let local = v8::Local::<v8::ArrayBuffer>::try_from(value)
+            .map_err(|_| caught_exception(scope, isolate_id, None, "value is not an ArrayBuffer"))?;
+        let key = key
+            .as_ref()
+            .map(|key| local_value(scope, isolate_id, key))
+            .transpose()?;
+        match local.detach(key) {
+            Some(true) => {
+                if let Some(state) = array_buffer
+                    .0
+                    .object_profile
+                    .as_ref()
+                    .and_then(|profile| profile.array_buffer_state.as_ref())
+                {
+                    state.detached.set(true);
+                }
+                Ok(())
+            }
+            Some(false) | None => Err(caught_exception(
+                scope,
+                isolate_id,
+                None,
+                "ArrayBuffer detach key did not match",
+            )),
+        }
+    }
+
+    fn get_value_from_buffer(
+        &mut self,
+        array_buffer: &V8Object,
+        byte_index: u64,
+        element_type: TypedArrayElementType,
+        _is_typed_array: bool,
+        _order: SharedMemoryOrder,
+    ) -> V8Value {
+        let constructor = match element_type {
+            TypedArrayElementType::Int8 => "Int8Array",
+            TypedArrayElementType::Uint8 => "Uint8Array",
+            TypedArrayElementType::Uint8Clamped => "Uint8ClampedArray",
+            TypedArrayElementType::Int16 => "Int16Array",
+            TypedArrayElementType::Uint16 => "Uint16Array",
+            TypedArrayElementType::Int32 => "Int32Array",
+            TypedArrayElementType::Uint32 => "Uint32Array",
+            TypedArrayElementType::Float16 => "Float16Array",
+            TypedArrayElementType::Float32 => "Float32Array",
+            TypedArrayElementType::Float64 => "Float64Array",
+            TypedArrayElementType::BigInt64 => "BigInt64Array",
+            TypedArrayElementType::BigUint64 => "BigUint64Array",
+        };
+        let byte_index = self.value_from_number(byte_index as f64);
+        self.call_js_helper(
+            &format!("(buffer, offset) => new {constructor}(buffer, offset, 1)[0]"),
+            &[array_buffer.0.clone(), byte_index],
+        )
+        .unwrap_or_else(|exception| exception)
+    }
+
+    fn set_value_in_buffer(
+        &mut self,
+        array_buffer: &V8Object,
+        byte_index: u64,
+        element_type: TypedArrayElementType,
+        value: V8Value,
+        _is_typed_array: bool,
+        _order: SharedMemoryOrder,
+    ) -> Completion<(), V8Types> {
+        let constructor = match element_type {
+            TypedArrayElementType::Int8 => "Int8Array",
+            TypedArrayElementType::Uint8 => "Uint8Array",
+            TypedArrayElementType::Uint8Clamped => "Uint8ClampedArray",
+            TypedArrayElementType::Int16 => "Int16Array",
+            TypedArrayElementType::Uint16 => "Uint16Array",
+            TypedArrayElementType::Int32 => "Int32Array",
+            TypedArrayElementType::Uint32 => "Uint32Array",
+            TypedArrayElementType::Float16 => "Float16Array",
+            TypedArrayElementType::Float32 => "Float32Array",
+            TypedArrayElementType::Float64 => "Float64Array",
+            TypedArrayElementType::BigInt64 => "BigInt64Array",
+            TypedArrayElementType::BigUint64 => "BigUint64Array",
+        };
+        let byte_index = self.value_from_number(byte_index as f64);
+        self.call_js_helper(
+            &format!("(buffer, offset, value) => {{ new {constructor}(buffer, offset, 1)[0] = value; }}"),
+            &[array_buffer.0.clone(), byte_index, value],
+        )?;
+        Ok(())
+    }
+
+    fn typed_array_buffer(&mut self, typed_array: &V8Object) -> Completion<V8Object, V8Types> {
+        let value = self.call_js_helper("view => view.buffer", &[typed_array.0.clone()])?;
+        V8Types::value_as_object(&value)
+            .ok_or_else(|| self.new_type_error("typed array has no ArrayBuffer"))
+    }
+
+    fn typed_array_byte_offset(&mut self, typed_array: &V8Object) -> Completion<u64, V8Types> {
+        let value = self.call_js_helper("view => view.byteOffset", &[typed_array.0.clone()])?;
+        Ok(V8Types::value_as_number(&value).unwrap_or(0.0) as u64)
+    }
+
+    fn typed_array_byte_length(&mut self, typed_array: &V8Object) -> Completion<u64, V8Types> {
+        let value = self.call_js_helper("view => view.byteLength", &[typed_array.0.clone()])?;
+        Ok(V8Types::value_as_number(&value).unwrap_or(0.0) as u64)
+    }
+
+    fn typed_array_element_type(&self, typed_array: &V8Object) -> Option<TypedArrayElementType> {
+        typed_array
+            .0
+            .object_profile
+            .as_ref()
+            .and_then(|profile| profile.typed_array_element_type)
+    }
+
+    fn construct_typed_array_view(
+        &mut self,
+        element_type: TypedArrayElementType,
+        buffer: V8Object,
+        byte_offset: u64,
+        byte_length: u64,
+    ) -> Completion<V8Object, V8Types> {
+        let isolate_id = self.isolate_id;
+        let byte_offset = usize::try_from(byte_offset)
+            .map_err(|_| self.new_range_error("typed array byte offset is too large"))?;
+        let element_size = match element_type {
+            TypedArrayElementType::Int8
+            | TypedArrayElementType::Uint8
+            | TypedArrayElementType::Uint8Clamped => 1,
+            TypedArrayElementType::Int16
+            | TypedArrayElementType::Uint16
+            | TypedArrayElementType::Float16 => 2,
+            TypedArrayElementType::Int32
+            | TypedArrayElementType::Uint32
+            | TypedArrayElementType::Float32 => 4,
+            TypedArrayElementType::Float64
+            | TypedArrayElementType::BigInt64
+            | TypedArrayElementType::BigUint64 => 8,
+        };
+        if byte_length % element_size != 0 {
+            return Err(self.new_range_error("typed array byte length is not element-aligned"));
+        }
+        let length = usize::try_from(byte_length / element_size)
+            .map_err(|_| self.new_range_error("typed array length is too large"))?;
+        v8_engine_scope_with_context!(let scope, self, &self.realm.context);
+        let buffer_value = local_value(scope, isolate_id, &buffer.0)?;
+        let buffer = v8::Local::<v8::ArrayBuffer>::try_from(buffer_value)
+            .map_err(|_| caught_exception(scope, isolate_id, None, "value is not an ArrayBuffer"))?;
+        if element_type == TypedArrayElementType::Float16 {
+            return Err(caught_exception(
+                scope,
+                isolate_id,
+                None,
+                "Float16Array is not exposed by this rusty_v8 build",
+            ));
+        }
+        let view: Option<v8::Local<v8::Value>> = match element_type {
+            TypedArrayElementType::Int8 => v8::Int8Array::new(scope, buffer, byte_offset, length).map(Into::into),
+            TypedArrayElementType::Uint8 => v8::Uint8Array::new(scope, buffer, byte_offset, length).map(Into::into),
+            TypedArrayElementType::Uint8Clamped => v8::Uint8ClampedArray::new(scope, buffer, byte_offset, length).map(Into::into),
+            TypedArrayElementType::Int16 => v8::Int16Array::new(scope, buffer, byte_offset, length).map(Into::into),
+            TypedArrayElementType::Uint16 => v8::Uint16Array::new(scope, buffer, byte_offset, length).map(Into::into),
+            TypedArrayElementType::Int32 => v8::Int32Array::new(scope, buffer, byte_offset, length).map(Into::into),
+            TypedArrayElementType::Uint32 => v8::Uint32Array::new(scope, buffer, byte_offset, length).map(Into::into),
+            TypedArrayElementType::Float16 => unreachable!(),
+            TypedArrayElementType::Float32 => v8::Float32Array::new(scope, buffer, byte_offset, length).map(Into::into),
+            TypedArrayElementType::Float64 => v8::Float64Array::new(scope, buffer, byte_offset, length).map(Into::into),
+            TypedArrayElementType::BigInt64 => v8::BigInt64Array::new(scope, buffer, byte_offset, length).map(Into::into),
+            TypedArrayElementType::BigUint64 => v8::BigUint64Array::new(scope, buffer, byte_offset, length).map(Into::into),
+        };
+        let view = view.ok_or_else(|| caught_exception(scope, isolate_id, None, "typed array construction failed"))?;
+        Ok(V8Object(wrap_local_value(scope, isolate_id, view)))
+    }
+
+    fn data_view_buffer(&mut self, data_view: &V8Object) -> Completion<V8Object, V8Types> {
+        let value = self.call_js_helper("view => view.buffer", &[data_view.0.clone()])?;
+        V8Types::value_as_object(&value)
+            .ok_or_else(|| self.new_type_error("DataView has no ArrayBuffer"))
+    }
+
+    fn data_view_byte_offset(&mut self, data_view: &V8Object) -> Completion<u64, V8Types> {
+        let value = self.call_js_helper("view => view.byteOffset", &[data_view.0.clone()])?;
+        Ok(V8Types::value_as_number(&value).unwrap_or(0.0) as u64)
+    }
+
+    fn data_view_byte_length(&mut self, data_view: &V8Object) -> Completion<u64, V8Types> {
+        let value = self.call_js_helper("view => view.byteLength", &[data_view.0.clone()])?;
+        Ok(V8Types::value_as_number(&value).unwrap_or(0.0) as u64)
+    }
+
+    fn construct_data_view_from_buffer(
+        &mut self,
+        buffer: V8Object,
+        byte_offset: u64,
+        byte_length: u64,
+    ) -> Completion<V8Object, V8Types> {
+        let isolate_id = self.isolate_id;
+        let byte_offset = usize::try_from(byte_offset)
+            .map_err(|_| self.new_range_error("DataView byte offset is too large"))?;
+        let byte_length = usize::try_from(byte_length)
+            .map_err(|_| self.new_range_error("DataView byte length is too large"))?;
+        v8_engine_scope_with_context!(let scope, self, &self.realm.context);
+        let buffer = local_value(scope, isolate_id, &buffer.0)?;
+        let buffer = v8::Local::<v8::ArrayBuffer>::try_from(buffer)
+            .map_err(|_| caught_exception(scope, isolate_id, None, "value is not an ArrayBuffer"))?;
+        let data_view = v8::DataView::new(scope, buffer, byte_offset, byte_length);
+        Ok(V8Object(wrap_local_value(scope, isolate_id, data_view.into())))
+    }
+
+    fn array_buffer_data(&self, array_buffer: &V8Object) -> Option<Vec<u8>> {
+        let state = array_buffer
+            .0
+            .object_profile
+            .as_ref()?
+            .array_buffer_state
+            .as_ref()?;
+        if state.detached.get() {
+            return None;
+        }
+        Some(state.backing_store.iter().map(Cell::get).collect())
+    }
+
+    fn get_date_value(&mut self, date: &V8Object) -> Completion<f64, V8Types> {
+        let value = self.call_js_helper("date => Date.prototype.getTime.call(date)", &[date.0.clone()])?;
+        V8Types::value_as_number(&value)
+            .ok_or_else(|| self.new_type_error("Date value is not a number"))
+    }
+
+    fn get_regexp_source(&mut self, regexp: &V8Object) -> Completion<String, V8Types> {
+        let value = self.call_js_helper("regexp => regexp.source", &[regexp.0.clone()])?;
+        self.to_rust_string(value)
+    }
+
+    fn get_regexp_flags(&mut self, regexp: &V8Object) -> Completion<String, V8Types> {
+        let value = self.call_js_helper("regexp => regexp.flags", &[regexp.0.clone()])?;
+        self.to_rust_string(value)
+    }
+
+    fn map_get_entries(&mut self, map: &V8Object) -> Completion<Vec<(V8Value, V8Value)>, V8Types> {
+        let entries = self.call_js_helper("map => Array.from(map.entries()).flat()", &[map.0.clone()])?;
+        let entries = V8Types::value_as_object(&entries)
+            .ok_or_else(|| self.new_type_error("Map entries did not produce an array"))?;
+        let length = ExecutionContext::get(self, entries.clone(), self.property_key_from_str("length"))?;
+        let length = V8Types::value_as_number(&length).unwrap_or(0.0) as u32;
+        let mut result = Vec::with_capacity((length / 2) as usize);
+        for index in (0..length).step_by(2) {
+            let key = ExecutionContext::get(self, entries.clone(), V8PropertyKey::Index(index))?;
+            let value = ExecutionContext::get(self, entries.clone(), V8PropertyKey::Index(index + 1))?;
+            result.push((key, value));
+        }
+        Ok(result)
+    }
+
+    fn map_set_entry(
+        &mut self,
+        map: &V8Object,
+        key: V8Value,
+        value: V8Value,
+    ) -> Completion<(), V8Types> {
+        self.call_js_helper("(map, key, value) => { map.set(key, value); }", &[map.0.clone(), key, value])?;
+        Ok(())
+    }
+
+    fn set_get_values(&mut self, set: &V8Object) -> Completion<Vec<V8Value>, V8Types> {
+        let values = self.call_js_helper("set => Array.from(set.values())", &[set.0.clone()])?;
+        let values = V8Types::value_as_object(&values)
+            .ok_or_else(|| self.new_type_error("Set values did not produce an array"))?;
+        let length = ExecutionContext::get(self, values.clone(), self.property_key_from_str("length"))?;
+        let length = V8Types::value_as_number(&length).unwrap_or(0.0) as u32;
+        let mut result = Vec::with_capacity(length as usize);
+        for index in 0..length {
+            result.push(ExecutionContext::get(self, values.clone(), V8PropertyKey::Index(index))?);
+        }
+        Ok(result)
+    }
+
+    fn set_add_entry(&mut self, set: &V8Object, value: V8Value) -> Completion<(), V8Types> {
+        self.call_js_helper("(set, value) => { set.add(value); }", &[set.0.clone(), value])?;
+        Ok(())
+    }
+
+    fn promise_resolve(
+        &mut self,
+        constructor: V8Object,
+        value: V8Value,
+    ) -> Completion<V8Object, V8Types> {
+        let promise = self.call_js_helper(
+            "(constructor, value) => Promise.resolve.call(constructor, value)",
+            &[constructor.0, value],
+        )?;
+        V8Types::value_as_object(&promise)
+            .ok_or_else(|| self.new_type_error("PromiseResolve did not return a promise"))
+    }
+
+    fn new_promise_capability(
+        &mut self,
+        constructor: V8Object,
+    ) -> Completion<PromiseCapability<V8Types>, V8Types> {
+        let parts = self.call_js_helper(
+            "constructor => { let resolve, reject; const promise = new constructor((res, rej) => { resolve = res; reject = rej; }); return [promise, resolve, reject]; }",
+            &[constructor.0],
+        )?;
+        let parts = V8Types::value_as_object(&parts)
+            .ok_or_else(|| self.new_type_error("promise capability did not produce an array"))?;
+        let promise = ExecutionContext::get(self, parts.clone(), V8PropertyKey::Index(0))?;
+        let resolve = ExecutionContext::get(self, parts.clone(), V8PropertyKey::Index(1))?;
+        let reject = ExecutionContext::get(self, parts, V8PropertyKey::Index(2))?;
+        let resolve = V8Types::value_as_object(&resolve)
+            .and_then(|object| V8Types::object_as_function(&object))
+            .ok_or_else(|| self.new_type_error("promise resolve is not callable"))?;
+        let reject = V8Types::value_as_object(&reject)
+            .and_then(|object| V8Types::object_as_function(&object))
+            .ok_or_else(|| self.new_type_error("promise reject is not callable"))?;
+        Ok(PromiseCapability {
+            promise,
+            resolve,
+            reject,
+        })
+    }
+
+    fn new_promise_pending(&mut self) -> Completion<(V8Value, PromiseResolvers<V8Types>), V8Types> {
+        let promise_constructor = self.realm_intrinsics(&self.realm).promise;
+        let capability = self.new_promise_capability(promise_constructor)?;
+        let promise = capability.promise;
+        let resolve = capability.resolve;
+        let reject = capability.reject;
+        let resolvers = PromiseResolvers::new(resolve, reject, self);
+        Ok((promise, resolvers))
+    }
+
+    fn perform_promise_then(
+        &mut self,
+        promise: V8Object,
+        on_fulfilled: Option<V8Object>,
+        on_rejected: Option<V8Object>,
+        result_capability: Option<PromiseCapability<V8Types>>,
+    ) -> Completion<V8Value, V8Types> {
+        let undefined = self.value_undefined();
+        let on_fulfilled = on_fulfilled.map_or_else(|| undefined.clone(), |function| function.0);
+        let on_rejected = on_rejected.map_or(undefined, |function| function.0);
+        if let Some(result_capability) = result_capability {
+            return self.call_js_helper(
+                "(promise, onFulfilled, onRejected, resultPromise, resolve, reject) => { promise.then(value => { try { resolve(onFulfilled === undefined ? value : onFulfilled(value)); } catch (error) { reject(error); } }, reason => { if (onRejected === undefined) { reject(reason); return; } try { resolve(onRejected(reason)); } catch (error) { reject(error); } }); return resultPromise; }",
+                &[
+                    promise.0,
+                    on_fulfilled,
+                    on_rejected,
+                    result_capability.promise,
+                    result_capability.resolve.0,
+                    result_capability.reject.0,
+                ],
+            );
+        }
+        self.call_js_helper(
+            "(promise, onFulfilled, onRejected) => promise.then(onFulfilled, onRejected)",
+            &[promise.0, on_fulfilled, on_rejected],
+        )
+    }
+
+    fn promise_state(&mut self, promise: &V8Object) -> Completion<PromiseState<V8Types>, V8Types> {
+        let isolate_id = self.isolate_id;
+        v8_engine_scope_with_context!(let scope, self, &self.realm.context);
+        let promise_value = local_value(scope, isolate_id, &promise.0)?;
+        let promise = v8::Local::<v8::Promise>::try_from(promise_value)
+            .map_err(|_| caught_exception(scope, isolate_id, None, "value is not a Promise"))?;
+        match promise.state() {
+            v8::PromiseState::Pending => Ok(PromiseState::Pending),
+            v8::PromiseState::Fulfilled => {
+                let result = promise.result(scope);
+                Ok(PromiseState::Fulfilled(wrap_local_value(
+                    scope, isolate_id, result,
+                )))
+            }
+            v8::PromiseState::Rejected => {
+                let result = promise.result(scope);
+                Ok(PromiseState::Rejected(wrap_local_value(
+                    scope, isolate_id, result,
+                )))
+            }
+        }
+    }
+
+    fn generator_start(
+        &mut self,
+        _generator: V8Object,
+        _closure: V8Object,
+    ) -> Completion<(), V8Types> {
+        Ok(())
+    }
+
+    fn global_object(&self) -> V8Object {
+        self.realm_global.clone()
+    }
+
+    fn property_key_from_str(&self, string: &str) -> V8PropertyKey {
+        V8PropertyKey::String(self.js_string_from_str(string))
+    }
+
+    fn property_key_from_index(&self, index: u32) -> V8PropertyKey {
+        V8PropertyKey::Index(index)
+    }
+
+    fn property_key_from_symbol(&self, symbol: &V8Symbol) -> V8PropertyKey {
+        V8PropertyKey::Symbol(symbol.clone())
+    }
+
+    fn value_from_property_key(&mut self, key: V8PropertyKey) -> V8Value {
+        let isolate_id = self.isolate_id;
+        v8_engine_scope_with_context!(let scope, self, &self.realm.context);
+        match local_property_key(scope, isolate_id, &key) {
+            Ok(value) => wrap_local_value(scope, isolate_id, value),
+            Err(error) => error,
+        }
+    }
+
+    fn property_key_from_well_known_symbol(&mut self, name: &str) -> V8PropertyKey {
+        let name = self.value_from_string(self.js_string_from_str(name));
+        let symbol = self
+            .call_js_helper("name => Symbol[name]", &[name])
+            .ok()
+            .and_then(|value| V8Types::value_as_symbol(&value))
+            .unwrap_or_else(|| panic!("unknown well-known Symbol name"));
+        V8PropertyKey::Symbol(symbol)
+    }
+
+    fn property_key_to_rust_string(&self, key: &V8PropertyKey) -> String {
+        match key {
+            V8PropertyKey::String(string) => String::from_utf16_lossy(&string.utf16),
+            V8PropertyKey::Symbol(symbol) => {
+                let _ = symbol;
+                "Symbol".to_owned()
+            }
+            V8PropertyKey::Index(index) => index.to_string(),
+        }
+    }
+
+    fn store_host_any(&mut self, id: TypeId, value: Box<dyn Any>) {
+        self.host_data.insert(id, value);
+    }
+
+    fn get_host_any(&self, id: &TypeId) -> Option<&dyn Any> {
+        self.host_data.get(id).map(Box::as_ref)
+    }
+
+    fn remove_host_any(&mut self, id: &TypeId) -> Option<Box<dyn Any>> {
+        self.host_data.remove(id)
+    }
+
+    fn create_object_with_any(
+        &mut self,
+        prototype: V8Object,
+        data: Box<dyn Any + 'static>,
+    ) -> V8Object {
+        let isolate_id = self.isolate_id;
+        v8_engine_scope_with_context!(let scope, self, &self.realm.context);
+        let object_template = v8::ObjectTemplate::new(scope);
+        object_template.set_internal_field_count(2);
+        let object = object_template
+            .new_instance(scope)
+            .expect("V8 failed to create a platform object");
+        let prototype = local_value(scope, isolate_id, &prototype.0)
+            .expect("platform-object prototype belongs to another isolate");
+        object
+            .set_prototype(scope, prototype)
+            .expect("V8 failed to set a platform-object prototype");
+
+        let record = Box::new(HostObjectRecord { data });
+        let record_pointer = Box::into_raw(record);
+        let marker = v8::External::new(
+            scope,
+            std::ptr::addr_of!(HOST_OBJECT_MARKER).cast_mut().cast(),
+        );
+        assert!(object.set_internal_field(0, marker.into()));
+        object.set_aligned_pointer_in_internal_field(
+            1,
+            record_pointer.cast(),
+            HOST_OBJECT_TAG,
+        );
+
+        let value = V8Object(wrap_local_value(scope, isolate_id, object.into()));
+        let weak = v8::Weak::with_guaranteed_finalizer(
+            scope,
+            object,
+            Box::new(move || {
+                // SAFETY: `record_pointer` is created by the single
+                // Box::into_raw above. This guaranteed finalizer is its sole
+                // owner and V8 invokes it at most once after the JS object can
+                // no longer expose its internal field.
+                unsafe {
+                    drop(Box::from_raw(record_pointer));
+                }
+            }),
+        );
+        self.host_object_handles.push(weak);
+        value
+    }
+
+    fn with_object_any(&self, object: &V8Object) -> Option<&dyn Any> {
+        if let Some(pointer) = object.0.host_data {
+            // SAFETY: `host_data_pointer` validates the marker and tag before
+            // placing this pointer in a V8Value. A Global handle in `object`
+            // keeps the JS object reachable, so its guaranteed finalizer cannot
+            // release the record during this borrow.
+            let record = unsafe { &*pointer.cast::<HostObjectRecord>().as_ptr() };
+            return Some(record.data.as_ref());
+        }
+        self.associated_objects
+            .iter()
+            .find(|(candidate, _)| candidate == object)
+            .map(|(_, data)| data.as_ref())
+    }
+
+    fn with_object_any_mut(&mut self, object: &V8Object) -> Option<&mut dyn Any> {
+        if let Some(pointer) = object.0.host_data {
+            // SAFETY: The marker, reachability, and finalization invariants are
+            // the same as in `with_object_any`. The `&mut self` receiver makes
+            // this the exclusive host-data access path for the duration of the
+            // returned borrow.
+            let record = unsafe { &mut *pointer.cast::<HostObjectRecord>().as_ptr() };
+            return Some(record.data.as_mut());
+        }
+        self.associated_objects
+            .iter_mut()
+            .find(|(candidate, _)| candidate == object)
+            .map(|(_, data)| data.as_mut())
+    }
+
+    fn with_object_any_mut_with(
+        &mut self,
+        object: &V8Object,
+        operation: Box<dyn FnOnce(&mut dyn Any, &mut dyn ExecutionContext<V8Types>) + '_>,
+    ) {
+        let data_pointer: Option<*mut dyn Any> = if let Some(pointer) = object.0.host_data {
+            // SAFETY: The validated host pointer remains alive because
+            // `object` owns a Global handle. Converting to a raw trait-object
+            // pointer lets the callback borrow both the record and the engine;
+            // no other access to the record occurs until the callback returns.
+            let record = unsafe { &mut *pointer.cast::<HostObjectRecord>().as_ptr() };
+            Some(record.data.as_mut())
+        } else {
+            self.associated_objects
+                .iter_mut()
+                .find(|(candidate, _)| candidate == object)
+                .map(|(_, data)| data.as_mut() as *mut dyn Any)
+        };
+        if let Some(data_pointer) = data_pointer {
+            // SAFETY: `data_pointer` was obtained from storage exclusively
+            // borrowed above and is used only for this call.
+            unsafe {
+                operation(&mut *data_pointer, self);
+            }
+        }
+    }
+
+    fn new_type_error(&mut self, message: &str) -> V8Value {
+        let isolate_id = self.isolate_id;
+        v8_engine_scope_with_context!(let scope, self, &self.realm.context);
+        let message = v8::String::new(scope, message).expect("V8 TypeError message allocation failed");
+        let exception = v8::Exception::type_error(scope, message);
+        wrap_local_value(scope, isolate_id, exception)
+    }
+
+    fn new_range_error(&mut self, message: &str) -> V8Value {
+        let isolate_id = self.isolate_id;
+        v8_engine_scope_with_context!(let scope, self, &self.realm.context);
+        let message = v8::String::new(scope, message).expect("V8 RangeError message allocation failed");
+        let exception = v8::Exception::range_error(scope, message);
+        wrap_local_value(scope, isolate_id, exception)
+    }
+
+    fn new_syntax_error(&mut self, message: &str) -> V8Value {
+        let isolate_id = self.isolate_id;
+        v8_engine_scope_with_context!(let scope, self, &self.realm.context);
+        let message = v8::String::new(scope, message).expect("V8 SyntaxError message allocation failed");
+        let exception = v8::Exception::syntax_error(scope, message);
+        wrap_local_value(scope, isolate_id, exception)
+    }
+
+    fn create_proxy(
+        &mut self,
+        target: V8Object,
+        handler: V8Object,
+    ) -> Completion<V8Object, V8Types> {
+        let isolate_id = self.isolate_id;
+        v8_engine_scope_with_context!(let scope, self, &self.realm.context);
+        let target = local_object(scope, isolate_id, &target)?;
+        let handler = local_object(scope, isolate_id, &handler)?;
+        let proxy = v8::Proxy::new(scope, target, handler)
+            .ok_or_else(|| caught_exception(scope, isolate_id, None, "Proxy creation failed"))?;
+        Ok(V8Object(wrap_local_value(scope, isolate_id, proxy.into())))
+    }
+
+    fn js_string_to_rust_string(&self, string: &V8String) -> String {
+        String::from_utf16_lossy(&string.utf16)
+    }
+
+    fn create_empty_array(&mut self) -> V8Object {
+        let isolate_id = self.isolate_id;
+        v8_engine_scope_with_context!(let scope, self, &self.realm.context);
+        let array = v8::Array::new(scope, 0);
+        V8Object(wrap_local_value(scope, isolate_id, array.into()))
+    }
+
+    fn array_push(&mut self, array: &V8Object, value: V8Value) -> Completion<(), V8Types> {
+        self.call_js_helper("(array, value) => { array.push(value); }", &[array.0.clone(), value])?;
+        Ok(())
+    }
+
+    fn create_plain_object(&mut self, prototype: Option<&V8Object>) -> V8Object {
+        let isolate_id = self.isolate_id;
+        v8_engine_scope_with_context!(let scope, self, &self.realm.context);
+        let object = v8::Object::new(scope);
+        if let Some(prototype) = prototype {
+            let prototype = local_value(scope, isolate_id, &prototype.0)
+                .expect("plain-object prototype belongs to another isolate");
+            object
+                .set_prototype(scope, prototype)
+                .expect("V8 failed to set plain-object prototype");
+        }
+        V8Object(wrap_local_value(scope, isolate_id, object.into()))
+    }
+
+    fn json_stringify(&mut self, value: V8Value) -> Completion<String, V8Types> {
+        let result = self.call_js_helper("value => JSON.stringify(value)", &[value])?;
+        if V8Types::value_is_undefined(&result) {
+            return Ok("null".to_owned());
+        }
+        self.to_rust_string(result)
+    }
+
+    fn evaluate_script(&mut self, source: &str) -> Completion<V8Value, V8Types> {
+        let realm = self.realm.clone();
+        JsEngine::evaluate_script(self, source, &realm)
+    }
+
+    fn value_from_bigint(&mut self, number: i64) -> V8Value {
+        let isolate_id = self.isolate_id;
+        v8_engine_scope_with_context!(let scope, self, &self.realm.context);
+        let bigint = v8::BigInt::new_from_i64(scope, number);
+        wrap_local_value(scope, isolate_id, bigint.into())
+    }
+
+    fn create_builtin_fn_static(
+        &mut self,
+        behaviour: fn(
+            &[V8Value],
+            V8Value,
+            &mut dyn ExecutionContext<V8Types>,
+        ) -> Completion<V8Value, V8Types>,
+        length: u32,
+        name: V8PropertyKey,
+    ) -> V8Object {
+        self.make_builtin_function(Box::new(behaviour), length, name, false)
+    }
+
+    fn create_builtin_fn(
+        &mut self,
+        behaviour: StoredBehaviour,
+        length: u32,
+        name: V8PropertyKey,
+    ) -> V8Object {
+        self.make_builtin_function(behaviour, length, name, false)
+    }
+
+    fn create_builtin_function(
+        &mut self,
+        behaviour: StoredBehaviour,
+        length: u32,
+        name: V8PropertyKey,
+        is_constructor: bool,
+    ) -> V8Object {
+        self.make_builtin_function(behaviour, length, name, is_constructor)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::cell::Cell;
+    use std::rc::Rc;
+
+    use crate::{EcmascriptHost, ExecutionContext, JsTypes};
+
+    use super::{V8Engine, V8Types};
+
+    struct DropFlag(Rc<Cell<bool>>);
+
+    impl Drop for DropFlag {
+        fn drop(&mut self) {
+            self.0.set(true);
+        }
+    }
+
+    #[test]
+    fn cross_isolate_handles_return_an_exception() {
+        let mut first_engine = V8Engine::new();
+        let value = first_engine.value_from_number(42.0);
+        let mut second_engine = V8Engine::new();
+
+        assert!(second_engine.to_number(value).is_err());
+    }
+
+    #[test]
+    fn thrown_javascript_becomes_a_completion_error() {
+        let mut engine = V8Engine::new();
+        let exception = ExecutionContext::evaluate_script(
+            &mut engine,
+            "throw new TypeError('expected exception')",
+        )
+        .expect_err("throwing script must produce a completion error");
+        let object = V8Types::value_as_object(&exception)
+            .expect("the caught TypeError must be represented as an object");
+
+        assert!(V8Types::object_is_error(&object));
+    }
+
+    #[test]
+    fn child_realms_share_an_isolate_and_survive_parent_drop() {
+        let parent_engine = V8Engine::new();
+        let mut first_document_engine = parent_engine.new_child_realm();
+        let mut second_document_engine = parent_engine.new_child_realm();
+
+        let first_value = ExecutionContext::evaluate_script(
+            &mut first_document_engine,
+            "21 * 2",
+        )
+        .expect("the first child realm must evaluate JavaScript");
+        assert_eq!(
+            first_document_engine
+                .to_number(first_value)
+                .expect("the first result must be numeric"),
+            42.0
+        );
+
+        drop(first_document_engine);
+        drop(parent_engine);
+
+        let callback_name = second_document_engine.property_key_from_str("sharedCallback");
+        let callback = second_document_engine.create_builtin_function(
+            Box::new(|_arguments, _this, execution_context| {
+                Ok(execution_context.value_from_number(7.0))
+            }),
+            0,
+            callback_name.clone(),
+            false,
+        );
+        let callback_value = V8Types::value_from_object(callback);
+        let global = second_document_engine.realm_global_object();
+        second_document_engine
+            .create_data_property(global, callback_name, callback_value)
+            .expect("the callback must be installed in the second child realm");
+
+        let second_value = ExecutionContext::evaluate_script(
+            &mut second_document_engine,
+            "sharedCallback()",
+        )
+        .expect("the remaining child realm must invoke native callbacks");
+        assert_eq!(
+            second_document_engine
+                .to_number(second_value)
+                .expect("the callback result must be numeric"),
+            7.0
+        );
+    }
+
+    #[test]
+    fn native_callback_can_create_a_child_realm() {
+        let mut engine = V8Engine::new();
+        let callback_name = engine.property_key_from_str("createChildRealm");
+        let callback = engine.create_builtin_function(
+            Box::new(|_arguments, _this, execution_context| {
+                let engine = execution_context
+                    .as_any_mut()
+                    .downcast_mut::<V8Engine>()
+                    .expect("the callback context must be a V8 engine");
+                let mut child_engine = engine.new_child_realm();
+                let child_value = ExecutionContext::evaluate_script(&mut child_engine, "6 * 7")?;
+                let number = child_engine.to_number(child_value)?;
+                drop(child_engine);
+                Ok(engine.value_from_number(number))
+            }),
+            0,
+            callback_name.clone(),
+            false,
+        );
+        let callback_value = V8Types::value_from_object(callback);
+        let global = engine.realm_global_object();
+        engine
+            .create_data_property(global, callback_name, callback_value)
+            .expect("the callback must be installed in the parent realm");
+
+        let result = ExecutionContext::evaluate_script(&mut engine, "createChildRealm()")
+            .expect("a native callback must create and evaluate a child realm");
+        assert_eq!(
+            engine
+                .to_number(result)
+                .expect("the callback result must be numeric"),
+            42.0
+        );
+    }
+
+    #[test]
+    fn weak_finalizers_release_host_objects_and_callbacks() {
+        let mut engine = V8Engine::new();
+
+        let host_object_dropped = Rc::new(Cell::new(false));
+        let prototype = engine.create_plain_object(None);
+        let host_object = engine.create_object_with_any(
+            prototype,
+            Box::new(DropFlag(Rc::clone(&host_object_dropped))),
+        );
+        drop(host_object);
+
+        let callback_dropped = Rc::new(Cell::new(false));
+        let callback_drop_flag = DropFlag(Rc::clone(&callback_dropped));
+        let callback_name = engine.property_key_from_str("finalizedCallback");
+        let callback = engine.create_builtin_function(
+            Box::new(move |_arguments, _this, execution_context| {
+                let _drop_flag = &callback_drop_flag;
+                Ok(execution_context.value_undefined())
+            }),
+            0,
+            callback_name,
+            false,
+        );
+        drop(callback);
+
+        engine.gc();
+
+        assert!(host_object_dropped.get());
+        assert!(callback_dropped.get());
+    }
+}

--- a/js_engine/src/v8/mod.rs
+++ b/js_engine/src/v8/mod.rs
@@ -2,4 +2,8 @@ mod engine;
 mod types;
 
 pub use engine::{V8Engine, create_builtin_fn_with_captures};
-pub use types::{V8BigInt, V8Object, V8PropertyKey, V8Realm, V8String, V8Symbol, V8Types, V8Value};
+pub use types::{
+    V8ArrayBuffer, V8AsyncGenerator, V8BigInt, V8Constructor, V8DataView, V8Function, V8Generator,
+    V8Map, V8Object, V8Promise, V8PropertyKey, V8Realm, V8Set, V8SharedArrayBuffer, V8String,
+    V8Symbol, V8TypedArray, V8Types, V8Value, V8WeakMap, V8WeakRef, V8WeakSet,
+};

--- a/js_engine/src/v8/mod.rs
+++ b/js_engine/src/v8/mod.rs
@@ -2,6 +2,4 @@ mod engine;
 mod types;
 
 pub use engine::{V8Engine, create_builtin_fn_with_captures};
-pub use types::{
-    V8BigInt, V8Object, V8PropertyKey, V8Realm, V8String, V8Symbol, V8Types, V8Value,
-};
+pub use types::{V8BigInt, V8Object, V8PropertyKey, V8Realm, V8String, V8Symbol, V8Types, V8Value};

--- a/js_engine/src/v8/mod.rs
+++ b/js_engine/src/v8/mod.rs
@@ -1,0 +1,7 @@
+mod engine;
+mod types;
+
+pub use engine::{V8Engine, create_builtin_fn_with_captures};
+pub use types::{
+    V8BigInt, V8Object, V8PropertyKey, V8Realm, V8String, V8Symbol, V8Types, V8Value,
+};

--- a/js_engine/src/v8/types.rs
+++ b/js_engine/src/v8/types.rs
@@ -22,17 +22,17 @@ pub(crate) enum CachedPrimitive {
     Other,
 }
 
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug)]
 pub(crate) struct ObjectProfile {
-    pub is_array_buffer: bool,
-    pub is_shared_array_buffer: bool,
-    pub is_typed_array: bool,
-    pub is_data_view: bool,
-    pub is_promise: bool,
-    pub is_function: bool,
-    pub is_constructor: bool,
-    pub is_map: bool,
-    pub is_set: bool,
+    pub object_handle: v8::Global<v8::Object>,
+    pub array_buffer_handle: Option<v8::Global<v8::ArrayBuffer>>,
+    pub shared_array_buffer_handle: Option<v8::Global<v8::SharedArrayBuffer>>,
+    pub typed_array_handle: Option<v8::Global<v8::TypedArray>>,
+    pub data_view_handle: Option<v8::Global<v8::DataView>>,
+    pub promise_handle: Option<v8::Global<v8::Promise>>,
+    pub function_handle: Option<v8::Global<v8::Function>>,
+    pub map_handle: Option<v8::Global<v8::Map>>,
+    pub set_handle: Option<v8::Global<v8::Set>>,
     pub is_weak_map: bool,
     pub is_weak_set: bool,
     pub is_generator: bool,
@@ -85,8 +85,7 @@ impl V8Value {
     }
 
     pub fn as_object(&self) -> Option<V8Object> {
-        self.object_profile.as_ref()?;
-        Some(V8Object(self.clone()))
+        V8Object::from_value(self.clone())
     }
 
     pub fn as_string(&self) -> Option<V8String> {
@@ -114,7 +113,14 @@ impl fmt::Display for V8Value {
 }
 
 #[derive(Clone, Debug)]
-pub struct V8Object(pub(crate) V8Value);
+pub struct V8Object(pub(crate) V8Value, pub(crate) v8::Global<v8::Object>);
+
+impl V8Object {
+    pub(crate) fn from_value(value: V8Value) -> Option<Self> {
+        let handle = value.object_profile.as_ref()?.object_handle.clone();
+        Some(Self(value, handle))
+    }
+}
 
 impl From<V8Object> for V8Value {
     fn from(object: V8Object) -> Self {
@@ -127,6 +133,60 @@ impl PartialEq for V8Object {
         self.0.isolate_id == other.0.isolate_id && self.0.handle == other.0.handle
     }
 }
+
+macro_rules! typed_v8_object {
+    ($name:ident, $handle:ty) => {
+        #[derive(Clone, Debug)]
+        pub struct $name(pub(crate) V8Object, pub(crate) v8::Global<$handle>);
+
+        impl From<$name> for V8Object {
+            fn from(value: $name) -> Self {
+                let $name(object, _handle) = value;
+                object
+            }
+        }
+
+        impl AsRef<V8Object> for $name {
+            fn as_ref(&self) -> &V8Object {
+                &self.0
+            }
+        }
+    };
+}
+
+macro_rules! tagged_v8_object {
+    ($name:ident) => {
+        #[derive(Clone, Debug)]
+        pub struct $name(pub(crate) V8Object);
+
+        impl From<$name> for V8Object {
+            fn from(value: $name) -> Self {
+                value.0
+            }
+        }
+
+        impl AsRef<V8Object> for $name {
+            fn as_ref(&self) -> &V8Object {
+                &self.0
+            }
+        }
+    };
+}
+
+typed_v8_object!(V8ArrayBuffer, v8::ArrayBuffer);
+typed_v8_object!(V8SharedArrayBuffer, v8::SharedArrayBuffer);
+typed_v8_object!(V8TypedArray, v8::TypedArray);
+typed_v8_object!(V8DataView, v8::DataView);
+typed_v8_object!(V8Promise, v8::Promise);
+typed_v8_object!(V8Map, v8::Map);
+typed_v8_object!(V8Set, v8::Set);
+tagged_v8_object!(V8WeakMap);
+tagged_v8_object!(V8WeakSet);
+tagged_v8_object!(V8WeakRef);
+tagged_v8_object!(V8Generator);
+tagged_v8_object!(V8AsyncGenerator);
+typed_v8_object!(V8Function, v8::Function);
+typed_v8_object!(V8Constructor, v8::Function);
 
 #[derive(Clone, Debug)]
 pub struct V8String {
@@ -202,17 +262,6 @@ pub struct V8Realm {
 pub struct V8Types;
 
 impl V8Types {
-    fn object_if(
-        value: &V8Value,
-        predicate: impl FnOnce(&ObjectProfile) -> bool,
-    ) -> Option<V8Object> {
-        value
-            .object_profile
-            .as_ref()
-            .is_some_and(|profile| predicate(profile))
-            .then(|| V8Object(value.clone()))
-    }
-
     fn cached_string(value: &V8Value) -> Option<V8String> {
         let CachedPrimitive::String(utf16) = &value.primitive else {
             return None;
@@ -240,56 +289,56 @@ impl JsTypes for V8Types {
     type JsBigInt = V8BigInt;
     type JsValue = V8Value;
     type JsObject = V8Object;
-    type ArrayBuffer = V8Object;
-    type SharedArrayBuffer = V8Object;
-    type TypedArray = V8Object;
-    type DataView = V8Object;
-    type Promise = V8Object;
-    type Map = V8Object;
-    type Set = V8Object;
-    type WeakMap = V8Object;
-    type WeakSet = V8Object;
-    type WeakRef = V8Object;
-    type Generator = V8Object;
-    type AsyncGenerator = V8Object;
-    type Function = V8Object;
-    type Constructor = V8Object;
+    type ArrayBuffer = V8ArrayBuffer;
+    type SharedArrayBuffer = V8SharedArrayBuffer;
+    type TypedArray = V8TypedArray;
+    type DataView = V8DataView;
+    type Promise = V8Promise;
+    type Map = V8Map;
+    type Set = V8Set;
+    type WeakMap = V8WeakMap;
+    type WeakSet = V8WeakSet;
+    type WeakRef = V8WeakRef;
+    type Generator = V8Generator;
+    type AsyncGenerator = V8AsyncGenerator;
+    type Function = V8Function;
+    type Constructor = V8Constructor;
     type PropertyKey = V8PropertyKey;
 
     fn object_from_array_buffer(value: Self::ArrayBuffer) -> Self::JsObject {
-        value
+        value.into()
     }
 
     fn object_from_shared_array_buffer(value: Self::SharedArrayBuffer) -> Self::JsObject {
-        value
+        value.into()
     }
 
     fn object_from_typed_array(value: Self::TypedArray) -> Self::JsObject {
-        value
+        value.into()
     }
 
     fn object_from_data_view(value: Self::DataView) -> Self::JsObject {
-        value
+        value.into()
     }
 
     fn object_from_promise(value: Self::Promise) -> Self::JsObject {
-        value
+        value.into()
     }
 
     fn object_from_map(value: Self::Map) -> Self::JsObject {
-        value
+        value.into()
     }
 
     fn object_from_set(value: Self::Set) -> Self::JsObject {
-        value
+        value.into()
     }
 
     fn object_from_function(value: Self::Function) -> Self::JsObject {
-        value
+        value.into()
     }
 
     fn object_from_constructor(value: Self::Constructor) -> Self::JsObject {
-        value
+        value.into()
     }
 
     fn value_from_object(value: Self::JsObject) -> Self::JsValue {
@@ -305,8 +354,7 @@ impl JsTypes for V8Types {
     }
 
     fn value_as_object(value: &Self::JsValue) -> Option<Self::JsObject> {
-        value.object_profile.as_ref()?;
-        Some(V8Object(value.clone()))
+        V8Object::from_value(value.clone())
     }
 
     fn value_as_string(value: &Self::JsValue) -> Option<Self::JsString> {
@@ -346,47 +394,84 @@ impl JsTypes for V8Types {
     }
 
     fn object_as_array_buffer(object: &Self::JsObject) -> Option<Self::ArrayBuffer> {
-        Self::object_if(&object.0, |profile| profile.is_array_buffer)
+        let handle = object
+            .0
+            .object_profile
+            .as_ref()?
+            .array_buffer_handle
+            .clone()?;
+        Some(V8ArrayBuffer(object.clone(), handle))
     }
 
     fn object_as_shared_array_buffer(object: &Self::JsObject) -> Option<Self::SharedArrayBuffer> {
-        Self::object_if(&object.0, |profile| profile.is_shared_array_buffer)
+        let handle = object
+            .0
+            .object_profile
+            .as_ref()?
+            .shared_array_buffer_handle
+            .clone()?;
+        Some(V8SharedArrayBuffer(object.clone(), handle))
     }
 
     fn object_as_typed_array(object: &Self::JsObject) -> Option<Self::TypedArray> {
-        Self::object_if(&object.0, |profile| profile.is_typed_array)
+        let handle = object
+            .0
+            .object_profile
+            .as_ref()?
+            .typed_array_handle
+            .clone()?;
+        Some(V8TypedArray(object.clone(), handle))
     }
 
     fn object_as_data_view(object: &Self::JsObject) -> Option<Self::DataView> {
-        Self::object_if(&object.0, |profile| profile.is_data_view)
+        let handle = object.0.object_profile.as_ref()?.data_view_handle.clone()?;
+        Some(V8DataView(object.clone(), handle))
     }
 
     fn object_as_promise(object: &Self::JsObject) -> Option<Self::Promise> {
-        Self::object_if(&object.0, |profile| profile.is_promise)
+        let handle = object.0.object_profile.as_ref()?.promise_handle.clone()?;
+        Some(V8Promise(object.clone(), handle))
     }
 
     fn object_as_function(object: &Self::JsObject) -> Option<Self::Function> {
-        Self::object_if(&object.0, |profile| profile.is_function)
+        let handle = object.0.object_profile.as_ref()?.function_handle.clone()?;
+        Some(V8Function(object.clone(), handle))
     }
 
     fn object_as_constructor(object: &Self::JsObject) -> Option<Self::Constructor> {
-        Self::object_if(&object.0, |profile| profile.is_constructor)
+        let profile = object.0.object_profile.as_ref()?;
+        Some(V8Constructor(
+            object.clone(),
+            profile.function_handle.clone()?,
+        ))
     }
 
     fn object_as_map(object: &Self::JsObject) -> Option<Self::Map> {
-        Self::object_if(&object.0, |profile| profile.is_map)
+        let handle = object.0.object_profile.as_ref()?.map_handle.clone()?;
+        Some(V8Map(object.clone(), handle))
     }
 
     fn object_as_set(object: &Self::JsObject) -> Option<Self::Set> {
-        Self::object_if(&object.0, |profile| profile.is_set)
+        let handle = object.0.object_profile.as_ref()?.set_handle.clone()?;
+        Some(V8Set(object.clone(), handle))
     }
 
     fn object_as_weak_map(object: &Self::JsObject) -> Option<Self::WeakMap> {
-        Self::object_if(&object.0, |profile| profile.is_weak_map)
+        object
+            .0
+            .object_profile
+            .as_ref()?
+            .is_weak_map
+            .then(|| V8WeakMap(object.clone()))
     }
 
     fn object_as_weak_set(object: &Self::JsObject) -> Option<Self::WeakSet> {
-        Self::object_if(&object.0, |profile| profile.is_weak_set)
+        object
+            .0
+            .object_profile
+            .as_ref()?
+            .is_weak_set
+            .then(|| V8WeakSet(object.clone()))
     }
 
     fn object_as_weak_ref(_object: &Self::JsObject) -> Option<Self::WeakRef> {
@@ -394,7 +479,12 @@ impl JsTypes for V8Types {
     }
 
     fn object_as_generator(object: &Self::JsObject) -> Option<Self::Generator> {
-        Self::object_if(&object.0, |profile| profile.is_generator)
+        object
+            .0
+            .object_profile
+            .as_ref()?
+            .is_generator
+            .then(|| V8Generator(object.clone()))
     }
 
     fn object_as_async_generator(_object: &Self::JsObject) -> Option<Self::AsyncGenerator> {

--- a/js_engine/src/v8/types.rs
+++ b/js_engine/src/v8/types.rs
@@ -1,0 +1,478 @@
+use std::borrow::Borrow;
+use std::cell::Cell;
+use std::ffi::c_void;
+use std::fmt;
+use std::hash::{Hash, Hasher};
+use std::ptr::NonNull;
+use std::sync::Arc;
+
+use rusty_v8 as v8;
+
+use crate::{JsTypes, JsTypesWithRealm};
+use crate::TypedArrayElementType;
+
+#[derive(Clone, Debug)]
+pub(crate) enum CachedPrimitive {
+    Undefined,
+    Null,
+    Boolean(bool),
+    Number(f64),
+    String(Arc<[u16]>),
+    BigInt(Arc<str>),
+    Other,
+}
+
+#[derive(Clone, Debug, Default)]
+pub(crate) struct ObjectProfile {
+    pub is_array_buffer: bool,
+    pub is_shared_array_buffer: bool,
+    pub is_typed_array: bool,
+    pub is_data_view: bool,
+    pub is_promise: bool,
+    pub is_function: bool,
+    pub is_constructor: bool,
+    pub is_map: bool,
+    pub is_set: bool,
+    pub is_weak_map: bool,
+    pub is_weak_set: bool,
+    pub is_generator: bool,
+    pub is_boolean_wrapper: bool,
+    pub is_number_wrapper: bool,
+    pub is_string_wrapper: bool,
+    pub is_bigint_wrapper: bool,
+    pub is_date: bool,
+    pub is_regexp: bool,
+    pub is_error: bool,
+    pub wrapper_primitive: Option<CachedPrimitive>,
+    pub array_buffer_state: Option<V8ArrayBufferState>,
+    pub typed_array_element_type: Option<TypedArrayElementType>,
+}
+
+#[derive(Clone)]
+pub(crate) struct V8ArrayBufferState {
+    pub backing_store: v8::SharedRef<v8::BackingStore>,
+    pub detached: std::rc::Rc<Cell<bool>>,
+    pub resizable: bool,
+}
+
+impl std::fmt::Debug for V8ArrayBufferState {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("V8ArrayBufferState")
+            .field("byte_length", &self.backing_store.byte_length())
+            .field("detached", &self.detached.get())
+            .field("resizable", &self.resizable)
+            .finish()
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct V8Value {
+    pub(crate) isolate_id: u64,
+    pub(crate) handle: v8::Global<v8::Value>,
+    pub(crate) primitive: CachedPrimitive,
+    pub(crate) object_profile: Option<ObjectProfile>,
+    pub(crate) host_data: Option<NonNull<c_void>>,
+}
+
+impl V8Value {
+    pub fn is_undefined(&self) -> bool {
+        matches!(self.primitive, CachedPrimitive::Undefined)
+    }
+
+    pub fn is_null(&self) -> bool {
+        matches!(self.primitive, CachedPrimitive::Null)
+    }
+
+    pub fn as_object(&self) -> Option<V8Object> {
+        self.object_profile.as_ref()?;
+        Some(V8Object(self.clone()))
+    }
+
+    pub fn as_string(&self) -> Option<V8String> {
+        V8Types::cached_string(self)
+    }
+
+    pub fn display(&self) -> String {
+        match &self.primitive {
+            CachedPrimitive::Undefined => String::from("undefined"),
+            CachedPrimitive::Null => String::from("null"),
+            CachedPrimitive::Boolean(boolean) => boolean.to_string(),
+            CachedPrimitive::Number(number) => number.to_string(),
+            CachedPrimitive::String(utf16) => String::from_utf16_lossy(utf16),
+            CachedPrimitive::BigInt(canonical) => canonical.to_string(),
+            CachedPrimitive::Other if self.object_profile.is_some() => String::from("[object]"),
+            CachedPrimitive::Other => String::from("[value]"),
+        }
+    }
+}
+
+impl fmt::Display for V8Value {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.display())
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct V8Object(pub(crate) V8Value);
+
+impl From<V8Object> for V8Value {
+    fn from(object: V8Object) -> Self {
+        object.0
+    }
+}
+
+impl PartialEq for V8Object {
+    fn eq(&self, other: &Self) -> bool {
+        self.0.isolate_id == other.0.isolate_id && self.0.handle == other.0.handle
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct V8String {
+    pub(crate) value: Option<V8Value>,
+    pub(crate) utf16: Arc<[u16]>,
+}
+
+impl PartialEq for V8String {
+    fn eq(&self, other: &Self) -> bool {
+        self.utf16 == other.utf16
+    }
+}
+
+impl PartialEq<str> for V8String {
+    fn eq(&self, other: &str) -> bool {
+        self.utf16.iter().copied().eq(other.encode_utf16())
+    }
+}
+
+impl PartialEq<&str> for V8String {
+    fn eq(&self, other: &&str) -> bool {
+        self == *other
+    }
+}
+
+impl Eq for V8String {}
+
+impl Hash for V8String {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.utf16.hash(state);
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct V8Symbol(pub(crate) V8Value);
+
+impl PartialEq for V8Symbol {
+    fn eq(&self, other: &Self) -> bool {
+        self.0.isolate_id == other.0.isolate_id && self.0.handle == other.0.handle
+    }
+}
+
+impl Eq for V8Symbol {}
+
+#[derive(Clone, Debug)]
+pub struct V8BigInt {
+    pub(crate) value: V8Value,
+    pub(crate) canonical: Arc<str>,
+}
+
+impl PartialEq for V8BigInt {
+    fn eq(&self, other: &Self) -> bool {
+        self.canonical == other.canonical
+    }
+}
+
+impl Eq for V8BigInt {}
+
+#[derive(Clone, Debug)]
+pub enum V8PropertyKey {
+    String(V8String),
+    Symbol(V8Symbol),
+    Index(u32),
+}
+
+#[derive(Clone, Debug)]
+pub struct V8Realm {
+    pub(crate) isolate_id: u64,
+    pub(crate) context: v8::Global<v8::Context>,
+}
+
+#[derive(Clone, Debug)]
+pub struct V8Types;
+
+impl V8Types {
+    fn object_if(value: &V8Value, predicate: impl FnOnce(&ObjectProfile) -> bool) -> Option<V8Object> {
+        value
+            .object_profile
+            .as_ref()
+            .is_some_and(predicate)
+            .then(|| V8Object(value.clone()))
+    }
+
+    fn cached_string(value: &V8Value) -> Option<V8String> {
+        let CachedPrimitive::String(utf16) = &value.primitive else {
+            return None;
+        };
+        Some(V8String {
+            value: Some(value.clone()),
+            utf16: utf16.clone(),
+        })
+    }
+
+    fn cached_bigint(value: &V8Value) -> Option<V8BigInt> {
+        let CachedPrimitive::BigInt(canonical) = &value.primitive else {
+            return None;
+        };
+        Some(V8BigInt {
+            value: value.clone(),
+            canonical: canonical.clone(),
+        })
+    }
+}
+
+impl JsTypes for V8Types {
+    type JsString = V8String;
+    type JsSymbol = V8Symbol;
+    type JsBigInt = V8BigInt;
+    type JsValue = V8Value;
+    type JsObject = V8Object;
+    type ArrayBuffer = V8Object;
+    type SharedArrayBuffer = V8Object;
+    type TypedArray = V8Object;
+    type DataView = V8Object;
+    type Promise = V8Object;
+    type Map = V8Object;
+    type Set = V8Object;
+    type WeakMap = V8Object;
+    type WeakSet = V8Object;
+    type WeakRef = V8Object;
+    type Generator = V8Object;
+    type AsyncGenerator = V8Object;
+    type Function = V8Object;
+    type Constructor = V8Object;
+    type PropertyKey = V8PropertyKey;
+
+    fn object_from_array_buffer(value: Self::ArrayBuffer) -> Self::JsObject {
+        value
+    }
+
+    fn object_from_shared_array_buffer(value: Self::SharedArrayBuffer) -> Self::JsObject {
+        value
+    }
+
+    fn object_from_typed_array(value: Self::TypedArray) -> Self::JsObject {
+        value
+    }
+
+    fn object_from_data_view(value: Self::DataView) -> Self::JsObject {
+        value
+    }
+
+    fn object_from_promise(value: Self::Promise) -> Self::JsObject {
+        value
+    }
+
+    fn object_from_map(value: Self::Map) -> Self::JsObject {
+        value
+    }
+
+    fn object_from_set(value: Self::Set) -> Self::JsObject {
+        value
+    }
+
+    fn object_from_function(value: Self::Function) -> Self::JsObject {
+        value
+    }
+
+    fn object_from_constructor(value: Self::Constructor) -> Self::JsObject {
+        value
+    }
+
+    fn value_from_object(value: Self::JsObject) -> Self::JsValue {
+        value.0
+    }
+
+    fn value_from_symbol(value: Self::JsSymbol) -> Self::JsValue {
+        value.0
+    }
+
+    fn value_from_bigint(value: Self::JsBigInt) -> Self::JsValue {
+        value.value
+    }
+
+    fn value_as_object(value: &Self::JsValue) -> Option<Self::JsObject> {
+        value.object_profile.as_ref()?;
+        Some(V8Object(value.clone()))
+    }
+
+    fn value_as_string(value: &Self::JsValue) -> Option<Self::JsString> {
+        Self::cached_string(value)
+    }
+
+    fn value_as_symbol(value: &Self::JsValue) -> Option<Self::JsSymbol> {
+        <v8::Global<v8::Value> as Borrow<v8::Value>>::borrow(&value.handle)
+            .is_symbol()
+            .then(|| V8Symbol(value.clone()))
+    }
+
+    fn value_as_number(value: &Self::JsValue) -> Option<f64> {
+        match value.primitive {
+            CachedPrimitive::Number(number) => Some(number),
+            _ => None,
+        }
+    }
+
+    fn value_as_bool(value: &Self::JsValue) -> Option<bool> {
+        match value.primitive {
+            CachedPrimitive::Boolean(boolean) => Some(boolean),
+            _ => None,
+        }
+    }
+
+    fn value_as_bigint(value: &Self::JsValue) -> Option<Self::JsBigInt> {
+        Self::cached_bigint(value)
+    }
+
+    fn value_is_undefined(value: &Self::JsValue) -> bool {
+        matches!(value.primitive, CachedPrimitive::Undefined)
+    }
+
+    fn value_is_null(value: &Self::JsValue) -> bool {
+        matches!(value.primitive, CachedPrimitive::Null)
+    }
+
+    fn object_as_array_buffer(object: &Self::JsObject) -> Option<Self::ArrayBuffer> {
+        Self::object_if(&object.0, |profile| profile.is_array_buffer)
+    }
+
+    fn object_as_shared_array_buffer(object: &Self::JsObject) -> Option<Self::SharedArrayBuffer> {
+        Self::object_if(&object.0, |profile| profile.is_shared_array_buffer)
+    }
+
+    fn object_as_typed_array(object: &Self::JsObject) -> Option<Self::TypedArray> {
+        Self::object_if(&object.0, |profile| profile.is_typed_array)
+    }
+
+    fn object_as_data_view(object: &Self::JsObject) -> Option<Self::DataView> {
+        Self::object_if(&object.0, |profile| profile.is_data_view)
+    }
+
+    fn object_as_promise(object: &Self::JsObject) -> Option<Self::Promise> {
+        Self::object_if(&object.0, |profile| profile.is_promise)
+    }
+
+    fn object_as_function(object: &Self::JsObject) -> Option<Self::Function> {
+        Self::object_if(&object.0, |profile| profile.is_function)
+    }
+
+    fn object_as_constructor(object: &Self::JsObject) -> Option<Self::Constructor> {
+        Self::object_if(&object.0, |profile| profile.is_constructor)
+    }
+
+    fn object_as_map(object: &Self::JsObject) -> Option<Self::Map> {
+        Self::object_if(&object.0, |profile| profile.is_map)
+    }
+
+    fn object_as_set(object: &Self::JsObject) -> Option<Self::Set> {
+        Self::object_if(&object.0, |profile| profile.is_set)
+    }
+
+    fn object_as_weak_map(object: &Self::JsObject) -> Option<Self::WeakMap> {
+        Self::object_if(&object.0, |profile| profile.is_weak_map)
+    }
+
+    fn object_as_weak_set(object: &Self::JsObject) -> Option<Self::WeakSet> {
+        Self::object_if(&object.0, |profile| profile.is_weak_set)
+    }
+
+    fn object_as_weak_ref(_object: &Self::JsObject) -> Option<Self::WeakRef> {
+        None
+    }
+
+    fn object_as_generator(object: &Self::JsObject) -> Option<Self::Generator> {
+        Self::object_if(&object.0, |profile| profile.is_generator)
+    }
+
+    fn object_as_async_generator(_object: &Self::JsObject) -> Option<Self::AsyncGenerator> {
+        None
+    }
+
+    fn object_is_boolean_wrapper(object: &Self::JsObject) -> bool {
+        object.0.object_profile.as_ref().is_some_and(|profile| profile.is_boolean_wrapper)
+    }
+
+    fn object_is_number_wrapper(object: &Self::JsObject) -> bool {
+        object.0.object_profile.as_ref().is_some_and(|profile| profile.is_number_wrapper)
+    }
+
+    fn object_is_string_wrapper(object: &Self::JsObject) -> bool {
+        object.0.object_profile.as_ref().is_some_and(|profile| profile.is_string_wrapper)
+    }
+
+    fn object_is_bigint_wrapper(object: &Self::JsObject) -> bool {
+        object.0.object_profile.as_ref().is_some_and(|profile| profile.is_bigint_wrapper)
+    }
+
+    fn object_is_date(object: &Self::JsObject) -> bool {
+        object.0.object_profile.as_ref().is_some_and(|profile| profile.is_date)
+    }
+
+    fn object_is_regexp(object: &Self::JsObject) -> bool {
+        object.0.object_profile.as_ref().is_some_and(|profile| profile.is_regexp)
+    }
+
+    fn object_is_error(object: &Self::JsObject) -> bool {
+        object.0.object_profile.as_ref().is_some_and(|profile| profile.is_error)
+    }
+
+    fn boolean_wrapper_data(object: &Self::JsObject) -> Option<bool> {
+        match object.0.object_profile.as_ref()?.wrapper_primitive.as_ref()? {
+            CachedPrimitive::Boolean(boolean) => Some(*boolean),
+            _ => None,
+        }
+    }
+
+    fn number_wrapper_data(object: &Self::JsObject) -> Option<f64> {
+        match object.0.object_profile.as_ref()?.wrapper_primitive.as_ref()? {
+            CachedPrimitive::Number(number) => Some(*number),
+            _ => None,
+        }
+    }
+
+    fn string_wrapper_data(object: &Self::JsObject) -> Option<Self::JsString> {
+        let CachedPrimitive::String(utf16) = object
+            .0
+            .object_profile
+            .as_ref()?
+            .wrapper_primitive
+            .as_ref()?
+        else {
+            return None;
+        };
+        Some(V8String {
+            value: Some(object.0.clone()),
+            utf16: utf16.clone(),
+        })
+    }
+
+    fn bigint_wrapper_data(object: &Self::JsObject) -> Option<Self::JsBigInt> {
+        let CachedPrimitive::BigInt(canonical) = object
+            .0
+            .object_profile
+            .as_ref()?
+            .wrapper_primitive
+            .as_ref()?
+        else {
+            return None;
+        };
+        Some(V8BigInt {
+            value: object.0.clone(),
+            canonical: canonical.clone(),
+        })
+    }
+}
+
+impl JsTypesWithRealm for V8Types {
+    type Realm = V8Realm;
+}

--- a/js_engine/src/v8/types.rs
+++ b/js_engine/src/v8/types.rs
@@ -8,8 +8,8 @@ use std::sync::Arc;
 
 use rusty_v8 as v8;
 
-use crate::{JsTypes, JsTypesWithRealm};
 use crate::TypedArrayElementType;
+use crate::{JsTypes, JsTypesWithRealm};
 
 #[derive(Clone, Debug)]
 pub(crate) enum CachedPrimitive {
@@ -71,7 +71,7 @@ pub struct V8Value {
     pub(crate) isolate_id: u64,
     pub(crate) handle: v8::Global<v8::Value>,
     pub(crate) primitive: CachedPrimitive,
-    pub(crate) object_profile: Option<ObjectProfile>,
+    pub(crate) object_profile: Option<Box<ObjectProfile>>,
     pub(crate) host_data: Option<NonNull<c_void>>,
 }
 
@@ -202,11 +202,14 @@ pub struct V8Realm {
 pub struct V8Types;
 
 impl V8Types {
-    fn object_if(value: &V8Value, predicate: impl FnOnce(&ObjectProfile) -> bool) -> Option<V8Object> {
+    fn object_if(
+        value: &V8Value,
+        predicate: impl FnOnce(&ObjectProfile) -> bool,
+    ) -> Option<V8Object> {
         value
             .object_profile
             .as_ref()
-            .is_some_and(predicate)
+            .is_some_and(|profile| predicate(profile))
             .then(|| V8Object(value.clone()))
     }
 
@@ -399,42 +402,82 @@ impl JsTypes for V8Types {
     }
 
     fn object_is_boolean_wrapper(object: &Self::JsObject) -> bool {
-        object.0.object_profile.as_ref().is_some_and(|profile| profile.is_boolean_wrapper)
+        object
+            .0
+            .object_profile
+            .as_ref()
+            .is_some_and(|profile| profile.is_boolean_wrapper)
     }
 
     fn object_is_number_wrapper(object: &Self::JsObject) -> bool {
-        object.0.object_profile.as_ref().is_some_and(|profile| profile.is_number_wrapper)
+        object
+            .0
+            .object_profile
+            .as_ref()
+            .is_some_and(|profile| profile.is_number_wrapper)
     }
 
     fn object_is_string_wrapper(object: &Self::JsObject) -> bool {
-        object.0.object_profile.as_ref().is_some_and(|profile| profile.is_string_wrapper)
+        object
+            .0
+            .object_profile
+            .as_ref()
+            .is_some_and(|profile| profile.is_string_wrapper)
     }
 
     fn object_is_bigint_wrapper(object: &Self::JsObject) -> bool {
-        object.0.object_profile.as_ref().is_some_and(|profile| profile.is_bigint_wrapper)
+        object
+            .0
+            .object_profile
+            .as_ref()
+            .is_some_and(|profile| profile.is_bigint_wrapper)
     }
 
     fn object_is_date(object: &Self::JsObject) -> bool {
-        object.0.object_profile.as_ref().is_some_and(|profile| profile.is_date)
+        object
+            .0
+            .object_profile
+            .as_ref()
+            .is_some_and(|profile| profile.is_date)
     }
 
     fn object_is_regexp(object: &Self::JsObject) -> bool {
-        object.0.object_profile.as_ref().is_some_and(|profile| profile.is_regexp)
+        object
+            .0
+            .object_profile
+            .as_ref()
+            .is_some_and(|profile| profile.is_regexp)
     }
 
     fn object_is_error(object: &Self::JsObject) -> bool {
-        object.0.object_profile.as_ref().is_some_and(|profile| profile.is_error)
+        object
+            .0
+            .object_profile
+            .as_ref()
+            .is_some_and(|profile| profile.is_error)
     }
 
     fn boolean_wrapper_data(object: &Self::JsObject) -> Option<bool> {
-        match object.0.object_profile.as_ref()?.wrapper_primitive.as_ref()? {
+        match object
+            .0
+            .object_profile
+            .as_ref()?
+            .wrapper_primitive
+            .as_ref()?
+        {
             CachedPrimitive::Boolean(boolean) => Some(*boolean),
             _ => None,
         }
     }
 
     fn number_wrapper_data(object: &Self::JsObject) -> Option<f64> {
-        match object.0.object_profile.as_ref()?.wrapper_primitive.as_ref()? {
+        match object
+            .0
+            .object_profile
+            .as_ref()?
+            .wrapper_primitive
+            .as_ref()?
+        {
             CachedPrimitive::Number(number) => Some(*number),
             _ => None,
         }

--- a/js_engine_macros/src/lib.rs
+++ b/js_engine_macros/src/lib.rs
@@ -9,14 +9,14 @@
 //! - **Boa** (`feature = "boa"`): `gc_struct_boa` emits
 //!   `#[derive(boa_gc::Finalize, boa_gc::Trace, boa_engine::JsData)]`
 //!   and translates `#[ignore_trace]` -> `#[unsafe_ignore_trace]`.
-//! - **JSC / other** (`not(feature = "boa")`): `gc_struct_jsc` emits
+//! - **JSC / V8**: `gc_struct_jsc` emits
 //!   no-op `Trace`/`Finalize` impls and strips `#[ignore_trace]`.
 //!
 //! ## `#[ignore_trace]` (field-level)
 //!
 //! Marks a field as not participating in GC tracing.  On Boa this becomes
 //! `#[unsafe_ignore_trace]` (consumed by `boa_gc::Trace` derive); on JSC
-//! it is stripped (no GC tracing needed).  Only valid inside a `#[gc_struct]`.
+//! it is stripped (persistent handles do not use tracing).  Only valid inside a `#[gc_struct]`.
 //!
 //! Usage:
 //! ```ignore


### PR DESCRIPTION
The JavaScript engine abstraction is pure engineering, it made adding V8 support remarkably straightforward.

I run each backend separately:

### Boa

```bash
rustup run 1.94.0 cargo build \
  --no-default-features --features boa,media

rustup run 1.94.0 cargo run \
  --no-default-features --features boa,media -- \
  cdp --port 9222 \
  --startup-url file:///Users/taym/opensource/formal-web/artifacts/StartupExample.html
```

Check in another terminal:

```bash
strings target/debug/formal-web-content | rg -m1 "boa_engine"
```

Output:

```bash
()boa_engine::object::jsobject::ErasedObjectData { :  {
```

### JavaScriptCore

```bash
rustup run 1.94.0 cargo build \
  --no-default-features --features jsc,media

rustup run 1.94.0 cargo run \
  --no-default-features --features jsc,media -- \
  cdp --port 9222 \
  --startup-url file:///Users/taym/opensource/formal-web/artifacts/StartupExample.html
```

Check:

```bash
otool -L target/debug/formal-web-content | rg "JavaScriptCore"
```

Output:

```bash
/System/Library/Frameworks/JavaScriptCore.framework/Versions/A/JavaScriptCore (compatibility version 1.0.0, current version 622.1.22)
```


### V8

```bash
rustup run 1.94.0 cargo build \
  --no-default-features --features v8,media

rustup run 1.94.0 cargo run \
  --no-default-features --features v8,media -- \
  cdp --port 9222 \
  --startup-url file:///Users/taym/opensource/formal-web/artifacts/StartupExample.html
```

Check:

```bash
strings target/debug/formal-web-content |
  rg -m1 "v8::OwnedIsolate instances"
```

Output:

```bash
If isolate was created using v8::Isolate::snapshot_creator, you should use v8::OwnedIsolate::create_blob before dropping an isolate.v8::OwnedIsolate instances must be dropped in the reverse order of creation. They are entered upon creation and exited upon being dropped.
```


Note for V8:

rusty_v8::OwnedIsolate entters its isolate when created and requires isolates to be destroyed in reverse creation order. Formal-web overlapping document lifecycle violated that requirement.

Fix:
A content process now owns one shared V8 isolate, each document still gets a separate V8 Context and global object, but those contexts belong to the same isolate.
SharedIsolate uses Rc<RefCell<OwnedIsolate>>, while every V8Engine represents one realm:
Content process
└── Shared V8 isolate
    ├── about:blank context
    ├── StartupExample context
    ├── same-process iframe context
    └── window.open context

