### PR TITLE
mac: fix bug where video frame showed up on wrong tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,14 @@
 
 formal-web is a Rust web-engine prototype with a modular architecture and support for formal verification.
 
-The modularity is goal orientated: it can be used to either support shipping on a platform with specific constraints (like using extensions for [BrowserEngineKit](https://developer.apple.com/documentation/browserenginekit)), support 
-platform specific performance (like integrating with Core Animation based compositing on Mac), introduce flexibility (like the ability to choose a JS engine), or simply to reduce binary size by re-using what is already on the system.
+The modularity is goal-oriented: it can be used to support the following:
+
+- **external constraint satisfaction**: shipping on a platform with specific constraints. Example: the ipc layer defaults to Rust multiprocessing, but is also designed to in the future support extensions in the context of [BrowserEngineKit](https://developer.apple.com/documentation/browserenginekit).
+- **performance optimization**: platform specific performance. Example: integrating with Core Animation based compositing on Mac.
+- **engineering flexibility**: subsystem swapping. For example, one can choose a JS engine such as V8 or Boa, and with Boa, one can also choose to add wasm via Wasmtime.
+- **cost reduction**: reduce binary size or build time by re-using what is already on the system. Example: choosing the url-session networking backend on Mac.
+
+Note: current implementation of generic component reflect Mac OS as the current main development platform: high-performance Mac OS paths with lower-performance cross platform paths. For example, there is a relatively high-performance rendering path on Mac OS, with zero copy texture sharing and a modicum of layering using multiple Core Animation layers to minimize re-rendering, and then there is a relatively low-performance cross platform path involving reading back data to the CPU.
 
 ## Getting Started
 
@@ -60,6 +66,29 @@ cargo run --release
 cargo build --release --no-default-features --features v8
 cargo run --release --no-default-features --features v8
 ```
+
+### Networking (selected on the `net` build)
+
+The fetch transport is one of two backends. macOS defaults to the Apple
+URLSession backend, which compiles no reqwest/tokio stack; on other
+platforms the tokio/reqwest backend is the only option and is always
+compiled:
+
+```bash
+# Default (macOS): Apple URLSession — the default build above.
+# Default (other platforms): tokio/reqwest — always compiled there, the
+# default build above.
+
+# macOS: tokio/reqwest backend (opt-in; URLSession is the default and wins
+# if both features are enabled)
+cargo build --release -p net --features tokio
+cargo run --release
+```
+
+A full `cargo build --release` prebuilds `formal-web-net` with the platform
+default backend and overwrites the copy it places next to the embedder
+binary, so build the `net` package after it when switching backends. See
+`net/README.md` for the backends themselves.
 
 ### Embedder
 

--- a/embedder/mac-embedder/src/app.rs
+++ b/embedder/mac-embedder/src/app.rs
@@ -447,6 +447,28 @@ struct SurfaceState {
     animating: bool,
 }
 
+/// The geometry of one compositing layer of a webview's last reported
+/// composition, cached per webview (see `MacWindow::stored_layers`): the
+/// geometry from the last arrival plus the newest surface the layer
+/// carried. The surface is retained so a tab switch re-presents the layer
+/// (a video's last frame included) without a new frame from the graphics
+/// process.
+struct StoredLayerState {
+    layer_id: CompositingLayerId,
+    parent: Option<CompositingLayerId>,
+    clip_bounds: [f64; 4],
+    corner_radius: f64,
+    z_order: (i32, u32),
+    /// The layer's content size in its own local space.
+    width: u32,
+    height: u32,
+    /// The newest surface received for the layer. None for the root (its
+    /// surface lives in `surfaces`) and for layers that never carried one.
+    surface: Option<CFRetained<IOSurfaceRef>>,
+    /// The global IOSurfaceID of `surface`.
+    surface_id: Option<u32>,
+}
+
 /// Per-window state: the NSWindow, the native chrome views, tabs, and
 /// per-webview surfaces.
 struct MacWindow {
@@ -476,10 +498,19 @@ struct MacWindow {
     active_tab: Option<WebviewId>,
     surfaces: HashMap<WebviewId, SurfaceState>,
     /// Sublayers under `web_layer`, one per child (non-root) compositing
-    /// layer of the active webview's composition: cross-origin iframe
+    /// layer of the **active** webview's composition: cross-origin iframe
     /// navigables and `<video>` embed sites. The root navigable itself is
-    /// presented on `web_layer`, not as one of these.
+    /// presented on `web_layer`, not as one of these. The tree always
+    /// mirrors the active tab's layers (see `stored_layers`); a frame for
+    /// an inactive tab never reaches it.
     sublayers: HashMap<CompositingLayerId, Retained<objc2_quartz_core::CALayer>>,
+    /// The last composition received per webview: every layer's geometry
+    /// plus the newest surface per layer, in the order the compositor
+    /// reported them. `handle_new_layers` refreshes this for every arriving
+    /// frame, active tab or not; switching tabs re-presents the incoming
+    /// tab's layers from here, so a video's last frame survives switching
+    /// away and back without a new frame from the graphics process.
+    stored_layers: HashMap<WebviewId, Vec<StoredLayerState>>,
     keyboard_modifiers: KeyboardModifiers,
     buttons: MouseEventButtons,
     /// Content view size in points (the window's content area).
@@ -683,6 +714,27 @@ impl MacApp {
         });
         if animating {
             self.start_display_link();
+        }
+    }
+
+    /// Recompute the display link from the visible tabs' stored surfaces:
+    /// an animating visible tab (a playing video, a CSS animation) keeps it
+    /// running, otherwise it stops. Called when the active tab changes (tab
+    /// switch, tab close, re-activation), so the link follows the tab on
+    /// screen rather than the last frame that happened to arrive — an
+    /// inactive tab's video must not keep the link running over a static
+    /// visible tab, nor stop it under an animating one.
+    fn sync_display_link(&mut self) {
+        let animating = self.windows.values().any(|window_state| {
+            window_state
+                .active_tab
+                .and_then(|webview_id| window_state.surfaces.get(&webview_id))
+                .is_some_and(|surface| surface.animating)
+        });
+        if animating {
+            self.start_display_link();
+        } else {
+            self.stop_display_link();
         }
     }
 
@@ -2069,12 +2121,22 @@ impl MacApp {
         if let Some(window_state) = self.windows.get_mut(&window_id) {
             window_state.active_tab = Some(webview_id);
             Self::present_active_surface(window_state);
+            // Rebuild the sublayer tree for the incoming tab from its
+            // stored layers, so the outgoing tab's layers (a playing
+            // video's frame included) never stay on screen over the new
+            // tab, and the incoming tab's own last frame is shown
+            // immediately.
+            Self::reconcile_sublayers(window_state, webview_id);
         }
         self.refresh_chrome(window_id);
         self.update_provider_viewport(window_id);
         if let Some(provider) = self.provider.as_ref() {
             let _ = provider.frame_needed(webview_id);
         }
+        // The display link follows the visible tab's stored surface: an
+        // animating tab (a playing video) keeps it running, a static tab
+        // stops it.
+        self.sync_display_link();
     }
 
     fn action_new_tab(&mut self) {
@@ -2199,6 +2261,7 @@ impl MacApp {
                 .position(|candidate| *candidate == webview_id);
             window_state.tabs.remove(&webview_id);
             window_state.surfaces.remove(&webview_id);
+            window_state.stored_layers.remove(&webview_id);
             if let Some(index) = index {
                 window_state.tab_order.remove(index);
             }
@@ -2222,13 +2285,18 @@ impl MacApp {
         if closed_active {
             // Present the new active tab's surface right away and request a
             // frame, so the closed tab's webview does not stay on screen
-            // until the user picks another tab.
+            // until the user picks another tab. The sublayer tree is
+            // rebuilt for the new active tab from its stored layers, so the
+            // closed tab's video/iframe layers do not linger over it.
             let active = self
                 .windows
                 .get(&window_id)
                 .and_then(|window_state| window_state.active_tab);
             if let Some(window_state) = self.windows.get_mut(&window_id) {
                 Self::present_active_surface(window_state);
+                if let Some(active) = active {
+                    Self::reconcile_sublayers(window_state, active);
+                }
             }
             if let Some(provider) = self.provider.as_ref()
                 && let Some(active) = active
@@ -2237,6 +2305,7 @@ impl MacApp {
                 error!("[mac-embedder] frame needed: {error}");
             }
         }
+        self.sync_display_link();
     }
 
     fn action_navigate(&mut self, input: String) {
@@ -2265,16 +2334,40 @@ impl MacApp {
     }
 
     fn add_tab(&mut self, window_id: WindowId, webview_id: WebviewId) {
-        let Some(window_state) = self.windows.get_mut(&window_id) else {
-            return;
+        let was_present = {
+            let Some(window_state) = self.windows.get_mut(&window_id) else {
+                return;
+            };
+            match window_state.tabs.entry(webview_id) {
+                std::collections::hash_map::Entry::Occupied(_) => true,
+                std::collections::hash_map::Entry::Vacant(vacant) => {
+                    vacant.insert(TabState::new());
+                    window_state.tab_order.push(webview_id);
+                    false
+                }
+            }
         };
-        if window_state.tabs.contains_key(&webview_id) {
+        // The incoming traversable becomes the active tab whether it was
+        // newly opened or already present (it has no content of its own
+        // yet when new; the previous tab's layers stay on screen until its
+        // first frame arrives).
+        {
+            let Some(window_state) = self.windows.get_mut(&window_id) else {
+                return;
+            };
             window_state.active_tab = Some(webview_id);
-            return;
         }
-        window_state.tabs.insert(webview_id, TabState::new());
-        window_state.tab_order.push(webview_id);
-        window_state.active_tab = Some(webview_id);
+        if was_present {
+            // Re-activating an existing tab (a navigation targeted at a tab
+            // that is already open): present it like a tab switch, restoring
+            // its stored layers.
+            let Some(window_state) = self.windows.get_mut(&window_id) else {
+                return;
+            };
+            Self::present_active_surface(window_state);
+            Self::reconcile_sublayers(window_state, webview_id);
+            self.sync_display_link();
+        }
     }
 
     /// Present the active tab's stored surface (the latest composited
@@ -2368,6 +2461,7 @@ impl MacApp {
             address_field_focused: false,
             surfaces: HashMap::new(),
             sublayers: HashMap::new(),
+            stored_layers: HashMap::new(),
             keyboard_modifiers: KeyboardModifiers::default(),
             buttons: MouseEventButtons::None,
             content_size: (INITIAL_WINDOW_WIDTH, INITIAL_WINDOW_HEIGHT),
@@ -2513,6 +2607,10 @@ impl MacApp {
     fn window_did_become_key(&mut self, notification: &NSNotification) {
         if let Some(window_id) = self.window_id_for_notification(notification) {
             self.active_window_id = Some(window_id);
+            // The display link follows the front window's active tab (the
+            // tick requests frames for it); re-sync when the front window
+            // changes.
+            self.sync_display_link();
         }
     }
 
@@ -2769,6 +2867,194 @@ impl MacApp {
         }
     }
 
+    /// Record the arriving layer stream as the webview's stored layers:
+    /// every layer's geometry plus the newest surface for the layers that
+    /// were re-rendered this cycle (a clean layer keeps the surface it last
+    /// carried), in the order the compositor reported them. Runs for every
+    /// frame, active tab or not: an inactive tab's stream only updates this
+    /// cache — it never reaches the live sublayer tree — and the cache is
+    /// what a tab switch re-presents (see
+    /// [`reconcile_sublayers`](Self::reconcile_sublayers)).
+    fn store_layers(window_state: &mut MacWindow, webview_id: WebviewId, layers: &[LayerFrame]) {
+        let previous = window_state
+            .stored_layers
+            .remove(&webview_id)
+            .unwrap_or_default();
+        let mut previous_by_id: HashMap<CompositingLayerId, StoredLayerState> = previous
+            .into_iter()
+            .map(|entry| (entry.layer_id, entry))
+            .collect();
+        let mut stored = Vec::with_capacity(layers.len());
+        for layer in layers {
+            let previous_entry = previous_by_id.remove(&layer.topology.layer_id);
+            // The root's surface is tracked in `surfaces` and presented on
+            // the web_layer; sublayers keep their newest surface here so a
+            // tab switch re-presents it. A re-rendered (dirty) layer
+            // imports its new surface; a clean layer keeps the previous
+            // one.
+            let (surface, surface_id) = if layer.topology.parent.is_some() {
+                match layer.frame.as_ref().and_then(import_shared_surface) {
+                    Some((surface, surface_id)) => (Some(surface), Some(surface_id)),
+                    None => (
+                        previous_entry
+                            .as_ref()
+                            .and_then(|entry| entry.surface.clone()),
+                        previous_entry.and_then(|entry| entry.surface_id),
+                    ),
+                }
+            } else {
+                (None, None)
+            };
+            stored.push(StoredLayerState {
+                layer_id: layer.topology.layer_id,
+                parent: layer.topology.parent,
+                clip_bounds: layer.topology.clip_bounds,
+                corner_radius: layer.topology.corner_radius,
+                z_order: layer.topology.z_order,
+                width: layer.topology.width,
+                height: layer.topology.height,
+                surface,
+                surface_id,
+            });
+        }
+        window_state.stored_layers.insert(webview_id, stored);
+    }
+
+    /// Mirror `webview_id`'s stored layers onto the window's live sublayer
+    /// tree: create the sublayers its composition has and the tree lacks,
+    /// refresh their geometry and contents, and remove the live sublayers
+    /// that are no longer part of its composition (the previous tab's
+    /// layers). Called when the active tab changes (`action_switch_tab`,
+    /// `close_tab`, `add_tab`): the tree always shows exactly the visible
+    /// tab's layers, so a tab switched away from loses nothing — its stored
+    /// layers (a video's last frame included) are re-presented on the way
+    /// back without waiting for a new frame from the graphics process. A
+    /// webview that never produced a frame leaves the tree untouched: its
+    /// tab has no content of its own, so the previous tab's layers stay on
+    /// screen until the first frame arrives.
+    fn reconcile_sublayers(window_state: &mut MacWindow, webview_id: WebviewId) {
+        let Some(stored) = window_state.stored_layers.get(&webview_id) else {
+            return;
+        };
+        let scale = window_state.scale;
+        // The compositor reports each layer's clip/transform in the root
+        // navigable's local (pixel) coordinate space — the root surface is
+        // 2400x1448 — while the web_layer and its sublayers live in window
+        // point space (the window content size). Scale sublayer geometry by
+        // (web_layer / root) so sublayers land where the root content is
+        // drawn.
+        let Some((root_w, root_h)) = stored
+            .iter()
+            .find(|entry| entry.parent.is_none())
+            .map(|entry| (f64::from(entry.width), f64::from(entry.height)))
+        else {
+            return;
+        };
+        let web_bounds = window_state.web_layer.bounds();
+        let scale_x = web_bounds.size.width / root_w.max(1.0);
+        let scale_y = web_bounds.size.height / root_h.max(1.0);
+
+        // Remove the live sublayers that are not part of this webview's
+        // composition: the previous active tab's layers on a switch, or
+        // layers the webview itself dropped (e.g. a video element removed
+        // from the document).
+        let desired: HashSet<CompositingLayerId> = stored
+            .iter()
+            .filter(|entry| entry.parent.is_some())
+            .map(|entry| entry.layer_id)
+            .collect();
+        let stale: Vec<_> = window_state
+            .sublayers
+            .keys()
+            .copied()
+            .filter(|layer_id| !desired.contains(layer_id))
+            .collect();
+        for layer_id in stale {
+            if let Some(layer) = window_state.sublayers.remove(&layer_id) {
+                debug!("[mac-embedder] remove sublayer {:?}", layer_id);
+                layer.removeFromSuperlayer();
+            }
+        }
+
+        // Add and refresh the webview's sublayers in the order the
+        // compositor reported them (parent layers before their children).
+        // One transaction disables implicit animations for all
+        // moves/appearances.
+        objc2_quartz_core::CATransaction::begin();
+        objc2_quartz_core::CATransaction::setDisableActions(true);
+        for entry in stored {
+            if entry.parent.is_none() {
+                continue; // the root navigable, presented on the web_layer
+            }
+            let layer_id = entry.layer_id;
+            // Resolve the parent CALayer: another sublayer if present, else
+            // the web_layer (the root navigable). Retained clone ends the
+            // sublayers borrow before the entry below.
+            let parent_layer = entry
+                .parent
+                .and_then(|parent_id| window_state.sublayers.get(&parent_id).cloned())
+                .unwrap_or_else(|| window_state.web_layer.clone());
+
+            let sublayer = window_state.sublayers.entry(layer_id).or_insert_with(|| {
+                let sublayer = CALayer::layer();
+                sublayer.setOpaque(true);
+                sublayer.setContentsScale(scale);
+                parent_layer.addSublayer(&sublayer);
+                sublayer
+            });
+
+            // Geometry: the layer's frame is its visible clip rect in its
+            // parent's space, converted from root-pixel space to web_layer
+            // point space; contents scale to fill (default
+            // contentsGravity = resize), matching the producer's placement.
+            //
+            // The clip is reported in the root navigable's top-down pixel
+            // space, while the web_layer (a layer-hosting view's backing
+            // layer) has a bottom-up (y-up) coordinate space. Mapping the
+            // top-down clip straight into the y-up frame would mirror the
+            // sublayer vertically: it would sit above its element and move
+            // opposite the page on scroll. Flip the y origin so sublayers
+            // land on their element and track the page.
+            let clip = &entry.clip_bounds;
+            let frame_y = web_bounds.size.height - clip[3] * scale_y;
+            sublayer.setFrame(NSRect::new(
+                NSPoint::new(clip[0] * scale_x, frame_y),
+                NSSize::new((clip[2] - clip[0]) * scale_x, (clip[3] - clip[1]) * scale_y),
+            ));
+            sublayer.setCornerRadius(entry.corner_radius);
+            sublayer.setMasksToBounds(entry.corner_radius > 0.0);
+            let (z_index, paint_order) = entry.z_order;
+            sublayer.setZPosition((z_index as f64) * 10000.0 + (paint_order as f64));
+            debug!(
+                "[mac-embedder] sublayer {:?} parent={:?} surface={} clip={:?} z={:?} surface_size={:?} frame_pos={:?} frame_size={:?}",
+                entry.layer_id,
+                entry.parent,
+                entry.surface_id.is_some(),
+                entry.clip_bounds,
+                entry.z_order,
+                (entry.width, entry.height),
+                (clip[0] * scale_x, frame_y),
+                ((clip[2] - clip[0]) * scale_x, (clip[3] - clip[1]) * scale_y),
+            );
+
+            // Contents: the newest surface the layer carried, presented for
+            // the re-presented layer (a clean layer of a frame that never
+            // re-rendered it has no new surface and keeps the old
+            // contents).
+            if let Some(surface) = &entry.surface {
+                let padded_width = padded_surface_width(entry.width);
+                // SAFETY: the sublayer retains the surface; the surface is
+                // a valid Objective-C object (an IOSurface).
+                let _: () = unsafe { msg_send![&**sublayer, setContents: &**surface] };
+                sublayer.setContentsRect(NSRect::new(
+                    NSPoint::new(0.0, 0.0),
+                    NSSize::new(f64::from(entry.width) / f64::from(padded_width.max(1)), 1.0),
+                ));
+            }
+        }
+        objc2_quartz_core::CATransaction::commit();
+    }
+
     fn handle_new_layers(
         &mut self,
         webview_id: WebviewId,
@@ -2784,6 +3070,12 @@ impl MacApp {
         };
         let is_active = window_state.active_tab == Some(webview_id);
         let scale = window_state.scale;
+
+        // Record the arriving stream as the webview's stored layers before
+        // anything is presented: the cache is what a later tab switch
+        // re-presents, and for an inactive tab it is the only place the
+        // frame goes.
+        Self::store_layers(window_state, webview_id, &layers);
 
         // The compositor reports each layer's clip/transform in the root
         // navigable's local (pixel) coordinate space — the root surface is
@@ -2874,128 +3166,137 @@ impl MacApp {
             );
         }
 
-        // Child layers (cross-origin iframe navigables, video embed sites)
-        // become sublayers under web_layer (or their parent's sublayer). One
-        // transaction disables implicit animations for all moves/appearances.
-        objc2_quartz_core::CATransaction::begin();
-        objc2_quartz_core::CATransaction::setDisableActions(true);
-        let mut seen = HashSet::new();
-        for layer in &layers {
-            let layer_id = layer.topology.layer_id;
-            if layer.topology.parent.is_none() {
-                continue; // root handled above
-            }
-            seen.insert(layer_id);
+        // The live sublayer tree always mirrors the **active** tab's
+        // layers. A frame for an inactive tab only updated its stored
+        // state (store_layers above): it must not create, update, or drop
+        // anything in the tree, or a video frame from a background tab
+        // would be drawn over the visible tab (and its stale-drop would
+        // tear down the visible tab's own layers).
+        if is_active {
+            // Child layers (cross-origin iframe navigables, video embed
+            // sites) become sublayers under web_layer (or their parent's
+            // sublayer). One transaction disables implicit animations for
+            // all moves/appearances.
+            objc2_quartz_core::CATransaction::begin();
+            objc2_quartz_core::CATransaction::setDisableActions(true);
+            let mut seen = HashSet::new();
+            for layer in &layers {
+                let layer_id = layer.topology.layer_id;
+                if layer.topology.parent.is_none() {
+                    continue; // root handled above
+                }
+                seen.insert(layer_id);
 
-            // Resolve the parent CALayer: another sublayer if present, else
-            // the web_layer (the root navigable). Retained clone ends the
-            // sublayers borrow before the entry below.
-            let parent_layer = layer
-                .topology
-                .parent
-                .and_then(|parent_id| window_state.sublayers.get(&parent_id).cloned())
-                .unwrap_or_else(|| window_state.web_layer.clone());
+                // Resolve the parent CALayer: another sublayer if present, else
+                // the web_layer (the root navigable). Retained clone ends the
+                // sublayers borrow before the entry below.
+                let parent_layer = layer
+                    .topology
+                    .parent
+                    .and_then(|parent_id| window_state.sublayers.get(&parent_id).cloned())
+                    .unwrap_or_else(|| window_state.web_layer.clone());
 
-            if !window_state.sublayers.contains_key(&layer_id) {
-                let sublayer = CALayer::layer();
-                sublayer.setOpaque(true);
-                sublayer.setContentsScale(scale);
-                parent_layer.addSublayer(&sublayer);
-                window_state.sublayers.insert(layer_id, sublayer);
-            }
-            let Some(sublayer) = window_state.sublayers.get(&layer_id) else {
-                continue;
-            };
-
-            // Geometry: the layer's frame is its visible clip rect in its
-            // parent's space, converted from root-pixel space to web_layer
-            // point space; contents scale to fill (default
-            // contentsGravity = resize), matching the producer's placement.
-            //
-            // The clip is reported in the root navigable's top-down pixel
-            // space, while the web_layer (a layer-hosting view's backing
-            // layer) has a bottom-up (y-up) coordinate space. Mapping the
-            // top-down clip straight into the y-up frame would mirror the
-            // sublayer vertically: it would sit above its element and move
-            // opposite the page on scroll. Flip the y origin so sublayers
-            // land on their element and track the page.
-            let clip = &layer.topology.clip_bounds;
-            let frame_y = web_bounds.size.height - clip[3] * scale_y;
-            sublayer.setFrame(NSRect::new(
-                NSPoint::new(clip[0] * scale_x, frame_y),
-                NSSize::new((clip[2] - clip[0]) * scale_x, (clip[3] - clip[1]) * scale_y),
-            ));
-            sublayer.setCornerRadius(layer.topology.corner_radius);
-            sublayer.setMasksToBounds(layer.topology.corner_radius > 0.0);
-            let (z_index, paint_order) = layer.topology.z_order;
-            sublayer.setZPosition((z_index as f64) * 10000.0 + (paint_order as f64));
-            debug!(
-                "[mac-embedder] sublayer {:?} parent={:?} frame={} clip={:?} z={:?} surface_size={:?} frame_pos={:?} frame_size={:?}",
-                layer.topology.layer_id,
-                layer.topology.parent,
-                layer.frame.is_some(),
-                layer.topology.clip_bounds,
-                layer.topology.z_order,
-                layer
-                    .frame
-                    .as_ref()
-                    .map(|_| (layer.topology.width, layer.topology.height)),
-                (clip[0] * scale_x, frame_y),
-                ((clip[2] - clip[0]) * scale_x, (clip[3] - clip[1]) * scale_y,),
-            );
-
-            // Contents: only when re-rendered; a clean layer (frame: None)
-            // keeps its last surface untouched.
-            if let Some(frame) = &layer.frame {
-                let SurfaceFrame::SharedTexture {
-                    surface_id, port, ..
-                } = frame
-                else {
-                    continue;
-                };
-                let surface = IOSurfaceRef::lookup(*surface_id).or_else(|| {
-                    let port_name = port.clone().into_name();
-                    let surface = IOSurfaceRef::lookup_from_mach_port(port_name);
-                    deallocate_mach_port(port_name);
-                    surface
+                let sublayer = window_state.sublayers.entry(layer_id).or_insert_with(|| {
+                    let sublayer = CALayer::layer();
+                    sublayer.setOpaque(true);
+                    sublayer.setContentsScale(scale);
+                    parent_layer.addSublayer(&sublayer);
+                    sublayer
                 });
-                if let Some(surface) = surface {
-                    let padded_width = padded_surface_width(layer.topology.width);
-                    // SAFETY: the sublayer retains the surface; the surface
-                    // is a valid Objective-C object (an IOSurface).
-                    let _: () = unsafe { msg_send![&**sublayer, setContents: &*surface] };
-                    sublayer.setContentsRect(NSRect::new(
-                        NSPoint::new(0.0, 0.0),
-                        NSSize::new(
-                            f64::from(layer.topology.width) / f64::from(padded_width.max(1)),
-                            1.0,
-                        ),
-                    ));
+
+                // Geometry: the layer's frame is its visible clip rect in its
+                // parent's space, converted from root-pixel space to web_layer
+                // point space; contents scale to fill (default
+                // contentsGravity = resize), matching the producer's placement.
+                //
+                // The clip is reported in the root navigable's top-down pixel
+                // space, while the web_layer (a layer-hosting view's backing
+                // layer) has a bottom-up (y-up) coordinate space. Mapping the
+                // top-down clip straight into the y-up frame would mirror the
+                // sublayer vertically: it would sit above its element and move
+                // opposite the page on scroll. Flip the y origin so sublayers
+                // land on their element and track the page.
+                let clip = &layer.topology.clip_bounds;
+                let frame_y = web_bounds.size.height - clip[3] * scale_y;
+                sublayer.setFrame(NSRect::new(
+                    NSPoint::new(clip[0] * scale_x, frame_y),
+                    NSSize::new((clip[2] - clip[0]) * scale_x, (clip[3] - clip[1]) * scale_y),
+                ));
+                sublayer.setCornerRadius(layer.topology.corner_radius);
+                sublayer.setMasksToBounds(layer.topology.corner_radius > 0.0);
+                let (z_index, paint_order) = layer.topology.z_order;
+                sublayer.setZPosition((z_index as f64) * 10000.0 + (paint_order as f64));
+                debug!(
+                    "[mac-embedder] sublayer {:?} parent={:?} frame={} clip={:?} z={:?} surface_size={:?} frame_pos={:?} frame_size={:?}",
+                    layer.topology.layer_id,
+                    layer.topology.parent,
+                    layer.frame.is_some(),
+                    layer.topology.clip_bounds,
+                    layer.topology.z_order,
+                    layer
+                        .frame
+                        .as_ref()
+                        .map(|_| (layer.topology.width, layer.topology.height)),
+                    (clip[0] * scale_x, frame_y),
+                    ((clip[2] - clip[0]) * scale_x, (clip[3] - clip[1]) * scale_y,),
+                );
+
+                // Contents: only when re-rendered; a clean layer (frame: None)
+                // keeps its last surface untouched.
+                if let Some(frame) = &layer.frame {
+                    let SurfaceFrame::SharedTexture {
+                        surface_id, port, ..
+                    } = frame
+                    else {
+                        continue;
+                    };
+                    let surface = IOSurfaceRef::lookup(*surface_id).or_else(|| {
+                        let port_name = port.clone().into_name();
+                        let surface = IOSurfaceRef::lookup_from_mach_port(port_name);
+                        deallocate_mach_port(port_name);
+                        surface
+                    });
+                    if let Some(surface) = surface {
+                        let padded_width = padded_surface_width(layer.topology.width);
+                        // SAFETY: the sublayer retains the surface; the surface
+                        // is a valid Objective-C object (an IOSurface).
+                        let _: () = unsafe { msg_send![&**sublayer, setContents: &*surface] };
+                        sublayer.setContentsRect(NSRect::new(
+                            NSPoint::new(0.0, 0.0),
+                            NSSize::new(
+                                f64::from(layer.topology.width) / f64::from(padded_width.max(1)),
+                                1.0,
+                            ),
+                        ));
+                    }
                 }
             }
-        }
-        // Drop sublayers whose layer no longer exists this cycle (navigable
-        // torn down, video ended) — mirrors mark_child_frame_removed.
-        let stale: Vec<_> = window_state
-            .sublayers
-            .iter()
-            .filter(|(id, _)| !seen.contains(id))
-            .map(|(id, _)| *id)
-            .collect();
-        for id in stale {
-            if let Some(layer) = window_state.sublayers.remove(&id) {
-                debug!("[mac-embedder] remove sublayer {:?}", id);
-                layer.removeFromSuperlayer();
+            // Drop sublayers whose layer no longer exists this cycle (navigable
+            // torn down, video ended) — mirrors mark_child_frame_removed.
+            let stale: Vec<_> = window_state
+                .sublayers
+                .iter()
+                .filter(|(id, _)| !seen.contains(id))
+                .map(|(id, _)| *id)
+                .collect();
+            for id in stale {
+                if let Some(layer) = window_state.sublayers.remove(&id) {
+                    debug!("[mac-embedder] remove sublayer {:?}", id);
+                    layer.removeFromSuperlayer();
+                }
             }
-        }
-        objc2_quartz_core::CATransaction::commit();
+            objc2_quartz_core::CATransaction::commit();
 
-        // Pacing: animated content runs the display link; a static scene is
-        // presented once and only re-renders on demand.
-        if animating {
-            self.start_display_link();
-        } else {
-            self.stop_display_link();
+            // Pacing: animated content runs the display link; a static
+            // scene is presented once and only re-renders on demand. Only
+            // the active tab's frames drive the link: an inactive tab's
+            // frames must not keep it running over a static visible tab
+            // (or stop it under an animating one).
+            if animating {
+                self.start_display_link();
+            } else {
+                self.stop_display_link();
+            }
         }
     }
 }
@@ -3042,7 +3343,7 @@ fn capture_web_view_png(web_view: &NSView) -> Result<Vec<u8>, String> {
         bitmap.representationUsingType_properties(NSBitmapImageFileType::PNG, &properties)
     }
     .ok_or_else(|| String::from("failed to encode the screenshot as PNG"))?;
-    let mut buffer = vec![0u8; data.length() as usize];
+    let mut buffer = vec![0u8; data.length()];
     // SAFETY: `buffer` is exactly `data.length()` bytes and `getBytes_length`
     // writes exactly that many.
     unsafe {
@@ -3053,6 +3354,28 @@ fn capture_web_view_png(web_view: &NSView) -> Result<Vec<u8>, String> {
         );
     }
     Ok(buffer)
+}
+
+/// Import a shared surface for presentation: look it up by its global ID
+/// first (a surface object imported from its Mach port cannot be composited
+/// by CoreAnimation), falling back to the port when the ID is not
+/// resolvable. Returns the retained surface plus its global IOSurfaceID.
+/// `None` for a CPU frame (unsupported on this embedder) or a failed
+/// lookup.
+fn import_shared_surface(frame: &SurfaceFrame) -> Option<(CFRetained<IOSurfaceRef>, u32)> {
+    let SurfaceFrame::SharedTexture {
+        surface_id, port, ..
+    } = frame
+    else {
+        return None;
+    };
+    let surface = IOSurfaceRef::lookup(*surface_id).or_else(|| {
+        let port_name = port.clone().into_name();
+        let surface = IOSurfaceRef::lookup_from_mach_port(port_name);
+        deallocate_mach_port(port_name);
+        surface
+    });
+    surface.map(|surface| (surface, *surface_id))
 }
 
 /// Round a surface width up to a multiple of 64, the Metal constraint for

--- a/embedder/mac-embedder/src/events.rs
+++ b/embedder/mac-embedder/src/events.rs
@@ -4,11 +4,9 @@
 use crate::platform::{clipboard_get_text, clipboard_set_text, window_viewport_snapshot};
 use automation::AutomationCommand;
 use log::error;
-use std::collections::HashMap;
 use std::sync::{Arc, mpsc};
 use webview::{
-    ColorScheme, Embedder, EmbedderSchemeRequest, LayerFrame, NavigationCompleted, RegisteredFont,
-    WebviewId,
+    ColorScheme, Embedder, EmbedderSchemeRequest, LayerFrame, NavigationCompleted, WebviewId,
 };
 
 use crate::app::MainThreadHandle;
@@ -153,18 +151,6 @@ impl Embedder for EventLoopEmbedder {
 
     fn host_message(&self, webview_id: WebviewId, url: String, body: String) -> Result<(), String> {
         log::debug!("[embedder] host message from {url} in webview {webview_id:?}: {body}");
-        Ok(())
-    }
-
-    fn new_web_content_scene(
-        &self,
-        _webview_id: WebviewId,
-        _scene_bytes: Vec<u8>,
-        _font_registrations: Vec<RegisteredFont>,
-        _font_data: HashMap<usize, Vec<u8>>,
-    ) -> Result<(), String> {
-        // The scene is presented via the IOSurface surface path
-        // (`new_web_content_layers`); the scene-bytes payload is unused.
         Ok(())
     }
 

--- a/embedder/winit-embedder/src/events.rs
+++ b/embedder/winit-embedder/src/events.rs
@@ -4,11 +4,9 @@
 use crate::shared::{clipboard_get_text, clipboard_set_text, window_viewport_snapshot};
 use automation::AutomationCommand;
 use log::error;
-use std::collections::HashMap;
 use std::sync::{Arc, LazyLock, Mutex, mpsc};
 use webview::{
-    ColorScheme, Embedder, EmbedderSchemeRequest, LayerFrame, NavigationCompleted, RegisteredFont,
-    WebviewId,
+    ColorScheme, Embedder, EmbedderSchemeRequest, LayerFrame, NavigationCompleted, WebviewId,
 };
 use winit::event_loop::EventLoopProxy;
 
@@ -72,12 +70,6 @@ pub fn event_loop_is_ready() -> bool {
 
 pub enum FormalWebUserEvent {
     RequestRedraw(WebviewId),
-    NewWebContentScene {
-        webview_id: WebviewId,
-        scene_bytes: Vec<u8>,
-        font_registrations: Vec<RegisteredFont>,
-        font_data: HashMap<usize, Vec<u8>>,
-    },
     NewWebContentLayers {
         webview_id: WebviewId,
         /// The per-layer frames: topology always, surface only for the
@@ -193,21 +185,6 @@ impl Embedder for EventLoopEmbedder {
     fn host_message(&self, webview_id: WebviewId, url: String, body: String) -> Result<(), String> {
         log::debug!("[embedder] host message from {url} in webview {webview_id:?}: {body}");
         Ok(())
-    }
-
-    fn new_web_content_scene(
-        &self,
-        webview_id: WebviewId,
-        scene_bytes: Vec<u8>,
-        font_registrations: Vec<RegisteredFont>,
-        font_data: HashMap<usize, Vec<u8>>,
-    ) -> Result<(), String> {
-        self.sink.send(FormalWebUserEvent::NewWebContentScene {
-            webview_id,
-            scene_bytes,
-            font_registrations,
-            font_data,
-        })
     }
 
     fn new_web_content_layers(

--- a/embedder/winit-embedder/src/headless.rs
+++ b/embedder/winit-embedder/src/headless.rs
@@ -13,13 +13,12 @@ use automation::{
 use keyboard_types::Modifiers as KeyboardModifiers;
 use log::{debug, error};
 use serde_json::Value;
-use std::collections::HashMap;
 use std::time::Duration;
 use webview::WebviewProvider;
 use webview::{
     BlitzPointerEvent, BlitzPointerId, BlitzWheelDelta, BlitzWheelEvent, ColorScheme,
-    FontTransportReceiver, MouseEventButton, MouseEventButtons, NavigationCompleted,
-    NavigationCompletion, PointerCoords, PointerDetails, RecordedScene, UiEvent, WebviewId,
+    MouseEventButton, MouseEventButtons, NavigationCompleted, NavigationCompletion, PointerCoords,
+    PointerDetails, UiEvent, WebviewId,
 };
 
 const HEADLESS_VIEWPORT_WIDTH: u32 = 800;
@@ -43,8 +42,6 @@ pub(super) struct HeadlessEmbedderApp {
     pub(super) provider: Option<WebviewProvider>,
     pub(super) current_webview_id: Option<WebviewId>,
     pub(super) buttons: MouseEventButtons,
-    pub(super) composed_scenes: HashMap<WebviewId, RecordedScene>,
-    pub(super) scene_font_receiver: FontTransportReceiver,
 }
 
 impl Default for HeadlessEmbedderApp {
@@ -58,8 +55,6 @@ impl Default for HeadlessEmbedderApp {
             provider: None,
             current_webview_id: None,
             buttons: MouseEventButtons::None,
-            composed_scenes: HashMap::new(),
-            scene_font_receiver: FontTransportReceiver::default(),
         }
     }
 }
@@ -337,25 +332,6 @@ impl ApplicationHandler<FormalWebUserEvent> for HeadlessEmbedderApp {
             }
             FormalWebUserEvent::ClipboardWrite { text, reply } => {
                 let _ = reply.send(write_clipboard_text(text));
-            }
-            FormalWebUserEvent::NewWebContentScene {
-                webview_id,
-                scene_bytes,
-                font_registrations,
-                font_data,
-            } => {
-                // Register fonts from the graphics process.
-                self.scene_font_receiver
-                    .register_fonts(font_registrations, &font_data);
-                // Deserialize and store the composed scene.
-                match webview::deserialize_scene_from_slice(&scene_bytes) {
-                    Ok(scene) => {
-                        self.composed_scenes.insert(webview_id, scene);
-                    }
-                    Err(error) => {
-                        error!("[embedder] failed to deserialize composed scene: {error}");
-                    }
-                }
             }
             FormalWebUserEvent::NewWebContentLayers {
                 webview_id, layers, ..

--- a/embedder/winit-embedder/src/windowed.rs
+++ b/embedder/winit-embedder/src/windowed.rs
@@ -23,7 +23,7 @@ use blitz_traits::events::{
     MouseEventButtons, PointerCoords, PointerDetails, UiEvent,
 };
 use blitz_traits::shell::ShellProvider;
-use kurbo::Affine;
+use kurbo::{Affine, RoundedRect};
 use serde_json::Value;
 use std::collections::{HashMap, HashSet};
 
@@ -32,7 +32,9 @@ use std::time::{Duration, Instant};
 use uuid::Uuid;
 #[cfg(target_os = "macos")]
 use webview::deallocate_mach_port;
-use webview::{NavigationCompletion, SurfaceFrame, WebviewId, WebviewProvider};
+use webview::{
+    CompositingLayerId, LayerFrame, NavigationCompletion, SurfaceFrame, WebviewId, WebviewProvider,
+};
 use winit::application::ApplicationHandler;
 use winit::dpi::{LogicalPosition, PhysicalPosition};
 use winit::event::{
@@ -76,13 +78,14 @@ impl TabState {
     }
 }
 
-/// Persistent GPU texture holding the latest composited surface pixels for
-/// one webview, registered once with the Vello renderer. One variant per
-/// delivery path: the CPU upload path fills the texture from shared-memory
-/// bytes each frame; the zero-copy path (macOS) wraps a shared IOSurface.
-pub(super) enum WebviewSurfaceTexture {
-    /// CPU upload path: the texture is exactly the viewport size and its
-    /// contents are replaced in place via `queue.write_texture`.
+/// A persistent GPU texture holding the latest rendered surface pixels for
+/// one layer of a webview's composition, registered once with the Vello
+/// renderer. One variant per delivery path: the CPU upload path fills the
+/// texture from shared-memory bytes each frame; the zero-copy path (macOS)
+/// wraps a shared IOSurface.
+pub(super) enum LayerSurface {
+    /// CPU upload path: the texture is exactly the layer's content size and
+    /// its contents are replaced in place via `queue.write_texture`.
     CpuUpload {
         texture: wgpu::Texture,
         /// Vello registration id; valid while `registered` is true.
@@ -101,11 +104,11 @@ pub(super) enum WebviewSurfaceTexture {
         texture: wgpu::Texture,
         /// Vello registration id; valid while `registered` is true.
         resource_id: ResourceId,
-        /// Logical (viewport) width/height of the surface content.
+        /// Logical (content) width/height of the surface.
         width: u32,
         height: u32,
         /// Physical width of the texture: the shared IOSurface is padded up
-        /// to a 64-multiple width (Metal constraint); the draw clips to
+        /// to a 64-multiple width (Metal constraint); drawing clips to
         /// `width`.
         texture_width: u32,
         /// False until the texture has been registered with the renderer.
@@ -117,59 +120,59 @@ pub(super) enum WebviewSurfaceTexture {
     },
 }
 
-impl WebviewSurfaceTexture {
+impl LayerSurface {
     fn width(&self) -> u32 {
         match self {
-            WebviewSurfaceTexture::CpuUpload { width, .. } => *width,
+            LayerSurface::CpuUpload { width, .. } => *width,
             #[cfg(target_os = "macos")]
-            WebviewSurfaceTexture::SharedSurface { width, .. } => *width,
+            LayerSurface::SharedSurface { width, .. } => *width,
         }
     }
 
     fn height(&self) -> u32 {
         match self {
-            WebviewSurfaceTexture::CpuUpload { height, .. } => *height,
+            LayerSurface::CpuUpload { height, .. } => *height,
             #[cfg(target_os = "macos")]
-            WebviewSurfaceTexture::SharedSurface { height, .. } => *height,
+            LayerSurface::SharedSurface { height, .. } => *height,
         }
     }
 
     /// Physical texture width; padded for the shared surface variant.
     fn texture_width(&self) -> u32 {
         match self {
-            WebviewSurfaceTexture::CpuUpload { width, .. } => *width,
+            LayerSurface::CpuUpload { width, .. } => *width,
             #[cfg(target_os = "macos")]
-            WebviewSurfaceTexture::SharedSurface { texture_width, .. } => *texture_width,
+            LayerSurface::SharedSurface { texture_width, .. } => *texture_width,
         }
     }
 
     fn texture(&self) -> &wgpu::Texture {
         match self {
-            WebviewSurfaceTexture::CpuUpload { texture, .. } => texture,
+            LayerSurface::CpuUpload { texture, .. } => texture,
             #[cfg(target_os = "macos")]
-            WebviewSurfaceTexture::SharedSurface { texture, .. } => texture,
+            LayerSurface::SharedSurface { texture, .. } => texture,
         }
     }
 
     fn resource_id(&self) -> ResourceId {
         match self {
-            WebviewSurfaceTexture::CpuUpload { resource_id, .. } => *resource_id,
+            LayerSurface::CpuUpload { resource_id, .. } => *resource_id,
             #[cfg(target_os = "macos")]
-            WebviewSurfaceTexture::SharedSurface { resource_id, .. } => *resource_id,
+            LayerSurface::SharedSurface { resource_id, .. } => *resource_id,
         }
     }
 
     fn is_registered(&self) -> bool {
         match self {
-            WebviewSurfaceTexture::CpuUpload { registered, .. } => *registered,
+            LayerSurface::CpuUpload { registered, .. } => *registered,
             #[cfg(target_os = "macos")]
-            WebviewSurfaceTexture::SharedSurface { registered, .. } => *registered,
+            LayerSurface::SharedSurface { registered, .. } => *registered,
         }
     }
 
     fn set_registration(&mut self, resource_id: ResourceId, registered: bool) {
         match self {
-            WebviewSurfaceTexture::CpuUpload {
+            LayerSurface::CpuUpload {
                 resource_id: id,
                 registered: reg,
                 ..
@@ -178,7 +181,7 @@ impl WebviewSurfaceTexture {
                 *reg = registered;
             }
             #[cfg(target_os = "macos")]
-            WebviewSurfaceTexture::SharedSurface {
+            LayerSurface::SharedSurface {
                 resource_id: id,
                 registered: reg,
                 ..
@@ -194,19 +197,76 @@ impl WebviewSurfaceTexture {
     #[cfg(target_os = "macos")]
     fn texture_id(&self) -> Option<u64> {
         match self {
-            WebviewSurfaceTexture::CpuUpload { .. } => None,
-            WebviewSurfaceTexture::SharedSurface { texture_id, .. } => Some(*texture_id),
+            LayerSurface::CpuUpload { .. } => None,
+            LayerSurface::SharedSurface { texture_id, .. } => Some(*texture_id),
         }
     }
+}
+
+/// The stored geometry and newest surface of one layer in a webview's
+/// composition, as last reported by the graphics process. Layers that are
+/// not re-rendered in a cycle arrive clean (with no new frame) and keep
+/// this state, so the layer's last surface stays on screen until the next
+/// time it changes.
+pub(super) struct StoredLayer {
+    pub(super) parent: Option<CompositingLayerId>,
+    /// Affine [a, b, c, d, tx, ty] mapping this layer's local coordinates
+    /// into its parent's local space; identity for the root navigable.
+    pub(super) transform: [f64; 6],
+    /// This layer's visible clip rect in its parent's local space.
+    pub(super) clip_bounds: [f64; 4],
+    pub(super) corner_radius: f64,
+    /// (z_index, paint_order) within the parent, for sibling ordering.
+    pub(super) z_order: (i32, u32),
+    /// The layer's content width: its surface is created at this size, and
+    /// a padded shared surface draws wider and is clipped back to it.
+    pub(super) width: u32,
+    /// The layer's GPU surface; None until the first frame for the layer
+    /// arrives. A clean layer keeps the surface it last carried.
+    pub(super) surface: Option<LayerSurface>,
+}
+
+/// One compositing layer quad scheduled for the next paint: where to draw
+/// the layer's surface and how to clip it, in window (physical pixel)
+/// coordinates.
+struct LayerDrawCommand {
+    /// Maps the layer's local space (its surface content) to the window;
+    /// includes the chrome offset that pushes the content area down.
+    transform: Affine,
+    /// Maps the layer's parent's local space to the window, for the clip
+    /// scope: `clip_bounds` lives in the parent's space.
+    clip_transform: Affine,
+    /// The layer's visible clip region in its parent's space, rounded when
+    /// the layer carries a corner radius.
+    clip: RoundedRect,
+    /// True for the root navigable layer, whose clip bounds are the outer
+    /// clip scope of the whole content area.
+    is_root: bool,
+    /// True when the quad needs its own clip scope: a padded shared
+    /// surface draws wider than its content, and a rounded layer draws
+    /// past its rect corners.
+    needs_clip: bool,
+    /// Vello registration id of the layer's surface texture.
+    resource_id: ResourceId,
+    /// Physical width of the surface texture; padded (wider than the
+    /// content) for shared IOSurfaces.
+    texture_width: u32,
+    height: u32,
 }
 
 /// Per-window state: owns a winit window, a renderer, chrome, and tabs
 pub(super) struct WindowState {
     pub(super) window: Option<Arc<Window>>,
     pub(super) renderer: VelloWindowRenderer,
-    /// Persistent GPU surface textures from the graphics process, keyed by
-    /// webview.
-    pub(super) surface_textures: HashMap<WebviewId, WebviewSurfaceTexture>,
+    /// The stored layer trees from the graphics process, per webview: each
+    /// compositing layer's geometry plus its persistent GPU surface.
+    pub(super) stored_layers: HashMap<WebviewId, HashMap<CompositingLayerId, StoredLayer>>,
+    /// The last `animating` flag the graphics process reported for each
+    /// webview: whether its composed scene contains animated content
+    /// (video, CSS animations) that needs frames at display cadence. A
+    /// visible animating tab keeps the redraw/pacing loop running so each
+    /// paint sends frame_needed to the UA.
+    pub(super) animating: HashMap<WebviewId, bool>,
     pub(super) chrome: Option<ChromeUi>,
     pub(super) tabs: HashMap<WebviewId, TabState>,
     pub(super) tab_order: Vec<WebviewId>,
@@ -224,7 +284,8 @@ impl WindowState {
         Self {
             window: None,
             renderer: VelloWindowRenderer::new(),
-            surface_textures: HashMap::new(),
+            stored_layers: HashMap::new(),
+            animating: HashMap::new(),
             chrome: None,
             tabs: HashMap::new(),
             tab_order: Vec::new(),
@@ -493,11 +554,15 @@ impl WindowedApp {
         }
         window.pre_present_notify();
 
-        // Re-register any surface textures whose Vello registration was
+        // Re-register any layer surfaces whose Vello registration was
         // dropped (e.g. after a renderer suspend).
-        for surface in state.surface_textures.values_mut() {
-            if !surface.is_registered() {
-                Self::register_surface_texture(&mut state.renderer, surface);
+        for stored in state.stored_layers.values_mut() {
+            for layer in stored.values_mut() {
+                if let Some(surface) = layer.surface.as_mut()
+                    && !surface.is_registered()
+                {
+                    Self::register_surface_texture(&mut state.renderer, surface);
+                }
             }
         }
 
@@ -510,63 +575,56 @@ impl WindowedApp {
             error!("[embedder] frame needed: {error}");
         }
 
+        // Build the per-layer quad plan for the active tab before rendering
+        // (it owns no borrow of the renderer). While a resize is in flight a
+        // layer's texture still holds the previous frame's dimensions, so
+        // the newly exposed area shows the surface base color until the
+        // next frame arrives; the quad is drawn at natural size rather than
+        // stretched.
+        let draw_plan = Self::content_draw_plan(state, chrome_height);
+        let quad_count = draw_plan
+            .as_ref()
+            .map_or(0, |(_, _, commands)| commands.len());
+        if quad_count > 0 {
+            info!(
+                "[render-pipe] Embedder paint webview={:?} layers={} at y={}",
+                state.active_tab, quad_count, chrome_height
+            );
+        }
         state.renderer.render(|scene| {
-            // Paint content surface if one is available.
-            let surface_found = state.active_tab.is_some_and(|webview_id| {
-                if let Some(surface) = state.surface_textures.get(&webview_id)
-                    && surface.is_registered()
-                {
-                    // Draw the texture at its natural (padded) size. While
-                    // a resize is in flight the texture still holds the
-                    // previous frame's dimensions, so the newly exposed area
-                    // shows the surface base color until the next frame
-                    // arrives; stretching it would look like the old content
-                    // is being pulled out of shape. The shared IOSurface is
-                    // padded to a 64-multiple width, so the padded region is
-                    // clipped to the logical content rect.
-                    let content_rect = kurbo::Rect::new(
-                        0.0,
-                        0.0,
-                        f64::from(surface.width()),
-                        f64::from(surface.height()),
-                    );
+            // Draw the web content layers. The outer clip scope is the root
+            // layer's clip bounds — the whole content area — so no sublayer
+            // quad can draw over the chrome or spill outside the window.
+            // Each padded or rounded layer clips itself inside it; every
+            // other quad lands exactly on its clip rect under the quad
+            // transform.
+            if let Some((content, outer_clip, commands)) = draw_plan {
+                scene.push_clip_layer(content, &outer_clip);
+                for command in &commands {
+                    if !command.is_root && command.needs_clip {
+                        scene.push_clip_layer(command.clip_transform, &command.clip);
+                    }
                     let texture_rect = kurbo::Rect::new(
                         0.0,
                         0.0,
-                        f64::from(surface.texture_width()),
-                        f64::from(surface.height()),
+                        f64::from(command.texture_width),
+                        f64::from(command.height),
                     );
-                    let content_transform = Affine::translate((0.0, chrome_height));
-                    scene.push_clip_layer(content_transform, &content_rect);
                     scene.fill(
                         peniko::Fill::NonZero,
-                        content_transform,
+                        command.transform,
                         PaintRef::Resource(peniko::ImageBrush {
-                            image: surface.resource_id(),
+                            image: command.resource_id,
                             sampler: Default::default(),
                         }),
                         None,
                         &texture_rect,
                     );
-                    scene.pop_layer();
-                    info!(
-                        "[render-pipe] Embedder paint webview={:?} {}x{} at y={}",
-                        webview_id,
-                        surface.width(),
-                        surface.height(),
-                        chrome_height
-                    );
-                    true
-                } else {
-                    info!(
-                        "[render-pipe] Embedder paint NO SURFACE for active_tab={:?}",
-                        webview_id
-                    );
-                    false
+                    if !command.is_root && command.needs_clip {
+                        scene.pop_layer();
+                    }
                 }
-            });
-            if !surface_found {
-                info!("[render-pipe] Embedder paint chrome-only");
+                scene.pop_layer();
             }
             // Always paint chrome, even when no content surface is available
             // (e.g. chrome-only hover, typing in address bar).
@@ -574,6 +632,331 @@ impl WindowedApp {
                 scene.append_scene(chrome_scene, Affine::IDENTITY);
             }
         });
+        // An animating active tab (video, CSS animations) needs the next
+        // frame at display cadence: keep requesting redraws so each paint
+        // sends frame_needed to the UA, which sustains the render cycle.
+        // (The AppKit embedder paces animated content with its
+        // CVDisplayLink.) The request is a no-op while the window is
+        // hidden or occluded, so the loop pauses there.
+        if state
+            .active_tab
+            .is_some_and(|webview_id| state.animating.get(&webview_id).copied().unwrap_or(false))
+        {
+            Self::request_window_redraw(state);
+        }
+    }
+
+    /// Record an arriving layer stream as the webview's stored layers:
+    /// every layer's geometry, plus a new persistent surface for each layer
+    /// re-rendered this cycle (a clean layer keeps the surface it last
+    /// carried). Layers absent from the stream have left the composition
+    /// (their navigable or video element is gone) and are dropped,
+    /// releasing their GPU textures. Runs for every frame, active tab or
+    /// not: an inactive tab's stream only updates this cache, which is what
+    /// a later tab switch repaints.
+    fn store_webview_layers(
+        state: &mut WindowState,
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        webview_id: WebviewId,
+        layers: Vec<LayerFrame>,
+    ) {
+        let incoming: HashSet<CompositingLayerId> =
+            layers.iter().map(|layer| layer.topology.layer_id).collect();
+        if incoming.is_empty() {
+            // An empty stream (e.g. the compositor was reset mid-navigation)
+            // carries nothing to store; keep the last stored layers so the
+            // previous frame stays on screen until the next one arrives.
+            return;
+        }
+        // Take the previous stored layers out of the window state first, so
+        // the renderer can be borrowed freely while surfaces are replaced.
+        let mut previous = state.stored_layers.remove(&webview_id).unwrap_or_default();
+        let mut stored = HashMap::with_capacity(incoming.len());
+        for frame in layers {
+            let topology = frame.topology;
+            // A kept entry keeps its surface (the layer arrived clean); a
+            // fresh entry starts with no surface until the first frame.
+            let mut entry = StoredLayer {
+                parent: topology.parent,
+                transform: topology.transform,
+                clip_bounds: topology.clip_bounds,
+                corner_radius: topology.corner_radius,
+                z_order: topology.z_order,
+                width: topology.width,
+                surface: previous
+                    .remove(&topology.layer_id)
+                    .and_then(|entry| entry.surface),
+            };
+            if let Some(frame) = frame.frame {
+                entry.surface = Self::update_layer_surface(
+                    &mut state.renderer,
+                    device,
+                    queue,
+                    entry.surface.take(),
+                    topology.width,
+                    topology.height,
+                    frame,
+                );
+            }
+            stored.insert(topology.layer_id, entry);
+        }
+        // Release the surfaces of stored layers the stream no longer lists.
+        for (_, entry) in previous {
+            if let Some(surface) = entry.surface
+                && surface.is_registered()
+            {
+                state.renderer.unregister_resource(surface.resource_id());
+            }
+        }
+        state.stored_layers.insert(webview_id, stored);
+    }
+
+    /// Deliver one layer's rendered frame to its persistent surface
+    /// texture: upload the CPU pixels in place into the existing texture
+    /// when the size is unchanged, otherwise (re)create the texture at the
+    /// new size. On macOS the zero-copy frame wraps a shared IOSurface that
+    /// is imported when the surface (or its identity) changes. `existing`
+    /// is the layer's previous surface, kept when the layer arrived clean.
+    fn update_layer_surface(
+        renderer: &mut VelloWindowRenderer,
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        existing: Option<LayerSurface>,
+        width: u32,
+        height: u32,
+        frame: SurfaceFrame,
+    ) -> Option<LayerSurface> {
+        match frame {
+            SurfaceFrame::CpuShmem(region) => {
+                let total_pixels = (width as usize) * (height as usize) * 4;
+                let pixels = region.as_slice();
+                if pixels.len() < total_pixels || width == 0 || height == 0 {
+                    info!(
+                        "[render-pipe] Embedder invalid surface {}x{} shmem={}B (expected {}B)",
+                        width,
+                        height,
+                        pixels.len(),
+                        total_pixels
+                    );
+                    return existing;
+                }
+                let surface = match existing {
+                    Some(surface @ LayerSurface::CpuUpload { .. })
+                        if surface.width() == width && surface.height() == height =>
+                    {
+                        surface
+                    }
+                    previous => {
+                        let mut surface = LayerSurface::CpuUpload {
+                            texture: Self::create_surface_texture(device, width, height),
+                            resource_id: ResourceId::new(),
+                            width,
+                            height,
+                            registered: false,
+                        };
+                        Self::register_surface_texture(renderer, &mut surface);
+                        if let Some(previous) = previous
+                            && previous.is_registered()
+                        {
+                            renderer.unregister_resource(previous.resource_id());
+                        }
+                        surface
+                    }
+                };
+                // Upload the new pixels in place into the persistent
+                // texture. `write_texture` copies the shared-memory bytes
+                // into a staging buffer synchronously; no allocation or
+                // Vello re-registration is involved.
+                let LayerSurface::CpuUpload { texture, .. } = &surface else {
+                    error!("[render-pipe] Embedder CPU frame for non-CPU surface layer");
+                    return Some(surface);
+                };
+                queue.write_texture(
+                    wgpu::TexelCopyTextureInfo {
+                        texture,
+                        mip_level: 0,
+                        origin: wgpu::Origin3d::ZERO,
+                        aspect: wgpu::TextureAspect::All,
+                    },
+                    &pixels[..total_pixels],
+                    wgpu::TexelCopyBufferLayout {
+                        offset: 0,
+                        bytes_per_row: Some(width * 4),
+                        rows_per_image: Some(height),
+                    },
+                    wgpu::Extent3d {
+                        width,
+                        height,
+                        depth_or_array_layers: 1,
+                    },
+                );
+                Some(surface)
+            }
+            #[cfg(target_os = "macos")]
+            SurfaceFrame::SharedTexture {
+                texture_id,
+                surface_id,
+                port,
+            } => {
+                // Zero-copy path: the frame was rendered directly into a
+                // shared IOSurface by the graphics process. Import the
+                // surface (once per surface identity) as the layer's
+                // persistent texture; on failure keep the previous surface.
+                let is_new_surface = match &existing {
+                    Some(surface) => {
+                        surface.width() != width
+                            || surface.height() != height
+                            || surface.texture_id() != Some(texture_id)
+                    }
+                    None => true,
+                };
+                if !is_new_surface {
+                    return existing;
+                }
+                // Look the shared surface up by its global ID first; fall
+                // back to the Mach port when the ID is not resolvable.
+                let surface_ref =
+                    objc2_io_surface::IOSurfaceRef::lookup(surface_id).or_else(|| {
+                        let port_name = port.into_name();
+                        let surface =
+                            objc2_io_surface::IOSurfaceRef::lookup_from_mach_port(port_name);
+                        deallocate_mach_port(port_name);
+                        surface
+                    });
+                let Some(surface_ref) = surface_ref else {
+                    error!("[embedder] IOSurfaceLookup failed for webview layer id={surface_id}");
+                    return existing;
+                };
+                let padded_width = Self::padded_surface_width(width);
+                let Some(texture) =
+                    Self::import_shared_surface(device, &surface_ref, padded_width, height)
+                else {
+                    error!("[embedder] failed to import shared surface for webview layer");
+                    return existing;
+                };
+                if let Some(previous) = existing
+                    && previous.is_registered()
+                {
+                    renderer.unregister_resource(previous.resource_id());
+                }
+                let mut surface = LayerSurface::SharedSurface {
+                    texture,
+                    resource_id: ResourceId::new(),
+                    width,
+                    height,
+                    texture_width: padded_width,
+                    registered: false,
+                    texture_id,
+                };
+                Self::register_surface_texture(renderer, &mut surface);
+                Some(surface)
+            }
+        }
+    }
+
+    /// Build the draw plan for the active tab's web content: the outer clip
+    /// (the root layer's clip bounds, i.e. the whole content area) plus the
+    /// ordered per-layer quads for every stored layer that has a registered
+    /// surface. Returns None while the active tab has no stored root layer.
+    fn content_draw_plan(
+        state: &WindowState,
+        chrome_height: f64,
+    ) -> Option<(Affine, RoundedRect, Vec<LayerDrawCommand>)> {
+        let webview_id = state.active_tab?;
+        let stored = state.stored_layers.get(&webview_id)?;
+        let root_id = stored
+            .iter()
+            .find_map(|(layer_id, layer)| layer.parent.is_none().then_some(*layer_id))?;
+        let content = Affine::translate((0.0, chrome_height));
+        let mut ordered: Vec<(CompositingLayerId, Affine, Affine)> = Vec::new();
+        Self::collect_layer_order(
+            stored,
+            root_id,
+            Affine::IDENTITY,
+            Affine::IDENTITY,
+            &mut ordered,
+        );
+        let mut commands = Vec::new();
+        for (layer_id, world, parent_world) in ordered {
+            let Some(layer) = stored.get(&layer_id) else {
+                continue;
+            };
+            let Some(surface) = layer
+                .surface
+                .as_ref()
+                .filter(|surface| surface.is_registered())
+            else {
+                continue;
+            };
+            commands.push(LayerDrawCommand {
+                transform: content * world,
+                clip_transform: content * parent_world,
+                clip: Self::clip_shape(layer),
+                is_root: layer.parent.is_none(),
+                // A padded shared surface draws wider than its content and
+                // a rounded layer draws past its rect corners; both need
+                // their own clip scope. The root's clip is the outer scope.
+                needs_clip: layer.corner_radius > 0.0 || surface.texture_width() != layer.width,
+                resource_id: surface.resource_id(),
+                texture_width: surface.texture_width(),
+                height: surface.height(),
+            });
+        }
+        if commands.is_empty() {
+            return None;
+        }
+        let root = stored.get(&root_id)?;
+        let outer_clip = Self::clip_shape(root);
+        Some((content, outer_clip, commands))
+    }
+
+    /// Collect the painter order of a layer subtree: the layer itself plus
+    /// its sublayers, each visited depth-first with its accumulated world
+    /// transform (layer-local → root-local space) and its parent's world
+    /// transform (for clip placement). Sublayers with a negative z-index
+    /// precede the layer (they paint below its content); the rest follow,
+    /// siblings ordered by ascending (z_index, paint_order) so later quads
+    /// composite on top of earlier ones.
+    fn collect_layer_order(
+        stored: &HashMap<CompositingLayerId, StoredLayer>,
+        layer_id: CompositingLayerId,
+        world: Affine,
+        parent_world: Affine,
+        ordered: &mut Vec<(CompositingLayerId, Affine, Affine)>,
+    ) {
+        let Some(layer) = stored.get(&layer_id) else {
+            return;
+        };
+        let child_world = world * Affine::new(layer.transform);
+        let mut children: Vec<(CompositingLayerId, (i32, u32))> = stored
+            .iter()
+            .filter_map(|(id, child)| {
+                (child.parent == Some(layer_id)).then_some((*id, child.z_order))
+            })
+            .collect();
+        children.sort_by_key(|(_, order)| *order);
+        for (child_id, (z_index, _)) in &children {
+            if *z_index < 0 {
+                Self::collect_layer_order(stored, *child_id, child_world, world, ordered);
+            }
+        }
+        ordered.push((layer_id, world, parent_world));
+        for (child_id, (z_index, _)) in &children {
+            if *z_index >= 0 {
+                Self::collect_layer_order(stored, *child_id, child_world, world, ordered);
+            }
+        }
+    }
+
+    /// The layer's visible clip region as a (possibly rounded) rectangle in
+    /// its parent's local space, as reported by the graphics process.
+    fn clip_shape(layer: &StoredLayer) -> RoundedRect {
+        let [x0, y0, x1, y1] = layer.clip_bounds;
+        let width = (x1 - x0).max(0.0);
+        let height = (y1 - y0).max(0.0);
+        let radius = layer.corner_radius.max(0.0).min(width.min(height) * 0.5);
+        RoundedRect::new(x0, y0, x0 + width, y0 + height, radius)
     }
 
     fn window_for_webview(app: &Self, webview_id: WebviewId) -> Option<WindowId> {
@@ -635,10 +1018,7 @@ impl WindowedApp {
     /// Register a surface texture with the Vello renderer, keeping the
     /// `ResourceId` stable across frames. No-op while the renderer is not
     /// active; `paint_frame` retries for unregistered textures.
-    fn register_surface_texture(
-        renderer: &mut VelloWindowRenderer,
-        surface: &mut WebviewSurfaceTexture,
-    ) {
+    fn register_surface_texture(renderer: &mut VelloWindowRenderer, surface: &mut LayerSurface) {
         if !renderer.is_active() {
             return;
         }
@@ -1392,48 +1772,24 @@ impl ApplicationHandler<FormalWebUserEvent> for WindowedApp {
             FormalWebUserEvent::ClipboardWrite { text, reply } => {
                 let _ = reply.send(write_clipboard_text(text));
             }
-            FormalWebUserEvent::NewWebContentScene { webview_id, .. } => {
-                // Removed: the IOSurface surface path replaces the old scene bytes path.
-                // Trigger a redraw so the surface-based path can render.
-                debug!(
-                    "[embedder] NewWebContentScene (ignored, using surface path) webview={:?}",
-                    webview_id,
-                );
-                if let Some(window) = Self::window_for_webview(self, webview_id)
-                    && let Some(state) = self.windows.get(&window)
-                {
-                    Self::request_window_redraw(state);
-                }
-            }
             FormalWebUserEvent::NewWebContentLayers {
-                webview_id, layers, ..
+                webview_id,
+                layers,
+                animating,
+                ..
             } => {
-                // Temporary: draw only the root navigable layer until the
-                // per-layer quad path lands (step 7).
-                let Some(root) = layers
-                    .into_iter()
-                    .find(|layer| layer.topology.parent.is_none())
-                else {
-                    return;
-                };
-                let Some(frame) = root.frame else {
-                    return;
-                };
-                let width = root.topology.width;
-                let height = root.topology.height;
+                // Store every arriving layer — geometry plus the newest
+                // frame for the layers re-rendered this cycle — then
+                // redraw so the quads repaint. The renderer must be active
+                // (window resumed) to create and register GPU textures; if
+                // not, drop the frame — the next one arrives once the
+                // window is rendering again.
                 let Some(window_id) = Self::window_for_webview(self, webview_id) else {
-                    info!(
-                        "[render-pipe] Embedder no window for webview={:?}",
-                        webview_id
-                    );
                     return;
                 };
                 let Some(state) = self.windows.get_mut(&window_id) else {
                     return;
                 };
-                // The renderer must be active (window resumed) to create and
-                // register GPU textures. If not, drop the frame — the next
-                // one arrives once the window is rendering again.
                 let Some(device_handle) = state.renderer.current_device_handle().cloned() else {
                     info!(
                         "[render-pipe] Embedder renderer inactive, dropping surface webview={:?}",
@@ -1441,173 +1797,22 @@ impl ApplicationHandler<FormalWebUserEvent> for WindowedApp {
                     );
                     return;
                 };
-
-                match frame {
-                    SurfaceFrame::CpuShmem(surface) => {
-                        let total_pixels = (width * height * 4) as usize;
-                        let pixels = surface.as_slice();
-                        info!(
-                            "[render-pipe] Embedder surface webview={:?} {}x{} pixels={}B active_tab={:?}",
-                            webview_id, width, height, total_pixels, state.active_tab
-                        );
-                        if pixels.len() < total_pixels || width == 0 || height == 0 {
-                            info!(
-                                "[render-pipe] Embedder invalid surface webview={:?} {}x{} shmem={}B (expected {}B)",
-                                webview_id,
-                                width,
-                                height,
-                                pixels.len(),
-                                total_pixels
-                            );
-                            return;
-                        }
-
-                        // Recreate the texture only when the viewport size
-                        // changed; otherwise keep the existing GPU resource
-                        // and just update its contents in place.
-                        let needs_new = match state.surface_textures.get(&webview_id) {
-                            Some(surface_tex) => {
-                                surface_tex.width() != width || surface_tex.height() != height
-                            }
-                            None => true,
-                        };
-                        if needs_new {
-                            if let Some(old) = state.surface_textures.remove(&webview_id)
-                                && old.is_registered()
-                            {
-                                state.renderer.unregister_resource(old.resource_id());
-                            }
-                            let texture =
-                                Self::create_surface_texture(&device_handle.device, width, height);
-                            let mut surface_tex = WebviewSurfaceTexture::CpuUpload {
-                                texture,
-                                resource_id: ResourceId::new(),
-                                width,
-                                height,
-                                registered: false,
-                            };
-                            Self::register_surface_texture(&mut state.renderer, &mut surface_tex);
-                            state.surface_textures.insert(webview_id, surface_tex);
-                        }
-
-                        // Upload the new pixels in place into the persistent
-                        // texture. `write_texture` copies the shared-memory
-                        // bytes into a staging buffer synchronously; no
-                        // allocation or Vello re-registration is involved.
-                        if let Some(surface_tex) = state.surface_textures.get_mut(&webview_id) {
-                            device_handle.queue.write_texture(
-                                wgpu::TexelCopyTextureInfo {
-                                    texture: surface_tex.texture(),
-                                    mip_level: 0,
-                                    origin: wgpu::Origin3d::ZERO,
-                                    aspect: wgpu::TextureAspect::All,
-                                },
-                                &pixels[..total_pixels],
-                                wgpu::TexelCopyBufferLayout {
-                                    offset: 0,
-                                    bytes_per_row: Some(width * 4),
-                                    rows_per_image: Some(height),
-                                },
-                                wgpu::Extent3d {
-                                    width,
-                                    height,
-                                    depth_or_array_layers: 1,
-                                },
-                            );
-                        } else {
-                            error!(
-                                "[embedder] missing surface texture for webview={:?} after insert",
-                                webview_id
-                            );
-                        }
-                    }
-                    #[cfg(target_os = "macos")]
-                    SurfaceFrame::SharedTexture {
-                        texture_id,
-                        surface_id,
-                        port,
-                    } => {
-                        // Zero-copy path: the frame was rendered directly
-                        // into a shared IOSurface by the graphics process.
-                        // Import the surface (once per texture id) as the
-                        // webview's persistent texture and blit it.
-                        info!(
-                            "[render-pipe] Embedder shared surface webview={:?} {}x{} texture_id={} active_tab={:?}",
-                            webview_id, width, height, texture_id, state.active_tab
-                        );
-                        let is_new_surface = match state.surface_textures.get(&webview_id) {
-                            Some(surface_tex) => {
-                                surface_tex.width() != width
-                                    || surface_tex.height() != height
-                                    || surface_tex.texture_id() != Some(texture_id)
-                            }
-                            None => true,
-                        };
-                        if is_new_surface {
-                            if let Some(old) = state.surface_textures.remove(&webview_id)
-                                && old.is_registered()
-                            {
-                                state.renderer.unregister_resource(old.resource_id());
-                            }
-                            // Look the shared surface up by its global ID
-                            // first; fall back to the Mach port when the ID
-                            // is not resolvable.
-                            let surface_ref = objc2_io_surface::IOSurfaceRef::lookup(surface_id)
-                                .or_else(|| {
-                                    let port_name = port.into_name();
-                                    let surface =
-                                        objc2_io_surface::IOSurfaceRef::lookup_from_mach_port(
-                                            port_name,
-                                        );
-                                    deallocate_mach_port(port_name);
-                                    surface
-                                });
-                            let Some(surface_ref) = surface_ref else {
-                                error!(
-                                    "[embedder] IOSurfaceLookup failed for webview={:?} id={surface_id}",
-                                    webview_id
-                                );
-                                return;
-                            };
-                            let padded_width = Self::padded_surface_width(width);
-                            let Some(texture) = Self::import_shared_surface(
-                                &device_handle.device,
-                                &surface_ref,
-                                padded_width,
-                                height,
-                            ) else {
-                                error!(
-                                    "[embedder] failed to import shared surface for webview={:?}",
-                                    webview_id
-                                );
-                                return;
-                            };
-                            let mut surface_tex = WebviewSurfaceTexture::SharedSurface {
-                                texture,
-                                resource_id: ResourceId::new(),
-                                width,
-                                height,
-                                texture_width: padded_width,
-                                registered: false,
-                                texture_id,
-                            };
-                            Self::register_surface_texture(&mut state.renderer, &mut surface_tex);
-                            state.surface_textures.insert(webview_id, surface_tex);
-                        }
-                    }
-                }
-                let is_active = state.active_tab == Some(webview_id);
-                info!(
-                    "[render-pipe] Embedder updated surface webview={:?} active={} tabs={:?} active_tab={:?} window={:?}",
-                    webview_id, is_active, state.tab_order, state.active_tab, window_id
+                Self::store_webview_layers(
+                    state,
+                    &device_handle.device,
+                    &device_handle.queue,
+                    webview_id,
+                    layers,
                 );
-                // A new surface frame is available; request a redraw so
-                // the next paint blits it.
+                state.animating.insert(webview_id, animating);
+                info!(
+                    "[render-pipe] Embedder stored layers webview={:?} window={:?}",
+                    webview_id, window_id
+                );
+                // A stored layer stream (a new frame or a geometry-only
+                // update) needs a repaint; request a redraw so the next
+                // paint redraws the quads at their latest positions.
                 Self::request_window_redraw(state);
-                info!(
-                    "[render-pipe] Embedder requested redraw for window={:?}",
-                    window_id
-                );
             }
             FormalWebUserEvent::Exit => event_loop.exit(),
         }

--- a/user_agent/src/user_agent.rs
+++ b/user_agent/src/user_agent.rs
@@ -229,15 +229,6 @@ pub trait Embedder: Send + Sync {
     /// process after parsing; the embedder labels the tab and window with it.
     /// <https://html.spec.whatwg.org/#the-title-element>
     fn title_changed(&self, webview_id: WebviewId, title: String) -> Result<(), String>;
-    /// Forward a composed web content scene from the graphics process to the
-    /// embedder for rendering.
-    fn new_web_content_scene(
-        &self,
-        webview_id: WebviewId,
-        scene_bytes: Vec<u8>,
-        font_registrations: Vec<ipc_messages::content::RegisteredFont>,
-        font_data: std::collections::HashMap<usize, Vec<u8>>,
-    ) -> Result<(), String>;
     /// Forward the per-layer rendered frame from the graphics process. Each
     /// layer carries its wire `topology` (transform, clip, z-order) plus the
     /// actual `frame` only when the layer was re-rendered this cycle; a clean

--- a/webview/src/lib.rs
+++ b/webview/src/lib.rs
@@ -14,11 +14,7 @@ pub use blitz_traits::shell::ColorScheme;
 // `webview` alone and never name the ipc crates directly.
 #[cfg(target_os = "macos")]
 pub use ipc_channel::platform::deallocate_mach_port;
-pub use ipc_messages::content::deserialize_scene_from_slice;
-pub use ipc_messages::content::{
-    EmbedderSchemeFetchId, FontTransportReceiver, RecordedScene, RegisteredFont, UserScript,
-    WebviewId,
-};
+pub use ipc_messages::content::{EmbedderSchemeFetchId, UserScript, WebviewId};
 pub use ipc_messages::graphics::{CompositingLayerId, LayerFrame, SurfaceFrame};
 
 use ipc_messages::content::{NavigateRequest, UserNavigationInvolvement};


### PR DESCRIPTION
mac embedder:

Per-webview stored layers

Live tree mirrors the active tab only

Tab switches re-present from the cache

winit embedder: per-layer quad compositing, animated pacing, drop scene-bytes path