### PR TITLE
user_agent: single Embedder host trait; drop the webview bridge

### DIFF
--- a/user_agent/README.md
+++ b/user_agent/README.md
@@ -39,7 +39,7 @@ The content processes send each traversable's `PaintFrame` directly to the
 embed sites + video frames) and returns `GraphicsEvent::PixelFrameReady`.
 The UA stores the accompanying `FrameHitInfo` in `UserAgentState::frame_hit_info`
 (keyed by webview id) for UI event routing, and forwards the layers to the
-host (`webview::Embedder` via `UserAgentHost::new_web_content_layers`).
+host via `Embedder::new_web_content_layers`.
 
 Gotcha: during a cross-origin navigation the traversable's event loop (and
 content process) switches before the UA-side active document does — the

--- a/user_agent/src/event_loops.rs
+++ b/user_agent/src/event_loops.rs
@@ -35,7 +35,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use verification::TraceSender;
 
-use crate::UserAgentHost;
+use crate::Embedder;
 use crate::ipc_manifest::ContentExtensionManifest;
 
 /// Graceful shutdown of the content process owned by one window event loop.
@@ -179,7 +179,7 @@ pub struct WorkerEventLoop {
 pub fn spawn_window_event_loop(
     event_loop_id: EventLoopId,
     process_label: String,
-    host: Arc<dyn UserAgentHost>,
+    host: Arc<dyn Embedder>,
     trace_sender: Option<TraceSender>,
     network_extension_sender: ipc::IpcSender<ipc_messages::network::Request>,
     graphics_sender_for_bootstrap: Option<ipc::IpcSender<GraphicsCommand>>,

--- a/user_agent/src/user_agent.rs
+++ b/user_agent/src/user_agent.rs
@@ -117,10 +117,11 @@ pub struct NavigationCompleted {
     pub status: NavigationCompletion,
 }
 
-/// The host interface the user-agent thread calls into (implemented by the
-/// webview crate, which adapts the embedder-facing `webview::Embedder`
-/// trait).
-pub trait UserAgentHost: Send + Sync {
+/// The embedder host interface: the callbacks the user agent makes into the
+/// embedder (navigation, paint, clipboard, viewport, window title). The
+/// embedder backends implement this trait; the webview crate re-exports it
+/// as part of its embedder-facing API.
+pub trait Embedder: Send + Sync {
     fn navigation_requested(
         &self,
         webview_id: WebviewId,
@@ -907,7 +908,7 @@ pub struct UserAgent {
 impl UserAgent {
     /// spawning the dedicated user-agent thread owned by the webview layer.
     pub fn start(
-        host: Arc<dyn UserAgentHost>,
+        host: Arc<dyn Embedder>,
         trace_sender: Option<TraceSender>,
     ) -> Result<Self, String> {
         let (command_sender, command_receiver) = unbounded();
@@ -1301,7 +1302,7 @@ struct UserAgentWorker {
     graphics_child: Option<std::process::Child>,
 
     /// Host integration used to surface navigation, paint, clipboard, and viewport state.
-    host: Arc<dyn UserAgentHost>,
+    host: Arc<dyn Embedder>,
     /// Trace logger for the Navigation TLA+ spec.
     tla_tracer: TLATracer,
     /// Monotonic-clock reading captured at the same moment as
@@ -1339,7 +1340,7 @@ impl UserAgentWorker {
     /// starting the fetch worker owned by the user-agent thread.
     fn new(
         command_receiver: Receiver<UserAgentCommand>,
-        host: Arc<dyn UserAgentHost>,
+        host: Arc<dyn Embedder>,
         trace_sender: Option<TraceSender>,
     ) -> Self {
         let net_connection = crate::fetch::NetConnection::new(trace_sender.clone())

--- a/webview/README.md
+++ b/webview/README.md
@@ -4,10 +4,13 @@ The `webview` crate is the embedder-facing API of formal-web: the embedder
 crates depend on `webview` alone and never name the ipc crates underneath
 it.
 
-- Defines the `Embedder` host-interface trait (navigation, paint, clipboard,
-  viewport, and window-title callbacks) that the embedder backends implement.
-  `WebviewProvider::new` adapts it to the user agent's own host interface
-  (`user_agent::UserAgentHost`).
+- Re-exports the `Embedder` host-interface trait (navigation, paint,
+  clipboard, viewport, and window-title callbacks). The `user_agent` crate
+  defines the trait and calls it from the user-agent thread; the embedder
+  backends implement it, and `WebviewProvider` hands their implementation to
+  the user agent at startup. New host callbacks are defined on
+  `user_agent::Embedder` only — never mirrored on a second trait behind a
+  forwarding adapter in `webview`.
 - Re-exports the host-facing type vocabulary whose definitions live in the
   ipc crates: `WebviewId`, the composed-scene payloads (`RecordedScene`,
   `deserialize_scene_from_slice`, `FontTransportReceiver`, `RegisteredFont`),

--- a/webview/src/lib.rs
+++ b/webview/src/lib.rs
@@ -20,130 +20,14 @@ pub use ipc_messages::graphics::{CompositingLayerId, LayerFrame, SurfaceFrame};
 
 use ipc_messages::content::{NavigateRequest, UserNavigationInvolvement};
 use log::{debug, error, trace};
-use std::collections::HashMap;
 use std::env;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
-use user_agent::{UserAgent, UserAgentHost};
+use user_agent::UserAgent;
 use verification::TraceSender;
 
-pub use user_agent::{NavigationCompleted, NavigationCompletion};
-
-/// The embedder host interface: the callbacks the user agent makes into the
-/// embedder (navigation, paint, clipboard, viewport, window title). The
-/// embedder crates implement this trait; the webview crate adapts it to the
-/// user agent's own host interface (`user_agent::UserAgentHost`).
-pub trait Embedder: Send + Sync {
-    fn navigation_requested(
-        &self,
-        webview_id: WebviewId,
-        destination_url: String,
-    ) -> Result<(), String>;
-    fn navigation_completed(&self, completed: NavigationCompleted) -> Result<(), String>;
-    fn new_webview(&self, webview_id: WebviewId, target_name: String) -> Result<(), String>;
-    fn request_redraw(&self, webview_id: WebviewId);
-    fn viewport_scale_factor(&self) -> f32;
-    fn window_viewport_snapshot(&self) -> Option<(u32, u32, f32, ColorScheme)>;
-    fn clipboard_get_text(&self) -> Result<String, String>;
-    fn clipboard_set_text(&self, text: String) -> Result<(), String>;
-    /// The parsed title of a top-level document, reported by the content
-    /// process after parsing; the embedder labels the tab and window with it.
-    /// <https://html.spec.whatwg.org/#the-title-element>
-    fn title_changed(&self, webview_id: WebviewId, title: String) -> Result<(), String>;
-    /// Forward a composed web content scene from the graphics process to the
-    /// embedder for rendering.
-    fn new_web_content_scene(
-        &self,
-        webview_id: WebviewId,
-        scene_bytes: Vec<u8>,
-        font_registrations: Vec<RegisteredFont>,
-        font_data: HashMap<usize, Vec<u8>>,
-    ) -> Result<(), String>;
-    /// Forward the per-layer rendered frame from the graphics process. Each
-    /// layer carries its wire `topology` (transform, clip, z-order) plus the
-    /// actual `frame` only when the layer was re-rendered this cycle; a clean
-    /// layer keeps its last surface and carries `frame: None`. `animating`
-    /// reports whether the composed scene contains animated content (video,
-    /// CSS animations) that needs the next frame at display cadence.
-    fn new_web_content_layers(
-        &self,
-        webview_id: WebviewId,
-        layers: Vec<LayerFrame>,
-        animating: bool,
-    ) -> Result<(), String>;
-}
-
-/// Bridges the user agent's host interface to the embedder-facing
-/// [`Embedder`] trait: the user agent is started with an adapter that
-/// forwards every host call to the embedder's implementation.
-struct UserAgentHostAdapter {
-    embedder: Arc<dyn Embedder>,
-}
-
-impl UserAgentHost for UserAgentHostAdapter {
-    fn navigation_requested(
-        &self,
-        webview_id: WebviewId,
-        destination_url: String,
-    ) -> Result<(), String> {
-        self.embedder
-            .navigation_requested(webview_id, destination_url)
-    }
-
-    fn navigation_completed(&self, completed: NavigationCompleted) -> Result<(), String> {
-        self.embedder.navigation_completed(completed)
-    }
-
-    fn new_webview(&self, webview_id: WebviewId, target_name: String) -> Result<(), String> {
-        self.embedder.new_webview(webview_id, target_name)
-    }
-
-    fn request_redraw(&self, webview_id: WebviewId) {
-        self.embedder.request_redraw(webview_id);
-    }
-
-    fn viewport_scale_factor(&self) -> f32 {
-        self.embedder.viewport_scale_factor()
-    }
-
-    fn window_viewport_snapshot(&self) -> Option<(u32, u32, f32, ColorScheme)> {
-        self.embedder.window_viewport_snapshot()
-    }
-
-    fn clipboard_get_text(&self) -> Result<String, String> {
-        self.embedder.clipboard_get_text()
-    }
-
-    fn clipboard_set_text(&self, text: String) -> Result<(), String> {
-        self.embedder.clipboard_set_text(text)
-    }
-
-    fn title_changed(&self, webview_id: WebviewId, title: String) -> Result<(), String> {
-        self.embedder.title_changed(webview_id, title)
-    }
-
-    fn new_web_content_scene(
-        &self,
-        webview_id: WebviewId,
-        scene_bytes: Vec<u8>,
-        font_registrations: Vec<RegisteredFont>,
-        font_data: HashMap<usize, Vec<u8>>,
-    ) -> Result<(), String> {
-        self.embedder
-            .new_web_content_scene(webview_id, scene_bytes, font_registrations, font_data)
-    }
-
-    fn new_web_content_layers(
-        &self,
-        webview_id: WebviewId,
-        layers: Vec<LayerFrame>,
-        animating: bool,
-    ) -> Result<(), String> {
-        self.embedder
-            .new_web_content_layers(webview_id, layers, animating)
-    }
-}
+pub use user_agent::{Embedder, NavigationCompleted, NavigationCompletion};
 
 fn startup_destination_url(startup_url: Option<&str>) -> Result<String, String> {
     match startup_url {
@@ -177,12 +61,7 @@ impl WebviewProvider {
         embedder: Arc<dyn Embedder>,
         trace_sender: Option<TraceSender>,
     ) -> Result<Self, String> {
-        let user_agent = UserAgent::start(
-            Arc::new(UserAgentHostAdapter {
-                embedder: embedder.clone(),
-            }),
-            trace_sender,
-        )?;
+        let user_agent = UserAgent::start(embedder.clone(), trace_sender)?;
 
         Ok(Self {
             embedder,


### PR DESCRIPTION
Restore the embedder host interface as one trait defined in user_agent (renamed back from UserAgentHost to Embedder) and delete webview's duplicate Embedder trait plus its UserAgentHostAdapter forwarding shim. WebviewProvider now passes the embedder's implementation directly to UserAgent::start; webview re-exports user_agent::Embedder so the embedder backends still depend on webview alone.