### PR TITLE
Fix per-navigation memory leak: release document event listeners and

### DIFF
--- a/content/src/dom/event.rs
+++ b/content/src/dom/event.rs
@@ -292,6 +292,21 @@ impl EventTarget {
         listeners.retain(|listener| !listener.removed);
     }
 
+    /// Release every listener callback and event handler on this target.
+    /// Called during document teardown so the callbacks' strong JS handles
+    /// stop rooting the realm once the document is gone. Returns how many
+    /// callbacks were released.
+    pub(crate) fn clear_all_listeners_and_handlers(
+        &self,
+        ec: &mut dyn ExecutionContext<Types>,
+    ) -> usize {
+        let listeners = self.event_listener_list.borrow_mut(ec).len();
+        let handlers = self.event_handlers.borrow_mut(ec).len();
+        self.event_listener_list.borrow_mut(ec).clear();
+        self.event_handlers.borrow_mut(ec).clear();
+        listeners + handlers
+    }
+
     // Note: Defined by the spec but not yet used by the current dispatch code.
     // <https://dom.spec.whatwg.org/#concept-event-listener>
     #[allow(dead_code)]

--- a/content/src/html/global_scope.rs
+++ b/content/src/html/global_scope.rs
@@ -395,6 +395,19 @@ impl GlobalScope {
             .retain(|entry| !node_ids.contains(&entry.node_id));
     }
 
+    /// Clone every cached node wrapper out of the cache, for teardown walks
+    /// that must clear per-node state without holding the cell borrow.
+    pub(crate) fn cached_node_objects(
+        &self,
+        ec: &mut dyn ExecutionContext<Types>,
+    ) -> Vec<JsObject> {
+        self.node_objects
+            .borrow(ec)
+            .iter()
+            .map(|entry| entry.object.clone())
+            .collect()
+    }
+
     /// <https://html.spec.whatwg.org/#dom-animationframeprovider-requestanimationframe>
     pub(crate) fn request_animation_frame(
         &self,

--- a/content/src/js/bindings/README.md
+++ b/content/src/js/bindings/README.md
@@ -302,3 +302,18 @@ JS bindings glue                 content/src/js/bindings/wasm/interfaces.rs
 - `content/README.md` — Content-crate overview
 - `content/src/webidl/README.md` — Web IDL bindings infrastructure, platform object pattern
 - `content/src/<domain>/README.md` — Domain-specific README (e.g. `content/src/wasm/README.md`)
+
+## Native-function captures and the `make_builtin_function` limitation
+
+Reaction/continuation callbacks (streams, promises, async iteration) must be
+created with `create_builtin_fn_with_traced_captures` (`content/src/js/builtin_fn.rs`),
+which keeps the captures in a cppgc-traced platform object: the captures' cells
+and JS edges stay alive exactly while the function is reachable, and are
+released when the function dies. **Do not** hand a bare closure to the engine's
+`make_builtin_function` with JS handles captured inside it — a Rust closure's
+captures cannot be walked by cppgc, so such handles are untraced strong roots.
+An untraced captured `GcCell` member can be collected while the function is
+still live (the streams empty-queue panic the teardown GC surfaced), and an
+untraced strong root pins the realm (the navigation memory leak). Use
+`create_builtin_fn_with_traced_captures`; if a callback needs no JS captures,
+pass an empty capture type instead of closing over handles.

--- a/content/src/js/bindings/README.md
+++ b/content/src/js/bindings/README.md
@@ -303,17 +303,47 @@ JS bindings glue                 content/src/js/bindings/wasm/interfaces.rs
 - `content/src/webidl/README.md` — Web IDL bindings infrastructure, platform object pattern
 - `content/src/<domain>/README.md` — Domain-specific README (e.g. `content/src/wasm/README.md`)
 
-## Native-function captures and the `make_builtin_function` limitation
+## Callback/JS-handle strength: three models
 
-Reaction/continuation callbacks (streams, promises, async iteration) must be
-created with `create_builtin_fn_with_traced_captures` (`content/src/js/builtin_fn.rs`),
-which keeps the captures in a cppgc-traced platform object: the captures' cells
-and JS edges stay alive exactly while the function is reachable, and are
-released when the function dies. **Do not** hand a bare closure to the engine's
-`make_builtin_function` with JS handles captured inside it — a Rust closure's
-captures cannot be walked by cppgc, so such handles are untraced strong roots.
-An untraced captured `GcCell` member can be collected while the function is
-still live (the streams empty-queue panic the teardown GC surfaced), and an
-untraced strong root pins the realm (the navigation memory leak). Use
-`create_builtin_fn_with_traced_captures`; if a callback needs no JS captures,
-pass an empty capture type instead of closing over handles.
+Any Rust-held JS handle is either a strong root or a traced edge; which one a
+callback needs depends on what keeps it alive in the Web platform, and the
+difference is enforced at teardown. The three models:
+
+1. **Event listener / event handler callbacks — strong roots, released at
+   document teardown.** `EventListener.callback` (`content/src/dom/event.rs`)
+   is a `v8::Global` root because a registered listener must keep its callback
+   alive until it is removed (a traced edge would let GC collect a
+   still-registered listener). The root is bounded by the registration
+   lifetime: `destroy_document` calls `clear_all_listeners_and_handlers` on
+   every EventTarget of the document (window, document, cached node wrappers)
+   so the strong handles are dropped when the document dies. Without that
+   clearing, each listener's bound function (e.g. React's
+   `dispatchEvent.bind` wrappers) references its own platform wrapper and the
+   root pins the whole dead realm forever — the navigation memory leak.
+
+2. **Reaction/continuation captures — traced edges, lifetime = function
+   reachability.** Streams, promise, and async-iteration callbacks must be
+   created with `create_builtin_fn_with_traced_captures`
+   (`content/src/js/builtin_fn.rs`): the captures live in a cppgc-traced
+   platform object, so their cells and JS edges stay alive exactly while the
+   function is reachable and are released when it dies. They are **not**
+   strong roots: an untraced captured `GcCell` member can be collected while
+   the function is still live (the streams empty-queue panic the teardown GC
+   surfaced), and a strong root pins the realm.
+
+3. **Resolved per call — no persistent handle.** Web IDL interface
+   constructors look up their prototype from the interface registry at
+   invocation time instead of capturing it (`register_interface_spec`): there
+   is no handle to root or trace, so nothing can be retained.
+
+## The `make_builtin_function` limitation
+
+A bare closure passed to the engine's `make_builtin_function` is an opaque
+`Box<dyn Fn>`: a Rust closure's captures cannot be walked by cppgc, so any JS
+handle closed over it is an untraced strong root — model 1 with no teardown,
+i.e. a leak. Native functions that need captures must use
+`create_builtin_fn_with_traced_captures` (model 2). If a callback needs no JS
+captures, pass an empty capture type instead of closing over handles. The
+Web IDL bindings follow model 3 for constructors; `prune_dead_realm_callbacks`
+(js_engine) is the safety net that clears dead-realm records built through
+`make_builtin_function`.

--- a/content/src/js/builtin_fn.rs
+++ b/content/src/js/builtin_fn.rs
@@ -3,6 +3,14 @@ use js_engine::{Completion, ExecutionContext, JsTypes, JsTypesWithRealm};
 /// Create a builtin function with GC-traceable captures.
 /// Generic over `T` so Web IDL infrastructure (operation.rs, attribute.rs)
 /// can call it with their own type parameter.
+///
+/// The captures are stored in a cppgc-traced platform object (V8) or the
+/// engine's traced-capture storage (Boa/JSC), so their cells and JS edges
+/// stay alive exactly while the function is reachable. Do NOT close over JS
+/// handles in a bare closure passed to the engine's `make_builtin_function`:
+/// a Rust closure's captures cannot be traced, so such handles are untraced
+/// roots (realm pinning) or leave cells collectable mid-flight (streams
+/// liveness). See `content/src/js/bindings/README.md`.
 #[cfg(boa_backend)]
 pub(crate) fn create_builtin_fn_with_traced_captures<T, C>(
     ec: &mut dyn ExecutionContext<T>,

--- a/content/src/main.rs
+++ b/content/src/main.rs
@@ -27,6 +27,7 @@ use crate::html::{
     run_dom_removing_steps_for_document, run_iframe_load_event_steps_for_traversable,
 };
 use crate::js::Engine;
+use crate::js::downcast::try_with_event_target_mut;
 use crate::js::platform_objects::with_global_scope;
 use crate::ui_event::deserialize_ui_event;
 #[cfg(all(boa_backend, feature = "wasm"))]
@@ -38,7 +39,7 @@ use blitz_traits::net::{Body, Bytes, NetHandler, NetProvider, Request};
 use blitz_traits::shell::{ClipboardError, ColorScheme, ShellProvider, Viewport};
 use data_url::DataUrl;
 use html5ever::local_name;
-use js_engine::ExecutionContext;
+use js_engine::{EcmascriptHost, ExecutionContext, JsTypes};
 
 use ipc_messages::content::Command::{
     ClickElement, CompleteDocumentFetch, ContentBootstrap, CreateEmptyDocument,
@@ -1146,6 +1147,14 @@ impl ContentProcess {
     fn destroy_document(&mut self, document_id: DocumentId) -> Result<(), String> {
         run_dom_removing_steps_for_document(self, document_id)?;
         if let Some(mut content_document) = self.documents.remove(&document_id) {
+            // Release every event listener and event handler callback on the
+            // document's EventTargets (window, document, cached node
+            // wrappers): the callbacks are strong JS handles that would
+            // otherwise root the realm's objects and keep the whole context
+            // alive after the document is gone.
+            if let Err(error) = Self::clear_document_event_listeners(&mut content_document) {
+                error!("failed to clear event listeners during document teardown: {error}");
+            }
             if self
                 .active_documents_by_traversable
                 .get(&content_document.traversable_id)
@@ -1157,6 +1166,7 @@ impl ContentProcess {
             if let Err(error) = content_document.settings.clear_all_window_timers() {
                 error!("failed to clear window timers during document teardown: {error}");
             }
+            drop(content_document);
         }
         #[cfg(all(boa_backend, feature = "wasm"))]
         {
@@ -1188,7 +1198,54 @@ impl ContentProcess {
                     ..
                 } => *pending_document_id != document_id,
             });
+        drop(local_state);
+
+        // Reclaim the destroyed document's realm: release the behaviour
+        // closures of callbacks whose creation realm died with it (their
+        // captured JS handles would keep rooting the dead realm), drain the
+        // shared microtask queue, then run a full V8 + cppgc collection so
+        // the dead context is reclaimed instead of waiting for allocation
+        // pressure that a fresh page may never generate.
+        #[cfg(v8_backend)]
+        self.realm_parent.prune_dead_realm_callbacks();
+        if let Err(error) = self.realm_parent.perform_a_microtask_checkpoint() {
+            log::debug!("microtask checkpoint during document teardown failed: {error:?}");
+        }
+        self.realm_parent.gc();
         Ok(())
+    }
+
+    /// Release every event listener and event handler callback held by the
+    /// document's EventTargets (the Window, the Document, and every cached
+    /// node wrapper). Called during document teardown: the callbacks are
+    /// strong JS handles, and a listener whose bound function references its
+    /// own platform wrapper would otherwise root the realm's objects and
+    /// keep the whole context alive after the document is gone.
+    fn clear_document_event_listeners(
+        content_document: &mut ContentDocument,
+    ) -> Result<(), String> {
+        with_global_scope(content_document.settings.ec(), |global_scope, ec| {
+            let window_value = crate::js::Types::value_from_object(ec.realm_global_object());
+            let mut cleared = 0usize;
+            let _ = try_with_event_target_mut(&window_value, ec, |target, ec| {
+                cleared += target.clear_all_listeners_and_handlers(ec);
+            });
+            if let Some(document_object) = global_scope.document_object(ec) {
+                let value = crate::js::Types::value_from_object(document_object);
+                let _ = try_with_event_target_mut(&value, ec, |target, ec| {
+                    cleared += target.clear_all_listeners_and_handlers(ec);
+                });
+            }
+            for object in global_scope.cached_node_objects(ec) {
+                let value = crate::js::Types::value_from_object(object);
+                let _ = try_with_event_target_mut(&value, ec, |target, ec| {
+                    cleared += target.clear_all_listeners_and_handlers(ec);
+                });
+            }
+            let _ = cleared;
+            Ok(())
+        })
+        .map_err(|error| format!("failed to clear document event listeners: {error:?}"))
     }
 
     fn dispatch_events(&mut self, events: Vec<DispatchEventEntry>) -> Result<(), String> {

--- a/content/src/webidl/bindings/interface.rs
+++ b/content/src/webidl/bindings/interface.rs
@@ -176,13 +176,8 @@ where
         &def.attributes,
     )?;
 
-    let instance_prototype = proto.clone();
-    let unforgeables_for_closure = unforgeables_obj.clone();
-
     let constructor_fn = engine.create_builtin_function(
-        Box::new({
-            let instance_prototype_for_fn = instance_prototype.clone();
-            let _unforgeables_ref = unforgeables_for_closure.clone();
+        Box::new(
             move |args: &[Ty::JsValue],
                   new_target_or_this: Ty::JsValue,
                   ec: &mut dyn ExecutionContext<Ty>| {
@@ -230,7 +225,16 @@ where
                         ec.new_type_error("TypeError: new.target.prototype is not an object")
                     })?
                 } else {
-                    instance_prototype_for_fn.clone()
+                    // Note: cross-realm fallback not yet implemented; always
+                    // falls back to the current realm's prototype object.
+                    super::registry::get_prototype_from_host_defined::<Ty, I>(ec).ok_or_else(
+                        || {
+                            ec.new_type_error(&format!(
+                                "interface not registered: {}",
+                                std::any::type_name::<I>()
+                            ))
+                        },
+                    )?
                 };
 
                 // Step 1.8 (cont): call I::create_platform_object.
@@ -268,8 +272,8 @@ where
 
                 // Steps 1.11-1.13: Assert and return O.
                 Ok(Ty::value_from_object(instance))
-            }
-        }),
+            },
+        ),
         I::constructor_length() as u32,
         engine.property_key_from_str(I::NAME),
         true,

--- a/js_engine/src/v8/README.md
+++ b/js_engine/src/v8/README.md
@@ -42,6 +42,35 @@ wrapper↔platform reflector cycle, a two-platform mutual cycle, and a JS
 object referenced only through a cell edge in a single pass; platform data
 is finalized at isolate destruction.
 
+## Native callback records and realm teardown
+
+`make_builtin_function` records live in the shared-isolate callback registry
+until the function is collected. A behaviour closure that captures a strong
+JS handle (interface prototype, promise resolver, bound listener, ...) roots
+that object; if the object transitively references its own realm's wrappers,
+the whole context is pinned: a `v8::Global` held in platform-object cells is
+an isolate root, so V8 can never collect the cycle
+`root → JS object → wrapper → platform → root`. Teardown breaks the cycle
+from both ends: `destroy_document` clears the document's event-listener and
+event-handler callbacks (the largest source of bound-function roots, e.g.
+React's `dispatchEvent.bind` listeners), and `prune_dead_realm_callbacks`
+clears the behaviour of records whose creation realm has been dropped.
+
+**Two capture models exist, with a hard limitation on one of them:**
+
+- `create_builtin_fn_with_captures` (the `create_builtin_fn_with_traced_captures`
+  family in content) keeps the captures in a cppgc-traced platform object
+  rooted by the record's behaviour closure. Marking visits the captures, so
+  their `GcCell` members and JS edges stay alive exactly while the function
+  is reachable and are released when the record is freed — proper liveness
+  (see `traced_captures_keep_payload_alive_and_follow_function_lifetime`).
+- `make_builtin_function` with a bare `Box<dyn Fn>` closure is the **opaque
+  closure path**: a Rust closure's captures cannot be walked generically, so
+  they can never be traced. Records built this way must follow the rule that
+  the closure captures **no strong JS handles** — resolve the realm's objects
+  per call instead (the Web IDL constructor fix in `register_interface_spec`
+  is the model). The teardown prune is the safety net for any violation.
+
 ## Build
 
 ```bash

--- a/js_engine/src/v8/engine.rs
+++ b/js_engine/src/v8/engine.rs
@@ -68,7 +68,12 @@ enum WrapperKind {
 struct CallbackRecord {
     isolate_id: u64,
     creation_realm: RcWeak<V8RealmState>,
-    behaviour: StoredBehaviour,
+    // `None` after the record's creation realm has been dropped: the
+    // behaviour closure may capture strong JS handles that would keep the
+    // dead realm's objects (and thus the realm itself) alive, so teardown
+    // clears it to release those captures. The record memory stays valid so
+    // a stale `External` data pointer is never dereferenced after a free.
+    behaviour: RefCell<Option<StoredBehaviour>>,
 }
 
 /// A registered native-function weak handle paired with the callback record
@@ -809,7 +814,13 @@ fn native_callback(
                     wrap_local_value(scope, record.isolate_id, arguments.this().into())
                 };
                 match catch_unwind(AssertUnwindSafe(|| {
-                    (record.behaviour)(&callback_arguments, this_value, engine)
+                    let behaviour = record.behaviour.borrow();
+                    let Some(behaviour) = behaviour.as_ref() else {
+                        return Err(engine.new_type_error(
+                            "native callback behaviour released after its realm was destroyed",
+                        ));
+                    };
+                    (behaviour)(&callback_arguments, this_value, engine)
                 })) {
                     Ok(completion) => completion,
                     Err(_) => Err(engine.new_type_error("Rust panic in native callback")),
@@ -975,6 +986,32 @@ fn resolve_module_import<'scope>(
 impl V8Engine {
     pub fn new() -> Self {
         Self::new_with_shared_isolate(SharedIsolate::new())
+    }
+
+    /// Clear the behaviour closures of callback records whose creation realm
+    /// has been dropped. Those closures capture strong JS handles (interface
+    /// prototypes, promise resolvers, ...) that would root the dead realm's
+    /// objects and keep the whole realm alive after navigation; clearing
+    /// them breaks the cycle so the context becomes collectable.
+    pub fn prune_dead_realm_callbacks(&self) {
+        let mut callback_handles = self.shared_isolate.callback_handles.borrow_mut();
+        callback_handles.retain(|handle| {
+            let mut record_slot = handle.record.borrow_mut();
+            let Some(record) = record_slot.as_mut() else {
+                return false;
+            };
+            if record.creation_realm.strong_count() == 0 {
+                // The function's creation realm is gone: no queued job, timer,
+                // or event can invoke it anymore, and any JS handles its
+                // behaviour captured must stop rooting the dead realm.
+                if let Some(behaviour) = record.behaviour.get_mut().take() {
+                    drop(behaviour);
+                }
+                false
+            } else {
+                true
+            }
+        });
     }
 
     fn new_with_shared_isolate(shared_isolate: Rc<SharedIsolate>) -> Self {
@@ -1289,7 +1326,7 @@ impl V8Engine {
         let record = Box::new(CallbackRecord {
             isolate_id: self.isolate_id,
             creation_realm: Rc::downgrade(&self.realm_state),
-            behaviour,
+            behaviour: RefCell::new(Some(behaviour)),
         });
         // The record lives in a shared slot owned by both the guaranteed
         // finalizer and the callback-handle registry entry; whichever drops
@@ -1672,11 +1709,47 @@ where
         std::mem::forget(name);
         destination.assume_init()
     };
+
+    // Move the captures into a cppgc-traced platform object instead of
+    // leaving them as strong roots inside the callback record: the platform
+    // traces the captures during unified-heap marking (keeping their GcCell
+    // members and JS edges alive while the function is reachable), and the
+    // wrapper is rooted by the record's behaviour closure, so the captures
+    // are released exactly when the function dies. Rooted handles inside the
+    // captures are converted to edges first so they participate in cycle
+    // collection.
+    let mut captures = captures;
+    Trace::store(&mut captures, engine);
+    let intrinsics = engine.realm_intrinsics(&engine.current_realm());
+    let captures_wrapper = engine.create_object_with_any(
+        intrinsics.object_prototype,
+        Box::new(V8PlatformData::new(captures)),
+    );
+
     let stored = Box::new(
         move |arguments: &[V8Value],
               this_value,
               execution_context: &mut dyn ExecutionContext<V8Types>| {
-            behaviour(arguments, this_value, &captures, execution_context)
+            // The captures live in a cppgc-traced platform object rooted by
+            // this closure: they are visited during unified-heap marking, so
+            // their cells and JS edges stay alive exactly while the function
+            // is reachable, and are released when the record (and thus this
+            // closure) is freed.
+            let engine = execution_context
+                .as_any_mut()
+                .downcast_mut::<V8Engine>()
+                .expect("native callback execution context is not the V8 engine");
+            // SAFETY: The captures platform is rooted by the wrapper handle
+            // captured in this closure, and cppgc is non-moving, so the
+            // pointer stays valid while the function is callable. The raw
+            // re-borrow avoids aliasing `execution_context` for the callback.
+            let captures_ptr = engine
+                .with_object_any(&captures_wrapper)
+                .and_then(|data| data.downcast_ref::<C>())
+                .expect("captures platform data type mismatch")
+                as *const C;
+            let captures = unsafe { &*captures_ptr };
+            behaviour(arguments, this_value, captures, execution_context)
         },
     );
     let result = engine.make_builtin_function(stored, length, name, is_constructor);
@@ -3818,9 +3891,9 @@ mod tests {
     use super::super::{V8AsyncGenerator, V8PlatformData, V8WeakMap, V8WeakRef, V8WeakSet};
     use super::{
         CALLBACK_HANDLE_COMPACTION_THRESHOLD, CURRENT_CALLBACK_ISOLATE_ID, CURRENT_CALLBACK_SCOPE,
-        StoredBehaviour, V8ArrayBuffer, V8Constructor, V8DataView, V8Engine, V8Function,
-        V8Generator, V8Map, V8Object, V8Promise, V8Set, V8SharedArrayBuffer, V8TypedArray, V8Types,
-        local_object,
+        HOST_OBJECT_TAG, StoredBehaviour, V8ArrayBuffer, V8Constructor, V8DataView, V8Engine,
+        V8Function, V8Generator, V8Map, V8Object, V8Promise, V8Set, V8SharedArrayBuffer,
+        V8TypedArray, V8Types, create_builtin_fn_with_captures, local_object,
     };
 
     pub(crate) struct DropFlag(pub(crate) Rc<Cell<bool>>);
@@ -5191,5 +5264,55 @@ mod tests {
             "the associated platform cell must survive gc"
         );
         drop(payload_weak);
+    }
+
+    #[test]
+    fn traced_captures_keep_payload_alive_and_follow_function_lifetime() {
+        struct Payload(Rc<Cell<bool>>);
+        impl Finalize for Payload {}
+        unsafe impl Trace for Payload {
+            unsafe fn trace(&self, _visitor: &mut Visitor) {}
+            fn store(&mut self, _ec: &mut dyn ExecutionContext<V8Types>) {}
+        }
+        impl Drop for Payload {
+            fn drop(&mut self) {
+                self.0.set(true);
+            }
+        }
+
+        let mut engine = V8Engine::new();
+        let finalized = Rc::new(Cell::new(false));
+        let function_name = engine.property_key_from_str("tracedCapturesFn");
+
+        let function: V8Function = create_builtin_fn_with_captures::<V8Types, Payload>(
+            &mut engine,
+            Payload(Rc::clone(&finalized)),
+            |_arguments,
+             _this_value,
+             _captures: &Payload,
+             ec: &mut dyn ExecutionContext<V8Types>| Ok(ec.value_undefined()),
+            0,
+            function_name,
+            false,
+        );
+
+        // The function handle is rooted: the traced captures must survive a
+        // full collection (their platform is traced from the wrapper, which
+        // is rooted by the record's behaviour closure).
+        engine.gc();
+        assert!(
+            !finalized.get(),
+            "captures of a rooted function must survive gc"
+        );
+
+        // Dropping the function handle frees the record, which drops the
+        // closure's root on the captures wrapper; the wrapper and its
+        // captures platform are then collectable.
+        drop(function);
+        engine.gc();
+        assert!(
+            finalized.get(),
+            "captures must be released once the function is collected"
+        );
     }
 }


### PR DESCRIPTION
   trace native-function captures

   Dead document realms were never collected: interface constructor
   closures and event-listener callbacks held strong v8::Global roots that
   pinned the whole context, and no GC ran at teardown. DestroyDocument now
   clears all event listeners/handlers, prunes dead-realm callback records,
   and runs a full V8+cppgc collection; Web IDL constructors resolve the
   prototype per call instead of capturing it; and builtin-function captures
   live in a cppgc-traced platform object so they follow the function's
   lifetime. RSS stays flat across navigations (was ~13 MB/nav).